### PR TITLE
v1.4.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Imports:
     patchwork,
     processx,
     purrr,
+    ragg,
     rclipboard,
     reactable,
     reactR,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     BiocGenerics,
     Biostrings,
     config,
+    cowplot,
     crayon,
     DBI,
     dbplyr,

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -22,6 +22,10 @@
 #' @param use_mitos_best logical; whether to pass --best to MITOS2 (default: FALSE).
 #' @param start_gene name of gene (PCG, rRNA, or tRNA) to start circular assembly (default = "trnF")
 #' @param coverage_trim logical; whether to trim low-coverage ends of linear assemblies (default: TRUE).
+#' @param retain_low_conf_trna logical; whether to keep low-confidence tRNAs with an
+#'   unresolved ("NNN") anticodon. When FALSE (default) these are dropped and are not
+#'   allowed to suppress overlapping MITOS2 tRNA predictions. When TRUE they are
+#'   retained (and may suppress overlapping MITOS2 predictions, the original behavior).
 #' @param ignore_scaffolds Comma-separated scaffold numbers (e.g. "1,3") to drop
 #'   from the assembly before annotation. These correspond to the `scaffold`
 #'   column in the assemblies table and reflect the per-scaffold `ignore` flag.
@@ -48,6 +52,7 @@ annotate <- function(
   use_mitos_best = TRUE,
   start_gene = "trnF",
   coverage_trim = TRUE,
+  retain_low_conf_trna = FALSE,
   ignore_scaffolds = NULL,
   out_dir = NULL
 ) {
@@ -249,6 +254,13 @@ annotate <- function(
   }
   combined_trna <- dplyr::bind_rows(annotations_trnaScan, annotations_arwen, annotations_aragorn) |>
     dplyr::mutate(gene = normalize_trna_gene(gene))
+  # Unless explicitly retaining low-confidence tRNAs, drop "NNN"-anticodon calls so
+  # they cannot suppress valid overlapping MITOS2 tRNA predictions (they are removed
+  # from the final output below anyway).
+  if (!isTRUE(retain_low_conf_trna)) {
+    combined_trna <- combined_trna |>
+      dplyr::filter(is.na(anticodon) | anticodon != "NNN")
+  }
   annotations_mitos <- annotations_mitos |>
     dplyr::mutate(gene = normalize_trna_gene(gene)) |>
     dplyr::filter(
@@ -280,8 +292,14 @@ annotate <- function(
   ) |>
     dplyr::select(-dplyr::any_of("tRNA_ID")) |> # remove temporary tRNA_ID column
     dplyr::mutate(dplyr::across("gene", stringr::str_replace, "trnS1|tnrS2", "trnS")) |> # Rename trnS1 and trnS2 to trnS
-    dplyr::mutate(dplyr::across("gene", stringr::str_replace, "trnL1|trnL2", "trnL")) |> # Rename trnL1 and trnL2 to trnL
-    dplyr::filter(type != "tRNA" | is.na(anticodon) | anticodon != "NNN") |>
+    dplyr::mutate(dplyr::across("gene", stringr::str_replace, "trnL1|trnL2", "trnL")) # Rename trnL1 and trnL2 to trnL
+  # Drop low-confidence "NNN"-anticodon tRNAs from the final output unless the user
+  # chose to retain them.
+  if (!isTRUE(retain_low_conf_trna)) {
+    annotations <- annotations |>
+      dplyr::filter(type != "tRNA" | is.na(anticodon) | anticodon != "NNN")
+  }
+  annotations <- annotations |>
     dplyr::arrange(contig, pos1)
 
 

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -79,7 +79,7 @@ annotate <- function(
       coverage_trimmed <- assembly |> purrr::imap(~ {
         stats <- coverage[coverage$SeqId == stringr::str_extract(.y, "\\S+"), ]
         # Skip for circular assemblies
-        if (stringr::str_detect("circular", .y)) {
+        if (stringr::str_detect(.y, "circular")) {
           return(list(assembly = .x, stats = stats))
         }
         coverage_trim(assembly = .x, stats = stats)

--- a/R/app_annotate.R
+++ b/R/app_annotate.R
@@ -635,6 +635,10 @@ annotate_server <- function(id) {
           inputId = "feature_trim",
           value = isTRUE(as.logical(cur$feature_trim %||% 1L))
         )
+        shinyWidgets::updatePrettyCheckbox(
+          inputId = "retain_low_conf_trna",
+          value = isTRUE(as.logical(cur$retain_low_conf_trna %||% 0L))
+        )
         updateSelectizeInput(
           inputId = "start_gene",
           choices = c(
@@ -696,6 +700,7 @@ annotate_server <- function(id) {
       shinyjs::toggleState("aragorn_opts", condition = input$edit_annotate_opts)
       shinyjs::toggleState("coverage_trim", condition = input$edit_annotate_opts)
       shinyjs::toggleState("feature_trim", condition = input$edit_annotate_opts)
+      shinyjs::toggleState("retain_low_conf_trna", condition = input$edit_annotate_opts)
       shinyjs::toggleState("start_gene", condition = input$edit_annotate_opts)
       # Check if editing opts that apply beyond selection
       if (input$edit_annotate_opts && input$annotate_opts %in% filtered_data()$annotate_opts) {
@@ -759,7 +764,8 @@ annotate_server <- function(id) {
               use_aragorn = as.integer(isTRUE(input$use_aragorn)),
               start_gene = req(input$start_gene),
               coverage_trim = as.integer(isTRUE(input$coverage_trim)),
-              feature_trim = as.integer(isTRUE(input$feature_trim))
+              feature_trim = as.integer(isTRUE(input$feature_trim)),
+              retain_low_conf_trna = as.integer(isTRUE(input$retain_low_conf_trna))
             ),
             in_place = TRUE,
             copy = TRUE,

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -413,23 +413,44 @@ annotations_details_server <- function(id, rv) {
 
       y_breaks <- scales::pretty_breaks()(range(rv$coverage$Depth))
       cov_max  <- max(rv$coverage$Position)
-      tick_x   <- seq(50, cov_max, by = 50)
-      depth_rng <- range(rv$coverage$Depth)
-      y_top    <- depth_rng[2]
-      y_tick   <- depth_rng[2] - diff(depth_rng) * 0.04
-      rv$coverage_plot <- rv$coverage |>
-        dplyr::mutate(
-          # Zero-depth end-fill positions have NA ErrorRate; NA Errors drops the
-          # background vline so the plot looks truncated. Treat NA as no error.
-          Errors = !is.na(ErrorRate) & ErrorRate > 0.05
-        ) |>
-        ggplot2::ggplot() +
+      minor_tick_x <- setdiff(seq(50, cov_max, by = 50), seq(1000, cov_max, by = 1000))
+      major_tick_x <- seq(1000, cov_max, by = 1000)
+      depth_rng    <- range(rv$coverage$Depth)
+      y_top        <- depth_rng[2]
+      y_tick_minor <- depth_rng[2] - diff(depth_rng) * 0.04
+      y_tick_major <- depth_rng[2] - diff(depth_rng) * 0.10
+
+      # Bin coverage to ~one point per output pixel (max-depth per bin) to
+      # cut geom_line vertex count on huge mitogenomes — visually lossless
+      # at 1px/bp display, ~10x faster path stroke.
+      target_pts  <- min(nrow(rv$coverage), 4000L)
+      bin_size    <- max(1L, ceiling(cov_max / target_pts))
+      cov_line_df <- rv$coverage |>
+        dplyr::mutate(.bin = ((Position - 1L) %/% bin_size) * bin_size + 1L) |>
+        dplyr::summarise(Depth = max(Depth), .by = .bin) |>
+        dplyr::rename(Position = .bin) |>
+        dplyr::arrange(Position)
+
+      # Only positions flagged as Errors get a red vline; everything else is
+      # invisible so emit no geom for them (drawing 16k transparent vlines was
+      # the dominant render cost).
+      err_df <- rv$coverage |>
+        dplyr::filter(!is.na(ErrorRate) & ErrorRate > 0.05) |>
+        dplyr::select(Position)
+
+      rv$coverage_plot <- ggplot2::ggplot(cov_line_df) +
         ggplot2::aes(x = Position, y = Depth) +
+        ggplot2::geom_vline(
+          data = err_df,
+          ggplot2::aes(xintercept = Position),
+          inherit.aes = FALSE,
+          color = "#FF667040", linewidth = 1
+        ) +
         ggplot2::geom_label(
           data = data.frame(
-            x = rep(seq(1000, max(rv$coverage$Position), by = 1000), length(y_breaks)),
-            y = rep(y_breaks, each = length(seq(1000, max(rv$coverage$Position), by = 1000))),
-            label = rep(y_breaks, each = length(seq(1000, max(rv$coverage$Position), by = 1000)))
+            x = rep(major_tick_x, length(y_breaks)),
+            y = rep(y_breaks, each = length(major_tick_x)),
+            label = rep(y_breaks, each = length(major_tick_x))
           ),
           ggplot2::aes(x = x, y = y, label = label),
           inherit.aes = FALSE,
@@ -438,18 +459,19 @@ annotations_details_server <- function(id, rv) {
           label.size = 0,
           size = 3
         ) +
-        ggplot2::geom_vline(
-          linewidth = 1,
-          ggplot2::aes(xintercept = Position, color = Errors)
+        ggplot2::geom_segment(
+          data = data.frame(x = minor_tick_x),
+          ggplot2::aes(x = x, xend = x, y = y_top, yend = y_tick_minor),
+          inherit.aes = FALSE,
+          color = "#00000060", linewidth = 0.3
         ) +
         ggplot2::geom_segment(
-          data = data.frame(x = tick_x),
-          ggplot2::aes(x = x, xend = x, y = y_top, yend = y_tick),
+          data = data.frame(x = major_tick_x),
+          ggplot2::aes(x = x, xend = x, y = y_top, yend = y_tick_major),
           inherit.aes = FALSE,
-          color = "#00000080", linewidth = 0.3
+          color = "#000000B0", linewidth = 0.5
         ) +
         ggplot2::geom_line() +
-        ggplot2::scale_color_manual(values = c("#00000000", "#FF667040")) +
         ggplot2::scale_y_continuous(breaks = y_breaks) +
         ggplot2::scale_x_continuous(
           expand = c(0, 0),
@@ -585,7 +607,7 @@ annotations_details_server <- function(id, rv) {
             id = ns("syntenyScrollDiv"),
             style = paste0("overflow-x: auto; flex: 1;",
                            if (has_aln) " cursor: zoom-in;" else ""),
-            plotOutput(ns("synteny_plot"), width = paste0(w, "px"), height = plot_h,
+            imageOutput(ns("synteny_plot"), width = paste0(w, "px"), height = plot_h,
                        click = ns("synteny_click"))
           )
         ),
@@ -617,10 +639,12 @@ annotations_details_server <- function(id, rv) {
         )
       )
     })
-    output$synteny_plot <- renderPlot({
+    output$synteny_plot <- shiny::renderImage(
+      {
       req(rv$blast_ref, rv$annotations, rv$coverage)
       req(nrow(rv$blast_ref) > 0)
 
+      img_w <- max(rv$updating$length %||% 800L, 800L)
       ref_length   <- rv$blast_ref$ref_length[1]
       sample_genes <- rv$annotations |> dplyr::filter(pos1 > 0)
       sample_len   <- max(c(rv$coverage$Position, sample_genes$pos2), na.rm = TRUE)
@@ -649,6 +673,11 @@ annotations_details_server <- function(id, rv) {
       has_aln <- !is.null(rv$blast_ref_aln) && nrow(rv$blast_ref_aln) > 0 &&
         isTRUE(nzchar(rv$blast_ref_aln$aligned_sample[1])) &&
         isTRUE(nzchar(rv$blast_ref_aln$aligned_ref[1]))
+
+      img_h <- if (has_aln) 280L else 200L
+      outfile <- tempfile(fileext = ".png")
+      ragg::agg_png(outfile, width = img_w, height = img_h, units = "px", res = 72)
+      on.exit(if (!is.null(dev.list())) dev.off(), add = TRUE)
 
       if (has_aln) {
         aln_rotation   <- as.integer(rv$blast_ref_aln$rotation[1])
@@ -698,10 +727,11 @@ annotations_details_server <- function(id, rv) {
         # rendering artifacts at overview scale.
         win      <- min(10L, aln_len)
         is_match <- as.integer(aln_class == "match")
-        n_wins   <- aln_len - win + 1L
-        win_pct  <- vapply(seq_len(n_wins), function(i) {
-          mean(is_match[i:(i + win - 1L)]) * 100
-        }, numeric(1))
+        # stats::filter does the rolling mean in C; ~20x faster than vapply for
+        # mitogenome-scale alignments.
+        win_pct  <- as.numeric(stats::filter(is_match, rep(1 / win, win), sides = 1)) * 100
+        win_pct  <- win_pct[!is.na(win_pct)]
+        n_wins   <- length(win_pct)
         # Pad x=0 and x=100 with edge values to fill to plot boundaries
         aln_win_df <- data.frame(
           x = c(0, (seq_len(n_wins) + win / 2 - 0.5) / aln_len * 100, 100),
@@ -774,7 +804,17 @@ annotations_details_server <- function(id, rv) {
                        fill = type, y = 0, label = gene) + gene_track
         print(sample_plot / ref_plot + patchwork::plot_layout(heights = c(1, 1)))
       }
-    })
+      dev.off()
+      list(
+        src = outfile,
+        contentType = "image/png",
+        width = img_w,
+        height = img_h,
+        alt = "Synteny plot"
+      )
+      },
+      deleteFile = TRUE
+    )
 
     # Zoomed base-pair view of selected gene's alignment region ----
     output$synteny_zoom_ui <- renderUI({

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -1228,7 +1228,7 @@ annotations_details_server <- function(id, rv) {
         }
         focal_set <- Biostrings::AAStringSet(focal)
         new_alignment$aln <- DECIPHER::AlignProfiles(
-          focal_set, ref_msa_cache$msa, verbose = FALSE
+          focal_set, ref_msa_cache$msa
         )
         new_alignment$alignmentHeight <- 20 + (length(new_alignment$seqs) * 20)
         new_alignment$id <- stringr::str_glue(

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -1287,19 +1287,25 @@ annotations_details_server <- function(id, rv) {
     # Notes ----
     notes_update <- debounce(reactive(input$notes), 500)
     observeEvent(notes_update(), ignoreInit = T, ignoreNULL = T, {
-      req(notes_update() != (rv$updating$annotate_notes %|NA|% ""))
-      rv$updating$annotate_notes <- notes_update() |>
-        stringr::str_remove_all(",")
+      cleaned <- notes_update() |> stringr::str_remove_all(",")
+      # Compare against the last-saved value (from rv$data) rather than rv$updating,
+      # so clearing notes back to empty still persists.
+      saved <- (rv$data$annotate_notes[rv$data$ID == rv$updating$ID])[1]
+      req(cleaned != (saved %|NA|% ""))
+      # Persist without mutating rv$updating: writing notes into rv$updating would
+      # invalidate every figure that reads it (coverage/synteny), reloading them on
+      # each keystroke.
+      notes_df <- data.frame(ID = rv$updating$ID, annotate_notes = cleaned)
       dplyr::tbl(session$userData$con, "annotate") |>
         dplyr::rows_update(
-          rv$updating[, c("ID", "annotate_notes")],
+          notes_df,
           by = "ID",
           unmatched = "ignore",
           copy = TRUE,
           in_place = TRUE
         )
       rv$data <- rv$data |>
-        dplyr::rows_update(rv$updating[, c("ID", "annotate_notes")], by = "ID")
+        dplyr::rows_update(notes_df, by = "ID")
       trigger("update_annotate_table")
     })
 
@@ -1510,7 +1516,10 @@ annotations_details_server <- function(id, rv) {
       note <- stringr::str_glue(
         "EDITED: linearized circular assembly after rotating {start-1} bp"
       )
-      rv$updating$annotate_notes <- paste(note, rv$updating$annotate_notes, sep = "; ")
+      # Read the live notes input (rv$updating$annotate_notes is no longer synced on
+      # every keystroke) so notes typed this session are preserved.
+      cur_notes <- (input$notes %||% rv$updating$annotate_notes) %|NA|% ""
+      rv$updating$annotate_notes <- paste(note, cur_notes, sep = "; ")
       updateTextAreaInput(
         inputId = "notes",
         value = rv$updating$annotate_notes

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -458,7 +458,7 @@ annotations_details_server <- function(id, rv) {
           panel.grid.major.y = ggplot2::element_line(
             linetype = "dotted", color = "#00000050"
           ),
-          plot.margin = ggplot2::margin(0, 0, 0, 2, "mm")
+          plot.margin = ggplot2::margin(0, 0, 0, 0, "mm")
         )
       # plot with dynamic width
       #plotOutput(ns("coverage_plot"), width = paste0(rv$updating$length, "px"), height = "125px")  # OLD CODE, problems with Cairo
@@ -487,11 +487,19 @@ annotations_details_server <- function(id, rv) {
     # }, deleteFile = TRUE)
     # OLD CODE, problems with Cairo
     # maybe stable now?
-    output$coverage_plot <- renderPlot({
-     req(rv$coverage_plot, rv$coverage)
-     combined_plot <- rv$coverage_plot / rv$genes_plot + plot_layout(heights = c(3, 1))
-       print(combined_plot)
-    })
+    output$coverage_plot <- renderPlot(
+      {
+        req(rv$coverage_plot, rv$coverage)
+        combined_plot <- cowplot::plot_grid(
+          rv$coverage_plot, rv$genes_plot,
+          ncol = 1, align = "v", axis = "lr",
+          rel_heights = c(3, 1)
+        )
+        print(combined_plot)
+      },
+      width  = function() rv$updating$length,
+      height = 125
+    )
     # BLAST Reference Synteny ----
     output$synteny_ui <- renderUI({
       req(rv$blast_ref, rv$updating)
@@ -2953,10 +2961,22 @@ annotations_details_server <- function(id, rv) {
 annotate_details_modal <- function(rv, session = getDefaultReactiveDomain()) {
   ns <- session$ns
 
+  topo      <- rv$updating$topology %||% "unknown"
+  topo_icon <- switch(topo, circular = "↺", linear = "↔", "?")
+  topo_badge <- span(
+    style = paste0(
+      "background:", if (topo == "circular") "#cce5ff" else if (topo == "linear") "#fff3cd" else "#e9ecef", ";",
+      "color:",      if (topo == "circular") "#004085" else if (topo == "linear") "#856404" else "#6c757d", ";",
+      "border-radius:3px;padding:2px 8px;font-size:0.75em;font-weight:600;white-space:nowrap;"
+    ),
+    paste(topo_icon, toupper(topo))
+  )
+
   modalDialog(
     title = div(
       style = "display: flex; align-items: center; gap: 12px; flex-wrap: wrap;",
       span(stringr::str_glue("Annotations: {rv$updating$ID} - {rv$updating$Taxon}")),
+      topo_badge,
       uiOutput(ns("status_badges"), inline = TRUE)
     ),
     size = "l",
@@ -3041,7 +3061,7 @@ annotate_details_modal <- function(rv, session = getDefaultReactiveDomain()) {
         tags$span(
           style = "display: inline-block; width: 10px; height: 10px; background: #FF667040; vertical-align: middle; margin-right: 4px;"
         ),
-        "Red bars mark positions with mean error rate > 5% (possible sequencing or assembly errors)."
+        "mean error rate > 5% (possible sequencing or assembly errors)."
       ),
       div(
         id = ns("coverageDiv"),

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -475,41 +475,32 @@ annotations_details_server <- function(id, rv) {
       #plotOutput(ns("coverage_plot"), width = paste0(rv$updating$length, "px"), height = "125px")  # OLD CODE, problems with Cairo
       shiny::imageOutput(ns("coverage_plot"), width = paste0(rv$updating$length, "px"), height = "125px")
     })
-    # possible fix for CAIRO error, but problems with JPEG libs on Hydra
-    # output$coverage_plot <- shiny::renderImage({
-    #   req(rv$coverage_plot, rv$coverage)
-    #
-    #   # Temporary file with .jpg extension
-    #   outfile <- tempfile(fileext = ".jpg")
-    #
-    #   # Save the combined plot as JPEG
-    #   grDevices::jpeg(outfile, width = rv$updating$length, height = 150, units = "px", quality = 100)
-    #   combined_plot <- rv$coverage_plot / rv$genes_plot + patchwork::plot_layout(heights = c(3, 1))
-    #   print(combined_plot)
-    #   dev.off()
-    #
-    #   list(
-    #     src = outfile,
-    #     contentType = "image/jpeg",
-    #     width = rv$updating$length,
-    #     height = 150,
-    #     alt = "Coverage Map"
-    #   )
-    # }, deleteFile = TRUE)
-    # OLD CODE, problems with Cairo
-    # maybe stable now?
-    output$coverage_plot <- renderPlot(
+    # Use renderImage + ragg::agg_png to bypass Cairo's per-dimension image
+    # surface limit (~16384 px on common libcairo builds), which silently
+    # truncated the right edge of large mitogenome plots under renderPlot.
+    output$coverage_plot <- shiny::renderImage(
       {
         req(rv$coverage_plot, rv$coverage)
+        w <- rv$updating$length
+        h <- 125L
+        outfile <- tempfile(fileext = ".png")
+        ragg::agg_png(outfile, width = w, height = h, units = "px", res = 72)
         combined_plot <- cowplot::plot_grid(
           rv$coverage_plot, rv$genes_plot,
           ncol = 1, align = "v", axis = "lr",
           rel_heights = c(3, 1)
         )
         print(combined_plot)
+        dev.off()
+        list(
+          src = outfile,
+          contentType = "image/png",
+          width = w,
+          height = h,
+          alt = "Coverage map"
+        )
       },
-      width  = function() rv$updating$length,
-      height = 125
+      deleteFile = TRUE
     )
     # BLAST Reference Synteny ----
     output$synteny_ui <- renderUI({

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -453,7 +453,7 @@ annotations_details_server <- function(id, rv) {
       major_tick_labels <- format(major_tick_x, big.mark = ",")
 
       # Bin coverage to ~one point per output pixel (max-depth per bin) to
-      # cut geom_line vertex count on huge mitogenomes — visually lossless
+      # cut geom_line vertex count on huge mitogenomes - visually lossless
       # at 1px/bp display, ~10x faster path stroke.
       target_pts  <- min(nrow(rv$coverage), 4000L)
       bin_size    <- max(1L, ceiling(cov_max / target_pts))
@@ -722,12 +722,12 @@ annotations_details_server <- function(id, rv) {
         s_nongap <- which(s_chars != "-")
         r_nongap <- which(r_chars != "-")
 
-        # Project sample position (original coords) → 0-100 in alignment space
+        # Project sample position (original coords) -> 0-100 in alignment space
         s_to_pct <- function(pos) {
           idx <- pmin(pmax(as.integer(pos), 1L), length(s_nongap))
           s_nongap[idx] / aln_len * 100
         }
-        # Project ref position (original coords) → rotate → 0-100 in alignment space
+        # Project ref position (original coords) -> rotate -> 0-100 in alignment space
         r_to_pct <- function(pos) {
           pos_r <- ((as.integer(pos) - 1L - aln_rotation) %% ref_length) + 1L
           idx   <- pmin(pmax(pos_r, 1L), length(r_nongap))
@@ -754,7 +754,7 @@ annotations_details_server <- function(id, rv) {
           TRUE ~ "mismatch"
         )
 
-        # Rolling-window % identity area plot — avoids per-column sub-pixel
+        # Rolling-window % identity area plot - avoids per-column sub-pixel
         # rendering artifacts at overview scale.
         win      <- min(10L, aln_len)
         is_match <- as.integer(aln_class == "match")
@@ -801,7 +801,7 @@ annotations_details_server <- function(id, rv) {
                 patchwork::plot_layout(heights = c(3, 1, 3)))
 
       } else {
-        # Fallback: no alignment — 2-track view with normalised genome coordinates
+        # Fallback: no alignment - 2-track view with normalised genome coordinates
         anchor_gene <- sample_genes |>
           dplyr::arrange(pos1) |> dplyr::pull(gene) |> head(1)
         anchor_ref <- rv$blast_ref |>
@@ -888,7 +888,7 @@ annotations_details_server <- function(id, rv) {
           style = "display: flex; align-items: flex-start;",
           div(
             # Labels pinned to track centres in the 180 px plot.
-            # y limits: -0.5 to 4.9 (range 5.4). 2 mm plot.margin ≈ 3 % of 180 px.
+            # y limits: -0.5 to 4.9 (range 5.4). 2 mm plot.margin ~ 3 % of 180 px.
             # top % = 3.15 + (4.9 - track_y) / 5.4 * 93.7
             style = paste0("flex-shrink: 0; width: 160px; font-size: 11px; ",
                            "padding-right: 6px; box-sizing: border-box; ",
@@ -941,7 +941,7 @@ annotations_details_server <- function(id, rv) {
       }
     })
 
-    # Validated window size — only invalidates when value actually changes (breaks render loop)
+    # Validated window size - only invalidates when value actually changes (breaks render loop)
     zoom_window_rv <- reactiveVal(200L)
 
     # Clamp the window-size input to [30, 2000] and drive zoom_window_rv
@@ -1037,7 +1037,7 @@ annotations_details_server <- function(id, rv) {
       }
       to_local <- function(aln_col) aln_col - win_start + 1L
 
-      # Sample genes overlapping the window — project pos1/pos2 to alignment cols
+      # Sample genes overlapping the window - project pos1/pos2 to alignment cols
       sg <- rv$annotations |> dplyr::filter(pos1 > 0)
       sg_aln1 <- s_nongap[pmin(pmax(as.integer(sg$pos1), 1L), length(s_nongap))]
       sg_aln2 <- s_nongap[pmin(pmax(as.integer(sg$pos2), 1L), length(s_nongap))]
@@ -1053,7 +1053,7 @@ annotations_details_server <- function(id, rv) {
         )
       } else NULL
 
-      # Ref genes — rotate to alignment-ref coords first, then map via r_nongap
+      # Ref genes - rotate to alignment-ref coords first, then map via r_nongap
       rg <- rv$blast_ref
       rg_pos1_r <- ((as.integer(rg$pos1) - 1L - aln_rotation) %% ref_length) + 1L
       rg_pos2_r <- ((as.integer(rg$pos2) - 1L - aln_rotation) %% ref_length) + 1L
@@ -1100,7 +1100,7 @@ annotations_details_server <- function(id, rv) {
             height = ggplot2::unit(4.5, "mm")
           )
         ) else NULL) +
-        # Identity bar — merged runs reduce render items
+        # Identity bar - merged runs reduce render items
         ggplot2::geom_rect(
           data = identity_df,
           ggplot2::aes(xmin = xmin, xmax = xmax, ymin = 1.65, ymax = 2.35, fill = fill),
@@ -1150,7 +1150,7 @@ annotations_details_server <- function(id, rv) {
       p
     })
 
-    # Synteny overview click → zoom centered at click x.
+    # Synteny overview click -> zoom centered at click x.
     # Patchwork plots can break ggplot's data-space coordmap, so we compute the
     # fraction along the plot width using CSS pixel coords (which are reliable),
     # divided by the plot's pixel width (set in the UI).
@@ -3060,7 +3060,7 @@ annotate_details_modal <- function(rv, session = getDefaultReactiveDomain()) {
   ns <- session$ns
 
   topo      <- rv$updating$topology %||% "unknown"
-  topo_icon <- switch(topo, circular = "↺", linear = "↔", "?")
+  topo_icon <- switch(topo, circular = "\u21ba", linear = "\u2194", "?")
   topo_badge <- span(
     style = paste0(
       "background:", if (topo == "circular") "#cce5ff" else if (topo == "linear") "#fff3cd" else "#e9ecef", ";",

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -414,7 +414,9 @@ annotations_details_server <- function(id, rv) {
       y_breaks <- scales::pretty_breaks()(range(rv$coverage$Depth))
       rv$coverage_plot <- rv$coverage |>
         dplyr::mutate(
-          Errors = ErrorRate > 0.05
+          # Zero-depth end-fill positions have NA ErrorRate; NA Errors drops the
+          # background vline so the plot looks truncated. Treat NA as no error.
+          Errors = !is.na(ErrorRate) & ErrorRate > 0.05
         ) |>
         ggplot2::ggplot() +
         ggplot2::aes(x = Position, y = Depth) +
@@ -700,6 +702,7 @@ annotations_details_server <- function(id, rv) {
           ggplot2::aes(x = x, y = y)
         ) +
           ggplot2::geom_area(fill = "#60BD68", colour = NA) +
+          ggplot2::geom_line(colour = "#60BD68") +
           ggplot2::scale_x_continuous(expand = c(0, 0), limits = c(0, 100)) +
           ggplot2::scale_y_continuous(expand = c(0, 0), limits = c(0, 100)) +
           ggplot2::coord_cartesian(clip = "off") +
@@ -3033,6 +3036,13 @@ annotate_details_modal <- function(rv, session = getDefaultReactiveDomain()) {
     tags$hr(style = "margin: 4px 0; border: none; border-top: 1px solid #e0e0e0;"),
     tags$details(
       tags$summary("Coverage Map"),
+      div(
+        style = "padding: 2px 5mm 0 5mm; font-size: 0.85em; color: #555;",
+        tags$span(
+          style = "display: inline-block; width: 10px; height: 10px; background: #FF667040; vertical-align: middle; margin-right: 4px;"
+        ),
+        "Red bars mark positions with mean error rate > 5% (possible sequencing or assembly errors)."
+      ),
       div(
         id = ns("coverageDiv"),
         style = "width: 100%; overflow-x: auto; padding: 5mm;",

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -406,12 +406,17 @@ annotations_details_server <- function(id, rv) {
         ggplot2::theme(
           legend.position = "none",
           axis.title = ggplot2::element_blank(),
-          axis.text.y = ggplot2::element_blank(),
-          axis.ticks.y = ggplot2::element_blank(),
+          axis.text  = ggplot2::element_blank(),
+          axis.ticks = ggplot2::element_blank(),
           plot.margin = ggplot2::margin(0, 0, 0, 0, "mm")
         )
 
       y_breaks <- scales::pretty_breaks()(range(rv$coverage$Depth))
+      cov_max  <- max(rv$coverage$Position)
+      tick_x   <- seq(50, cov_max, by = 50)
+      depth_rng <- range(rv$coverage$Depth)
+      y_top    <- depth_rng[2]
+      y_tick   <- depth_rng[2] - diff(depth_rng) * 0.04
       rv$coverage_plot <- rv$coverage |>
         dplyr::mutate(
           # Zero-depth end-fill positions have NA ErrorRate; NA Errors drops the
@@ -437,6 +442,12 @@ annotations_details_server <- function(id, rv) {
           linewidth = 1,
           ggplot2::aes(xintercept = Position, color = Errors)
         ) +
+        ggplot2::geom_segment(
+          data = data.frame(x = tick_x),
+          ggplot2::aes(x = x, xend = x, y = y_top, yend = y_tick),
+          inherit.aes = FALSE,
+          color = "#00000080", linewidth = 0.3
+        ) +
         ggplot2::geom_line() +
         ggplot2::scale_color_manual(values = c("#00000000", "#FF667040")) +
         ggplot2::scale_y_continuous(breaks = y_breaks) +
@@ -446,16 +457,15 @@ annotations_details_server <- function(id, rv) {
             1,
             max(c(rv$coverage$Position, rv$annotations$pos2))
           ),
-          breaks = seq(50, max(rv$coverage$Position), by = 50)
+          breaks = NULL
         ) +
         ggplot2::coord_cartesian(clip = "off") +
         ggthemes::theme_tufte() +
         ggplot2::theme(
           legend.position = "none",
           axis.title = ggplot2::element_blank(),
-          axis.text = ggplot2::element_blank(),
-          axis.ticks.y = ggplot2::element_blank(),
-          axis.ticks.length.x = ggplot2::unit(2, "mm"),
+          axis.text  = ggplot2::element_blank(),
+          axis.ticks = ggplot2::element_blank(),
           panel.grid.major.y = ggplot2::element_line(
             linetype = "dotted", color = "#00000050"
           ),

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -376,9 +376,31 @@ annotations_details_server <- function(id, rv) {
       shinyjs::click("close")
     })
 
+    # Snapshot of the sample fields the figures actually use. Updated only when one
+    # of them changes, so toggling unrelated state (reviewed / problematic / ID
+    # verified) leaves this value untouched and does not invalidate the coverage /
+    # synteny figures, which would otherwise re-render on every click.
+    fig_ctx <- reactiveVal(NULL)
+    observe({
+      u <- rv$updating
+      if (is.null(u) || is.null(u$ID)) {
+        if (!is.null(fig_ctx())) fig_ctx(NULL)
+        return()
+      }
+      ctx <- list(
+        ID              = u$ID,
+        length          = u$length,
+        topology        = u$topology,
+        blast_accession = u$blast_accession,
+        blast_species   = u$blast_species,
+        poor_blast_ref  = u$poor_blast_ref
+      )
+      if (!identical(ctx, fig_ctx())) fig_ctx(ctx)
+    })
+
     # Coverage Map ----
     output$coverage_map <- renderUI({
-      req(rv$coverage)
+      req(rv$coverage, fig_ctx())
       rv$genes_plot <- rv$annotations |>
         dplyr::filter(pos1 > 0) |>
         dplyr::mutate(
@@ -503,15 +525,15 @@ annotations_details_server <- function(id, rv) {
         )
       # plot with dynamic width
       #plotOutput(ns("coverage_plot"), width = paste0(rv$updating$length, "px"), height = "125px")  # OLD CODE, problems with Cairo
-      shiny::imageOutput(ns("coverage_plot"), width = paste0(rv$updating$length, "px"), height = "125px")
+      shiny::imageOutput(ns("coverage_plot"), width = paste0(fig_ctx()$length, "px"), height = "125px")
     })
     # Use renderImage + ragg::agg_png to bypass Cairo's per-dimension image
     # surface limit (~16384 px on common libcairo builds), which silently
     # truncated the right edge of large mitogenome plots under renderPlot.
     output$coverage_plot <- shiny::renderImage(
       {
-        req(rv$coverage_plot, rv$coverage)
-        w <- rv$updating$length
+        req(rv$coverage_plot, rv$coverage, fig_ctx())
+        w <- fig_ctx()$length
         h <- 125L
         outfile <- tempfile(fileext = ".png")
         ragg::agg_png(outfile, width = w, height = h, units = "px", res = 72)
@@ -534,17 +556,18 @@ annotations_details_server <- function(id, rv) {
     )
     # BLAST Reference Synteny ----
     output$synteny_ui <- renderUI({
-      req(rv$blast_ref, rv$updating)
+      req(rv$blast_ref)
+      ctx <- req(fig_ctx())
       req(nrow(rv$blast_ref) > 0)
       # Don't render synteny when no current BLAST ref exists on this sample
       # (e.g. BLAST disabled in opts). Stale rows may linger in
       # blast_ref_annotations from a prior run with BLAST enabled.
-      req(!is.na(rv$updating$blast_accession),
-          nzchar(rv$updating$blast_accession))
-      w          <- max(rv$updating$length %||% 800L, 800L)
-      sample_lbl <- rv$updating$ID
-      ref_lbl    <- rv$updating$blast_species %||% rv$updating$blast_accession
-      ref_acc    <- rv$updating$blast_accession
+      req(!is.na(ctx$blast_accession),
+          nzchar(ctx$blast_accession))
+      w          <- max(ctx$length %||% 800L, 800L)
+      sample_lbl <- ctx$ID
+      ref_lbl    <- ctx$blast_species %||% ctx$blast_accession
+      ref_acc    <- ctx$blast_accession
       has_aln    <- !is.null(rv$blast_ref_aln) && nrow(rv$blast_ref_aln) > 0 &&
         isTRUE(nzchar(rv$blast_ref_aln$aligned_sample[1])) &&
         isTRUE(nzchar(rv$blast_ref_aln$aligned_ref[1]))
@@ -570,7 +593,7 @@ annotations_details_server <- function(id, rv) {
           lbl("100px", div(div(ref_acc), div(style = "color: #888; font-size: 10px;", ref_lbl)))
         )
       }
-      is_poor <- isTRUE(rv$updating$poor_blast_ref == "poor")
+      is_poor <- isTRUE(ctx$poor_blast_ref == "poor")
       tagList(
         div(
           style = "display: flex; justify-content: start; margin-bottom: 6px;",
@@ -586,7 +609,7 @@ annotations_details_server <- function(id, rv) {
             inline = TRUE
           )
         ),
-        if (isTRUE(rv$updating$topology == "linear")) {
+        if (isTRUE(ctx$topology == "linear")) {
           div(
             class = "alert alert-warning",
             style = "padding: 6px 10px; font-size: 0.85em; margin-bottom: 6px;",
@@ -649,10 +672,10 @@ annotations_details_server <- function(id, rv) {
     })
     output$synteny_plot <- shiny::renderImage(
       {
-      req(rv$blast_ref, rv$annotations, rv$coverage)
+      req(rv$blast_ref, rv$annotations, rv$coverage, fig_ctx())
       req(nrow(rv$blast_ref) > 0)
 
-      img_w <- max(rv$updating$length %||% 800L, 800L)
+      img_w <- max(fig_ctx()$length %||% 800L, 800L)
       ref_length   <- rv$blast_ref$ref_length[1]
       sample_genes <- rv$annotations |> dplyr::filter(pos1 > 0)
       sample_len   <- max(c(rv$coverage$Position, sample_genes$pos2), na.rm = TRUE)
@@ -783,7 +806,7 @@ annotations_details_server <- function(id, rv) {
           dplyr::arrange(pos1) |> dplyr::pull(gene) |> head(1)
         anchor_ref <- rv$blast_ref |>
           dplyr::filter(gene == anchor_gene) |> dplyr::arrange(pos1)
-        rotation <- if (rv$updating$topology == "circular" && nrow(anchor_ref) > 0) {
+        rotation <- if (fig_ctx()$topology == "circular" && nrow(anchor_ref) > 0) {
           as.integer(anchor_ref$pos1[1]) - 1L
         } else {
           0L
@@ -843,8 +866,9 @@ annotations_details_server <- function(id, rv) {
       win <- zoom_window_rv()
       px_per_col <- 14L
       plot_w <- as.integer(win * px_per_col)
-      sample_lbl <- rv$updating$ID
-      ref_acc    <- rv$updating$blast_accession
+      ctx <- req(fig_ctx())
+      sample_lbl <- ctx$ID
+      ref_acc    <- ctx$blast_accession
       header_txt <- if (!is.null(click_col)) {
         s_chars   <- strsplit(rv$blast_ref_aln$aligned_sample[1], "")[[1]]
         anchor_bp <- as.integer(cumsum(s_chars != "-")[click_col])

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -403,15 +403,21 @@ annotations_details_server <- function(id, rv) {
             1,
             max(c(rv$coverage$Position, rv$annotations$pos2))
           ),
-          breaks = seq(1000, max(rv$coverage$Position), by = 1000)
+          breaks = seq(1000, max(rv$coverage$Position), by = 1000),
+          labels = format(seq(1000, max(rv$coverage$Position), by = 1000), big.mark = ",")
         ) +
         ggplot2::coord_cartesian(clip = "off") +
         ggthemes::theme_tufte() +
         ggplot2::theme(
           legend.position = "none",
-          axis.title = ggplot2::element_blank(),
-          axis.text  = ggplot2::element_blank(),
-          axis.ticks = ggplot2::element_blank(),
+          axis.title  = ggplot2::element_blank(),
+          axis.text.y = ggplot2::element_blank(),
+          # Match coverage plot's bottom-axis bounding box (invisible) so cowplot
+          # align="lr" doesn't pad either panel.
+          axis.text.x = ggplot2::element_text(size = 7, color = NA),
+          axis.ticks.y = ggplot2::element_blank(),
+          axis.ticks.x = ggplot2::element_line(color = NA, linewidth = 0.4),
+          axis.ticks.length.x = ggplot2::unit(1.5, "mm"),
           plot.margin = ggplot2::margin(0, 0, 0, 0, "mm")
         )
 
@@ -420,9 +426,9 @@ annotations_details_server <- function(id, rv) {
       minor_tick_x <- setdiff(seq(50, cov_max, by = 50), seq(1000, cov_max, by = 1000))
       major_tick_x <- seq(1000, cov_max, by = 1000)
       depth_rng    <- range(rv$coverage$Depth)
-      y_top        <- depth_rng[2]
-      y_tick_minor <- depth_rng[2] - diff(depth_rng) * 0.04
-      y_tick_major <- depth_rng[2] - diff(depth_rng) * 0.10
+      y_bottom     <- depth_rng[1]
+      y_tick_minor <- depth_rng[1] + diff(depth_rng) * 0.04
+      major_tick_labels <- format(major_tick_x, big.mark = ",")
 
       # Bin coverage to ~one point per output pixel (max-depth per bin) to
       # cut geom_line vertex count on huge mitogenomes — visually lossless
@@ -465,15 +471,9 @@ annotations_details_server <- function(id, rv) {
         ) +
         ggplot2::geom_segment(
           data = data.frame(x = minor_tick_x),
-          ggplot2::aes(x = x, xend = x, y = y_top, yend = y_tick_minor),
+          ggplot2::aes(x = x, xend = x, y = y_bottom, yend = y_tick_minor),
           inherit.aes = FALSE,
           color = "#00000060", linewidth = 0.3
-        ) +
-        ggplot2::geom_segment(
-          data = data.frame(x = major_tick_x),
-          ggplot2::aes(x = x, xend = x, y = y_top, yend = y_tick_major),
-          inherit.aes = FALSE,
-          color = "#000000B0", linewidth = 0.5
         ) +
         ggplot2::geom_line() +
         ggplot2::scale_y_continuous(breaks = y_breaks) +
@@ -483,15 +483,19 @@ annotations_details_server <- function(id, rv) {
             1,
             max(c(rv$coverage$Position, rv$annotations$pos2))
           ),
-          breaks = NULL
+          breaks = major_tick_x,
+          labels = major_tick_labels
         ) +
         ggplot2::coord_cartesian(clip = "off") +
         ggthemes::theme_tufte() +
         ggplot2::theme(
           legend.position = "none",
           axis.title = ggplot2::element_blank(),
-          axis.text  = ggplot2::element_blank(),
-          axis.ticks = ggplot2::element_blank(),
+          axis.text.y = ggplot2::element_blank(),
+          axis.text.x = ggplot2::element_text(size = 7, color = "#000000B0"),
+          axis.ticks.y = ggplot2::element_blank(),
+          axis.ticks.x = ggplot2::element_line(color = "#000000B0", linewidth = 0.4),
+          axis.ticks.length.x = ggplot2::unit(1.5, "mm"),
           panel.grid.major.y = ggplot2::element_line(
             linetype = "dotted", color = "#00000050"
           ),

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -272,6 +272,8 @@ annotations_details_server <- function(id, rv) {
           return(rv$editing$idx)
         }
         rv$alignment <- rv$local_hits <- NULL
+        ref_msa_cache$msa <- NULL
+        ref_msa_cache$key <- NULL
         if (rv$annotations$type[sel] == "PCG" & length(rv$alignment) != 0) {
           trigger("align_now")
         } else {
@@ -344,6 +346,8 @@ annotations_details_server <- function(id, rv) {
       rv$alignment <- NULL
       rv$coverage_width <- NULL
       rv$editing <- NULL
+      ref_msa_cache$msa <- NULL
+      ref_msa_cache$key <- NULL
       trigger("update_annotate_table")
       removeModal()
     })
@@ -1166,6 +1170,12 @@ annotations_details_server <- function(id, rv) {
     })
 
     # MSA ----
+    # Non-reactive cache for the reference-only MSA. Avoids re-running
+    # DECIPHER::AlignSeqs(refs) on every codon edit (refs don't change).
+    ref_msa_cache <- new.env(parent = emptyenv())
+    ref_msa_cache$msa <- NULL
+    ref_msa_cache$key <- NULL
+
     init("align_now")
     observeEvent(input$align, ignoreInit = T, {
       shinyWidgets::updatePrettyCheckbox(
@@ -1174,12 +1184,17 @@ annotations_details_server <- function(id, rv) {
       )
       trigger("align_now")
     })
-    on("align_now", {
+    # Debounce align_now: rapid codon-edit clicks collapse into one MSA rebuild
+    # after the user pauses for ~250ms.
+    align_now_dbnc <- shiny::debounce(
+      shiny::reactive(gargoyle::watch("align_now")),
+      250
+    )
+    observeEvent(align_now_dbnc(), ignoreInit = TRUE, {
       # check if user wants to use fewer reference samples in alignment
       if (isTRUE(input$reduce_align)){ n_hits = 5 } else { n_hits = Inf }
 
       req(rv$annotations$type[selected()] == "PCG")
-      rv$alignment <- NULL
 
       hits <- rv$local_hits %||% json_parse(rv$annotations$refHits[selected()], TRUE) |>
         dplyr::slice_head(n = n_hits)
@@ -1187,47 +1202,51 @@ annotations_details_server <- function(id, rv) {
       focal <- rv$annotations$translation[selected()] |>
         setNames(paste(rv$annotations$gene[selected()], "(focal)"))
 
+      new_alignment <- list()
       if(nrow(hits)==0){
-        rv$alignment$seqs <- character(0)
-        rv$alignment$aln <- Biostrings::AAStringSet(focal)
-
-        rv$alignment$alignmentHeight <- 40
-        rv$alignment$id <- stringr::str_glue(
+        new_alignment$seqs <- character(0)
+        new_alignment$aln <- Biostrings::AAStringSet(focal)
+        new_alignment$alignmentHeight <- 40
+        new_alignment$id <- stringr::str_glue(
           "<b>Max Similarity:</b> n/a"
         )
-        rv$alignment$stop <- stringr::str_glue(
-          "<b>Stop Codon:</b> {rv$annotations$stop_codon[selected()]}"
-        )
-        rv$alignment$start <- stringr::str_glue(
-          "<b>Start Codon:</b> {rv$annotations$start_codon[selected()]}"
-        )
-        rv$alignment$internal_stop <- ifelse(
-          stringr::str_detect(rv$annotations$translation[selected()], "\\*"),
-          paste("<span>", as.character(icon("warning")), "<b>Internal Stop Detected</b>", as.character(icon("warning")), "<span>"),
-          ""
-        )
       }else{
-        rv$alignment$seqs <- hits |>
+        new_alignment$seqs <- hits |>
           dplyr::pull(target, name = Taxon)
-        rv$alignment$aln <- c(focal, rv$alignment$seqs) |>
-          Biostrings::AAStringSet() |>
-          DECIPHER::AlignSeqs(verbose = FALSE)
-        rv$alignment$alignmentHeight <- 20 + (length(rv$alignment$seqs) * 20)
-        rv$alignment$id <- stringr::str_glue(
+        # Cache the reference-only MSA across codon edits: the references don't
+        # change while the user walks codons, so reuse the prior MSA and add
+        # the (cheap) focal sequence via profile alignment.
+        ref_key <- paste(selected(), n_hits, paste(new_alignment$seqs, collapse = "|"), sep = "::")
+        if (!identical(ref_msa_cache$key, ref_key)) {
+          ref_set <- Biostrings::AAStringSet(new_alignment$seqs)
+          ref_msa_cache$msa <- if (length(ref_set) == 1L) {
+            ref_set
+          } else {
+            DECIPHER::AlignSeqs(ref_set, verbose = FALSE)
+          }
+          ref_msa_cache$key <- ref_key
+        }
+        focal_set <- Biostrings::AAStringSet(focal)
+        new_alignment$aln <- DECIPHER::AlignProfiles(
+          focal_set, ref_msa_cache$msa, verbose = FALSE
+        )
+        new_alignment$alignmentHeight <- 20 + (length(new_alignment$seqs) * 20)
+        new_alignment$id <- stringr::str_glue(
           "<b>Max Similarity:</b> {ifelse(max(hits$similarity)<25,'-',paste0(round(max(hits$similarity),1),'%'))}"
         )
-        rv$alignment$stop <- stringr::str_glue(
-          "<b>Stop Codon:</b> {rv$annotations$stop_codon[selected()]}"
-        )
-        rv$alignment$start <- stringr::str_glue(
-          "<b>Start Codon:</b> {rv$annotations$start_codon[selected()]}"
-        )
-        rv$alignment$internal_stop <- ifelse(
-          stringr::str_detect(rv$annotations$translation[selected()], "\\*"),
-          paste("<span>", as.character(icon("warning")), "<b>Internal Stop Detected</b>", as.character(icon("warning")), "<span>"),
-          ""
-        )
       }
+      new_alignment$stop <- stringr::str_glue(
+        "<b>Stop Codon:</b> {rv$annotations$stop_codon[selected()]}"
+      )
+      new_alignment$start <- stringr::str_glue(
+        "<b>Start Codon:</b> {rv$annotations$start_codon[selected()]}"
+      )
+      new_alignment$internal_stop <- ifelse(
+        stringr::str_detect(rv$annotations$translation[selected()], "\\*"),
+        paste("<span>", as.character(icon("warning")), "<b>Internal Stop Detected</b>", as.character(icon("warning")), "<span>"),
+        ""
+      )
+      rv$alignment <- new_alignment
     })
     output$msa_header <- renderUI({
       div(
@@ -1690,7 +1709,7 @@ annotations_details_server <- function(id, rv) {
         }
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1, pos2 - nchar(rv$annotations$stop_codon[selected()])) |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code))
+          Biostrings::translate(genetic.code = session$userData$gcode)
       }
       if (rv$annotations$direction[selected()] == "-") {
         while (codon %nin% rv$editing$params$start_codons) {
@@ -1705,7 +1724,7 @@ annotations_details_server <- function(id, rv) {
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1 + nchar(rv$annotations$stop_codon[selected()]), pos2) |>
           Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       rv$annotations$pos1[selected()] <- pos1
@@ -1735,7 +1754,7 @@ annotations_details_server <- function(id, rv) {
         }
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1, pos2 - nchar(rv$annotations$stop_codon[selected()])) |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code))
+          Biostrings::translate(genetic.code = session$userData$gcode)
       }
       if (rv$annotations$direction[selected()] == "-") {
         for(counter in 1:5){
@@ -1754,7 +1773,7 @@ annotations_details_server <- function(id, rv) {
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1 + nchar(rv$annotations$stop_codon[selected()]), pos2) |>
           Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       rv$annotations$pos1[selected()] <- pos1
@@ -1784,7 +1803,7 @@ annotations_details_server <- function(id, rv) {
         }
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1, pos2 - nchar(rv$annotations$stop_codon[selected()])) |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code))
+          Biostrings::translate(genetic.code = session$userData$gcode)
       }
       if (rv$annotations$direction[selected()] == "-") {
         for(counter in 1:10){
@@ -1803,7 +1822,7 @@ annotations_details_server <- function(id, rv) {
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1 + nchar(rv$annotations$stop_codon[selected()]), pos2) |>
           Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       rv$annotations$pos1[selected()] <- pos1
@@ -1851,7 +1870,7 @@ annotations_details_server <- function(id, rv) {
         }
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1, pos2 - nchar(rv$annotations$stop_codon[selected()])) |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       if (rv$annotations$direction[selected()] == "-") {
@@ -1867,7 +1886,7 @@ annotations_details_server <- function(id, rv) {
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1 + nchar(rv$annotations$stop_codon[selected()]), pos2) |>
           Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       rv$annotations$pos1[selected()] <- pos1
@@ -1896,7 +1915,7 @@ annotations_details_server <- function(id, rv) {
         }
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1, pos2 - nchar(rv$annotations$stop_codon[selected()])) |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code))
+          Biostrings::translate(genetic.code = session$userData$gcode)
       }
       if (rv$annotations$direction[selected()] == "-") {
         for(counter in 1:5){
@@ -1915,7 +1934,7 @@ annotations_details_server <- function(id, rv) {
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1 + nchar(rv$annotations$stop_codon[selected()]), pos2) |>
           Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       rv$annotations$pos1[selected()] <- pos1
@@ -1945,7 +1964,7 @@ annotations_details_server <- function(id, rv) {
         }
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1, pos2 - nchar(rv$annotations$stop_codon[selected()])) |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code))
+          Biostrings::translate(genetic.code = session$userData$gcode)
       }
       if (rv$annotations$direction[selected()] == "-") {
         for(counter in 1:10){
@@ -1964,7 +1983,7 @@ annotations_details_server <- function(id, rv) {
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1 + nchar(rv$annotations$stop_codon[selected()]), pos2) |>
           Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       rv$annotations$pos1[selected()] <- pos1
@@ -2024,7 +2043,7 @@ annotations_details_server <- function(id, rv) {
         pos2 <- pos2 - (3 - nchar(codon))
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1, pos2 - nchar(codon)) |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       if (rv$annotations$direction[selected()] == "-") {
@@ -2053,7 +2072,7 @@ annotations_details_server <- function(id, rv) {
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1 + nchar(codon), pos2) |>
           Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       rv$annotations$pos1[selected()] <- pos1
@@ -2094,7 +2113,7 @@ annotations_details_server <- function(id, rv) {
         pos2 <- pos2 - (3 - nchar(codon))
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1, pos2 - nchar(codon)) |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       if (rv$annotations$direction[selected()] == "-") {
@@ -2127,7 +2146,7 @@ annotations_details_server <- function(id, rv) {
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1 + nchar(codon), pos2) |>
           Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       rv$annotations$pos1[selected()] <- pos1
@@ -2168,7 +2187,7 @@ annotations_details_server <- function(id, rv) {
         pos2 <- pos2 - (3 - nchar(codon))
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1, pos2 - nchar(codon)) |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       if (rv$annotations$direction[selected()] == "-") {
@@ -2201,7 +2220,7 @@ annotations_details_server <- function(id, rv) {
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1 + nchar(codon), pos2) |>
           Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       rv$annotations$pos1[selected()] <- pos1
@@ -2262,7 +2281,7 @@ annotations_details_server <- function(id, rv) {
         pos2 <- pos2 - (3 - nchar(codon))
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1, pos2 - nchar(codon)) |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       if (rv$annotations$direction[selected()] == "-") {
@@ -2293,7 +2312,7 @@ annotations_details_server <- function(id, rv) {
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1 + nchar(codon), pos2) |>
           Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       rv$annotations$pos1[selected()] <- pos1
@@ -2336,7 +2355,7 @@ annotations_details_server <- function(id, rv) {
         pos2 <- pos2 - (3 - nchar(codon))
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1, pos2 - nchar(codon)) |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       if (rv$annotations$direction[selected()] == "-") {
@@ -2371,7 +2390,7 @@ annotations_details_server <- function(id, rv) {
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1 + nchar(codon), pos2) |>
           Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       rv$annotations$pos1[selected()] <- pos1
@@ -2414,7 +2433,7 @@ annotations_details_server <- function(id, rv) {
         pos2 <- pos2 - (3 - nchar(codon))
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1, pos2 - nchar(codon)) |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       if (rv$annotations$direction[selected()] == "-") {
@@ -2449,7 +2468,7 @@ annotations_details_server <- function(id, rv) {
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1 + nchar(codon), pos2) |>
           Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)) |>
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
           as.character()
       }
       rv$annotations$pos1[selected()] <- pos1
@@ -2502,7 +2521,7 @@ annotations_details_server <- function(id, rv) {
         dplyr::arrange(dplyr::desc(similarity))
 
       temp_hits <- json_string(hits)
-      rv$alignment <- NULL
+      # Keep rv$alignment around (incl. cached ref_msa); align_now rebuilds it.
       trigger("align_now")
     })
 
@@ -2724,7 +2743,7 @@ annotations_details_server <- function(id, rv) {
           merged$translation <- assembly |>
             Biostrings::subseq(new_pos1, new_pos2 - nchar(merged$stop_codon)) |>
             Biostrings::translate(
-              genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)
+              genetic.code = session$userData$gcode
             ) |>
             as.character()
         } else {
@@ -2740,7 +2759,7 @@ annotations_details_server <- function(id, rv) {
             Biostrings::subseq(new_pos1 + nchar(merged$stop_codon), new_pos2) |>
             Biostrings::reverseComplement() |>
             Biostrings::translate(
-              genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)
+              genetic.code = session$userData$gcode
             ) |>
             as.character()
         }
@@ -2935,7 +2954,7 @@ annotations_details_server <- function(id, rv) {
               merged_orig_pos2 - nchar(reverted$stop_codon)
             ) |>
             Biostrings::translate(
-              genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)
+              genetic.code = session$userData$gcode
             ) |>
             as.character()
         } else {
@@ -2954,7 +2973,7 @@ annotations_details_server <- function(id, rv) {
             ) |>
             Biostrings::reverseComplement() |>
             Biostrings::translate(
-              genetic.code = Biostrings::getGeneticCode(session$userData$genetic_code)
+              genetic.code = session$userData$gcode
             ) |>
             as.character()
         }

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -446,7 +446,7 @@ annotations_details_server <- function(id, rv) {
             1,
             max(c(rv$coverage$Position, rv$annotations$pos2))
           ),
-          breaks = seq(1000, max(rv$coverage$Position), by = 1000)
+          breaks = seq(50, max(rv$coverage$Position), by = 50)
         ) +
         ggplot2::coord_cartesian(clip = "off") +
         ggthemes::theme_tufte() +
@@ -454,7 +454,8 @@ annotations_details_server <- function(id, rv) {
           legend.position = "none",
           axis.title = ggplot2::element_blank(),
           axis.text = ggplot2::element_blank(),
-          axis.ticks = ggplot2::element_blank(),
+          axis.ticks.y = ggplot2::element_blank(),
+          axis.ticks.length.x = ggplot2::unit(2, "mm"),
           panel.grid.major.y = ggplot2::element_line(
             linetype = "dotted", color = "#00000050"
           ),

--- a/R/app_annotate_utils.R
+++ b/R/app_annotate_utils.R
@@ -290,6 +290,12 @@ annotate_opts_modal <- function(rv = NULL, session = getDefaultReactiveDomain())
           value = isTRUE(as.logical(current$feature_trim %||% 1L)),
           status = "primary"
         ) |> shinyjs::disabled(),
+        shinyWidgets::prettyCheckbox(
+          ns("retain_low_conf_trna"),
+          label = "Retain low-confidence (NNN anticodon) tRNAs",
+          value = isTRUE(as.logical(current$retain_low_conf_trna %||% 0L)),
+          status = "primary"
+        ) |> shinyjs::disabled(),
         div(
           selectizeInput(
             ns("start_gene"),

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -64,6 +64,8 @@ app_server <- function(input, output, session) {
     stringr::str_extract("genetic_code.*") |>
     na.omit() |>
     stringr::str_extract("[0-9]+$")
+  # Cache the genetic code lookup table once; called ~30x during codon edits.
+  session$userData$gcode <- Biostrings::getGeneticCode(session$userData$genetic_code)
 
   # View mode ----
   observeEvent(input$mode, {

--- a/R/app_server_userAsmb.R
+++ b/R/app_server_userAsmb.R
@@ -34,6 +34,8 @@ app_server_userAsmb <- function(input, output, session) {
     stringr::str_extract("genetic_code.*") |>
     na.omit() |>
     stringr::str_extract("[0-9]+$")
+  # Cache the genetic code lookup table once; called ~30x during codon edits.
+  session$userData$gcode <- Biostrings::getGeneticCode(session$userData$genetic_code)
 
   # View mode ----
   observeEvent(input$mode, {

--- a/R/backwards_compatibility.R
+++ b/R/backwards_compatibility.R
@@ -439,6 +439,25 @@ backwards_compatibility <- function(
       )
   }
 
+  # if retain_low_conf_trna column doesn't exist, add it (default off = drop NNN)
+  if (!("retain_low_conf_trna" %in% names(annotate_opts_table))) {
+    message("added 'retain_low_conf_trna' column to annotate_opts table")
+    annotate_opts_table$retain_low_conf_trna <- rep(0L, nrow(annotate_opts_table))
+    glue::glue_sql(
+      "ALTER TABLE annotate_opts
+       ADD COLUMN retain_low_conf_trna INTEGER",
+      col = col,
+      .con = con
+    ) |> DBI::dbExecute(con, statement = _)
+    dplyr::tbl(con, "annotate_opts") |>
+      dplyr::rows_upsert(
+        annotate_opts_table,
+        in_place = TRUE,
+        copy = TRUE,
+        by = "annotate_opts"
+      )
+  }
+
   # if start_gene column doesn't exist, add it
   if(!("start_gene" %in% names(annotate_opts_table))){
     message("added 'start_gene' column to annotate_opts table")

--- a/R/init_db.R
+++ b/R/init_db.R
@@ -428,6 +428,7 @@ new_db <- function(
       start_gene TEXT,
       coverage_trim INTEGER,
       feature_trim INTEGER,
+      retain_low_conf_trna INTEGER,
       PRIMARY KEY (annotate_opts)
     );"
   )
@@ -448,7 +449,8 @@ new_db <- function(
         use_aragorn = 0L,
         start_gene = "trnF",
         coverage_trim = 1L,
-        feature_trim = 1L
+        feature_trim = 1L,
+        retain_low_conf_trna = 0L
       ),
       in_place = TRUE,
       copy = TRUE,

--- a/R/init_db_userAsmb.R
+++ b/R/init_db_userAsmb.R
@@ -379,6 +379,7 @@ new_db_userAsmb <- function(
       start_gene TEXT,
       coverage_trim INTEGER,
       feature_trim INTEGER,
+      retain_low_conf_trna INTEGER,
       PRIMARY KEY (annotate_opts)
     );"
   )
@@ -399,7 +400,8 @@ new_db_userAsmb <- function(
         use_aragorn = 0L,
         start_gene = "trnF",
         coverage_trim = 1L,
-        feature_trim = 1L
+        feature_trim = 1L,
+        retain_low_conf_trna = 0L
       ),
       in_place = TRUE,
       copy = TRUE,

--- a/R/validate_annelid_mito.R
+++ b/R/validate_annelid_mito.R
@@ -167,6 +167,12 @@ validate_annelid_mito <- function(
         annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "tRNA within PCG or rRNA")
         total_warnings = total_warnings + 1
       }
+      # Flag low-confidence tRNAs whose anticodon could not be resolved ("NNN").
+      # These only reach validation when the user enabled retain_low_conf_trna.
+      if (isTRUE(annotations$anticodon[i] == "NNN")) {
+        annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "low-confidence tRNA (NNN anticodon)")
+        total_warnings = total_warnings + 1
+      }
     }
 
     ## Length limits ----

--- a/R/validate_bird_mito.R
+++ b/R/validate_bird_mito.R
@@ -167,6 +167,12 @@ validate_bird_mito <- function(
         annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "tRNA within PCG or rRNA")
         total_warnings = total_warnings + 1
       }
+      # Flag low-confidence tRNAs whose anticodon could not be resolved ("NNN").
+      # These only reach validation when the user enabled retain_low_conf_trna.
+      if (isTRUE(annotations$anticodon[i] == "NNN")) {
+        annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "low-confidence tRNA (NNN anticodon)")
+        total_warnings = total_warnings + 1
+      }
     }
 
     ## Length limits ----

--- a/R/validate_copepod_mito.R
+++ b/R/validate_copepod_mito.R
@@ -167,6 +167,12 @@ validate_copepod_mito <- function(
         annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "tRNA within PCG or rRNA")
         total_warnings = total_warnings + 1
       }
+      # Flag low-confidence tRNAs whose anticodon could not be resolved ("NNN").
+      # These only reach validation when the user enabled retain_low_conf_trna.
+      if (isTRUE(annotations$anticodon[i] == "NNN")) {
+        annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "low-confidence tRNA (NNN anticodon)")
+        total_warnings = total_warnings + 1
+      }
     }
 
     ## Length limits ----

--- a/R/validate_ctenophore_mito.R
+++ b/R/validate_ctenophore_mito.R
@@ -167,6 +167,12 @@ validate_ctenophore_mito <- function(
         annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "tRNA within PCG or rRNA")
         total_warnings = total_warnings + 1
       }
+      # Flag low-confidence tRNAs whose anticodon could not be resolved ("NNN").
+      # These only reach validation when the user enabled retain_low_conf_trna.
+      if (isTRUE(annotations$anticodon[i] == "NNN")) {
+        annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "low-confidence tRNA (NNN anticodon)")
+        total_warnings = total_warnings + 1
+      }
     }
 
     ## Length limits ----

--- a/R/validate_diptera_mito.R
+++ b/R/validate_diptera_mito.R
@@ -166,6 +166,12 @@ validate_diptera_mito <- function(
         annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "tRNA within PCG or rRNA")
         total_warnings = total_warnings + 1
       }
+      # Flag low-confidence tRNAs whose anticodon could not be resolved ("NNN").
+      # These only reach validation when the user enabled retain_low_conf_trna.
+      if (isTRUE(annotations$anticodon[i] == "NNN")) {
+        annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "low-confidence tRNA (NNN anticodon)")
+        total_warnings = total_warnings + 1
+      }
     }
 
     ## Length limits ----

--- a/R/validate_fish_mito.R
+++ b/R/validate_fish_mito.R
@@ -167,6 +167,12 @@ validate_fish_mito <- function(
         annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "tRNA within PCG or rRNA")
         total_warnings = total_warnings + 1
       }
+      # Flag low-confidence tRNAs whose anticodon could not be resolved ("NNN").
+      # These only reach validation when the user enabled retain_low_conf_trna.
+      if (isTRUE(annotations$anticodon[i] == "NNN")) {
+        annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "low-confidence tRNA (NNN anticodon)")
+        total_warnings = total_warnings + 1
+      }
     }
 
     ## Length limits ----

--- a/R/validate_hexacoral_mito.R
+++ b/R/validate_hexacoral_mito.R
@@ -195,6 +195,12 @@ validate_hexacoral_mito <- function(
         annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "tRNA within PCG or rRNA")
         total_warnings = total_warnings + 1
       }
+      # Flag low-confidence tRNAs whose anticodon could not be resolved ("NNN").
+      # These only reach validation when the user enabled retain_low_conf_trna.
+      if (isTRUE(annotations$anticodon[i] == "NNN")) {
+        annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "low-confidence tRNA (NNN anticodon)")
+        total_warnings = total_warnings + 1
+      }
     }
 
     ## Length limits ----

--- a/R/validate_lepidosaur_mito.R
+++ b/R/validate_lepidosaur_mito.R
@@ -167,6 +167,12 @@ validate_lepidosaur_mito <- function(
         annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "tRNA within PCG or rRNA")
         total_warnings = total_warnings + 1
       }
+      # Flag low-confidence tRNAs whose anticodon could not be resolved ("NNN").
+      # These only reach validation when the user enabled retain_low_conf_trna.
+      if (isTRUE(annotations$anticodon[i] == "NNN")) {
+        annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "low-confidence tRNA (NNN anticodon)")
+        total_warnings = total_warnings + 1
+      }
     }
 
     ## Length limits ----

--- a/R/validate_mammal_mito.R
+++ b/R/validate_mammal_mito.R
@@ -167,6 +167,12 @@ validate_mammal_mito <- function(
         annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "tRNA within PCG or rRNA")
         total_warnings = total_warnings + 1
       }
+      # Flag low-confidence tRNAs whose anticodon could not be resolved ("NNN").
+      # These only reach validation when the user enabled retain_low_conf_trna.
+      if (isTRUE(annotations$anticodon[i] == "NNN")) {
+        annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "low-confidence tRNA (NNN anticodon)")
+        total_warnings = total_warnings + 1
+      }
     }
 
     ## Length limits ----

--- a/R/validate_octocoral_mito.R
+++ b/R/validate_octocoral_mito.R
@@ -167,6 +167,12 @@ validate_octocoral_mito <- function(
         annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "tRNA within PCG or rRNA")
         total_warnings = total_warnings + 1
       }
+      # Flag low-confidence tRNAs whose anticodon could not be resolved ("NNN").
+      # These only reach validation when the user enabled retain_low_conf_trna.
+      if (isTRUE(annotations$anticodon[i] == "NNN")) {
+        annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "low-confidence tRNA (NNN anticodon)")
+        total_warnings = total_warnings + 1
+      }
     }
 
     ## Length limits ----

--- a/R/validate_starfish_mito.R
+++ b/R/validate_starfish_mito.R
@@ -167,6 +167,12 @@ validate_starfish_mito <- function(
         annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "tRNA within PCG or rRNA")
         total_warnings = total_warnings + 1
       }
+      # Flag low-confidence tRNAs whose anticodon could not be resolved ("NNN").
+      # These only reach validation when the user enabled retain_low_conf_trna.
+      if (isTRUE(annotations$anticodon[i] == "NNN")) {
+        annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "low-confidence tRNA (NNN anticodon)")
+        total_warnings = total_warnings + 1
+      }
     }
 
     ## Length limits ----

--- a/R/validate_turtle_mito.R
+++ b/R/validate_turtle_mito.R
@@ -167,6 +167,12 @@ validate_turtle_mito <- function(
         annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "tRNA within PCG or rRNA")
         total_warnings = total_warnings + 1
       }
+      # Flag low-confidence tRNAs whose anticodon could not be resolved ("NNN").
+      # These only reach validation when the user enabled retain_low_conf_trna.
+      if (isTRUE(annotations$anticodon[i] == "NNN")) {
+        annotations$warnings[i] <- warnings <- semicolon_paste(warnings, "low-confidence tRNA (NNN anticodon)")
+        total_warnings = total_warnings + 1
+      }
     }
 
     ## Length limits ----

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN conda config --set channel_priority true && \
     conda config --add channels conda-forge && \
     conda config --add channels bioconda 
 
-RUN mamba install -y -c conda-forge libtiff libxml2 libxml2-devel r-base=4.5.2 r-reticulate r-remotes
+RUN mamba install -y -c conda-forge libtiff libxml2 libxml2-devel r-base=4.5.2 r-reticulate r-remotes r-ragg
 
 # Install Conda packages
 RUN mamba install -c bioconda fastp=0.23.4 && \

--- a/inst/nextflow/modules/annotate.nf
+++ b/inst/nextflow/modules/annotate.nf
@@ -59,6 +59,7 @@ process annotate {
         start_gene = '!{opts.start_gene}', \
         ignore_scaffolds = '!{opts.ignore_scaffolds}', \
         coverage_trim = !{opts.coverage_trim == 1 ? "TRUE" : "FALSE"}, \
+        retain_low_conf_trna = !{opts.retain_low_conf_trna == 1 ? "TRUE" : "FALSE"}, \
         out_dir = '!{dir}'
     )"
     ### work dir info for troubleshooting ####

--- a/inst/nextflow/modules/annotate_workflow.nf
+++ b/inst/nextflow/modules/annotate_workflow.nf
@@ -3,13 +3,13 @@ include {annotate} from './annotate.nf'
 params.sqlRead =    'SELECT a.ID, a.path, b.assemble_opts, ' +
                         'd.cpus, d.memory, d.ref_db, d.ref_dir, d.mitos_opts, d.use_mitos_best, d.trnaScan_opts, d.start_gene, d.arwen_opts, d.use_arwen, d.aragorn_opts, d.use_aragorn, ' +
                         "GROUP_CONCAT(CASE WHEN a.ignore = 1 THEN a.scaffold END, ',') AS ignore_scaffolds, " +
-                        'd.coverage_trim ' +
+                        'd.coverage_trim, d.retain_low_conf_trna ' +
                     'FROM assemblies a ' +
                     'JOIN assemble b ON a.ID = b.ID ' +
                     'JOIN annotate c ON a.ID = c.ID ' +
                     'JOIN annotate_opts d ON c.annotate_opts = d.annotate_opts ' +
                     'WHERE c.annotate_switch = 1 AND c.annotate_lock = 0 AND b.assemble_lock = 1 ' +
-                    'GROUP BY a.ID, a.path, b.assemble_opts, d.cpus, d.memory, d.ref_db, d.ref_dir, d.mitos_opts, d.use_mitos_best, d.trnaScan_opts, d.start_gene, d.arwen_opts, d.use_arwen, d.aragorn_opts, d.use_aragorn, d.coverage_trim ' +
+                    'GROUP BY a.ID, a.path, b.assemble_opts, d.cpus, d.memory, d.ref_db, d.ref_dir, d.mitos_opts, d.use_mitos_best, d.trnaScan_opts, d.start_gene, d.arwen_opts, d.use_arwen, d.aragorn_opts, d.use_aragorn, d.coverage_trim, d.retain_low_conf_trna ' +
                     'HAVING SUM(CASE WHEN a.ignore = 0 THEN 1 ELSE 0 END) > 0'
 
 workflow ANNOTATE {
@@ -51,7 +51,8 @@ workflow ANNOTATE {
                     aragorn: it[13],                                   // aragorn_opts
                     use_aragorn: it[14],                               // use_aragorn toggle
                     ignore_scaffolds: it[15] ?: '',                    // comma-separated scaffold numbers to drop
-                    coverage_trim: it[16] != null ? it[16] as Integer : 1  // coverage trimming toggle (default on)
+                    coverage_trim: it[16] != null ? it[16] as Integer : 1,  // coverage trimming toggle (default on)
+                    retain_low_conf_trna: it[17] != null ? it[17] as Integer : 0  // retain low-conf (NNN) tRNAs (default off)
                 ],
                 file(it[6] + "/" + it[5]),                              // curation ref dir + clade
                 it[5].replaceFirst(/\.tar\.gz$/, '')                // ref_db without ".tar.gz"

--- a/man/annotate.Rd
+++ b/man/annotate.Rd
@@ -23,6 +23,7 @@ annotate(
   use_mitos_best = TRUE,
   start_gene = "trnF",
   coverage_trim = TRUE,
+  retain_low_conf_trna = FALSE,
   ignore_scaffolds = NULL,
   out_dir = NULL
 )
@@ -65,6 +66,11 @@ annotate(
 \item{start_gene}{name of gene (PCG, rRNA, or tRNA) to start circular assembly (default = "trnF")}
 
 \item{coverage_trim}{logical; whether to trim low-coverage ends of linear assemblies (default: TRUE).}
+
+\item{retain_low_conf_trna}{logical; whether to keep low-confidence tRNAs with an
+unresolved ("NNN") anticodon. When FALSE (default) these are dropped and are not
+allowed to suppress overlapping MITOS2 tRNA predictions. When TRUE they are
+retained (and may suppress overlapping MITOS2 predictions, the original behavior).}
 
 \item{ignore_scaffolds}{Comma-separated scaffold numbers (e.g. "1,3") to drop
 from the assembly before annotation. These correspond to the `scaffold`


### PR DESCRIPTION
  ## Summary

  Branch focused on the annotate-details page: correctness and performance of the
  coverage/synteny figures, faster reactivity while editing, plus an annotation fix
  that was dropping valid `trnA` calls. Also adds the build dependencies these changes
  require.

  ## Annotation correctness

  - **Fix `trnA` (and other tRNAs) lost to NNN-anticodon calls.** Low-confidence
    tRNAscan/ARWEN/ARAGORN calls with an unresolved `NNN` anticodon could overlap a
    valid MITOS2 tRNA, suppress it via the >10% overlap filter, then be removed by the
    modal to keep NNN tRNAs when desired. Plumbed through `annotate()`, the DB schema
    (init + backwards-compat migration), and the Nextflow annotate workflow.

  ## Coverage / synteny rendering

  - Render the coverage map with `ragg::agg_png` to bypass Cairo's ~16384px surface
    limit that silently truncated large mitogenome plots.
  - Fix coverage map truncation short of the gene track and the end-gap; align the
    coverage and gene-track panels; synteny identity stripes.
  - Speed up coverage, synteny, and alignment/codon-edit rendering.
  - Cache the genetic-code lookup table once per session (was recomputed ~30x per codon
    edit).

  ## Reactivity performance (annotate-details)

  - **Editing notes no longer reloads the figures on every keystroke.** Notes now
    persist to the DB and `rv$data` without mutating `rv$updating` (which figures read).
  - **Review toggles (ID verified / reviewed / problematic) no longer re-render the
    figures.** Added a `fig_ctx` snapshot of only the fields the figures use, refreshed
    from `rv$updating` but only changed when one of those fields actually changes.

  ## Build

  - Add `ragg` and `cowplot` to `Imports`.
  - Dockerfile installs `r-ragg` from conda-forge (with its font/graphics deps) so the
    conda image doesn't try to compile ragg/systemfonts/textshaping from source.

  ## Notes

  - Existing projects get the new `retain_low_conf_trna` column via the
    backwards-compatibility migration (default off = fix applied).
  - The Docker image must be rebuilt for the new ragg dependency and the annotate fix.

