### PR TITLE
Local config coverage process

### DIFF
--- a/inst/config.local
+++ b/inst/config.local
@@ -10,12 +10,7 @@ process {
   executor = 'local'
   container = '<<CONTAINER_ID>>'
   cpus = { opts.cpus }
-  memory = { opts.memory.GB * task.attempt }
-  // opts not used for coverage process
-  withName:coverage {
-    cpus = { params.coverage.cpus }
-    memory = { params.coverage.memory.GB }
-  }
+  memory = { (opts?.memory?.GB ?: 1) * task.attempt }
 }
 
 // SQL database configuration (https://github.com/nextflow-io/nf-sqldb)

--- a/inst/config.local
+++ b/inst/config.local
@@ -11,6 +11,11 @@ process {
   container = '<<CONTAINER_ID>>'
   cpus = { opts.cpus }
   memory = { opts.memory.GB * task.attempt }
+  // opts not used for coverage process
+  withName:coverage {
+    cpus = { params.coverage.cpus }
+    memory = { params.coverage.memory.GB }
+  }
 }
 
 // SQL database configuration (https://github.com/nextflow-io/nf-sqldb)


### PR DESCRIPTION
Current default local config results in a Nexflow error during coverage process execution:

`No signature of method: groovy.util.ConfigObject.multiply() is applicable for argument types: (Integer) values: [1] `

The issue is that the process block attempts to calculate `memory = { opts.memory.GB * task.attempt }` even though the opts var is not passed to the process, resulting in an undefined operation. Changing to:

`memory = { (opts?.memory?.GB ?: 1) * task.attempt }`

is probably not optimal, but prevents the error.

