### PR TITLE
feat(app): sample status filters + transl_except export qualifier

### DIFF
--- a/R/app_annotate.R
+++ b/R/app_annotate.R
@@ -53,6 +53,8 @@ annotate_ui <- function(id) {
           multiple = TRUE,
           options  = list(
             `actions-box`          = TRUE,
+            selectAllText          = "All",
+            deselectAllText        = "None",
             `selected-text-format` = "count > 0",
             width                  = "140px"
           ),
@@ -66,6 +68,8 @@ annotate_ui <- function(id) {
           multiple = TRUE,
           options  = list(
             `actions-box`          = TRUE,
+            selectAllText          = "All",
+            deselectAllText        = "None",
             `selected-text-format` = "count > 0",
             width                  = "140px"
           ),
@@ -79,6 +83,8 @@ annotate_ui <- function(id) {
           multiple = TRUE,
           options  = list(
             `actions-box`          = TRUE,
+            selectAllText          = "All",
+            deselectAllText        = "None",
             `selected-text-format` = "count > 0",
             width                  = "150px"
           ),

--- a/R/app_annotate.R
+++ b/R/app_annotate.R
@@ -17,6 +17,18 @@ ANNOTATE_COL_GROUP_LOOKUP <- {
   out
 }
 
+# Status-filter pickers. Values match the annotate_lock / annotate_switch
+# codes; each row is tagged with mp-lock-<v> / mp-state-<v> classes so
+# unselected codes can be hidden via CSS (same mechanism as the column
+# picker, so sort order, search, other filters, page, and selection survive).
+ANNOTATE_LOCK_CHOICES <- c("Unlocked" = "0", "Locked" = "1")
+ANNOTATE_STATE_CHOICES <- c(
+  "Pre-Annotate" = "0",
+  "In Progress"  = "1",
+  "Success"      = "2",
+  "Failed"       = "3"
+)
+
 #' annotate UI Function
 #'
 #' @description A shiny Module.
@@ -33,6 +45,30 @@ annotate_ui <- function(id) {
       uiOutput(ns("col_css")),
       div(
         style = "display: flex; align-items: center; gap: 20px; flex-wrap: wrap;",
+        shinyWidgets::pickerInput(
+          inputId  = ns("lock_filter"),
+          label    = "Lock:",
+          choices  = ANNOTATE_LOCK_CHOICES,
+          selected = ANNOTATE_LOCK_CHOICES,
+          multiple = TRUE,
+          options  = list(
+            `actions-box`          = TRUE,
+            `selected-text-format` = "count > 0"
+          ),
+          inline = TRUE
+        ),
+        shinyWidgets::pickerInput(
+          inputId  = ns("state_filter"),
+          label    = "State:",
+          choices  = ANNOTATE_STATE_CHOICES,
+          selected = ANNOTATE_STATE_CHOICES,
+          multiple = TRUE,
+          options  = list(
+            `actions-box`          = TRUE,
+            `selected-text-format` = "count > 0"
+          ),
+          inline = TRUE
+        ),
         shinyWidgets::pickerInput(
           inputId  = ns("col_groups"),
           label    = "Show columns:",
@@ -141,6 +177,17 @@ annotate_server <- function(id) {
       col_groups_rv(input$col_groups %||% character(0))
     }, ignoreNULL = FALSE, ignoreInit = TRUE)
 
+    # Mirror the lock / state status pickers the same way, so clearing all
+    # is distinguishable from the pre-init state. Default: all codes shown.
+    lock_filter_rv <- reactiveVal(unname(ANNOTATE_LOCK_CHOICES))
+    observeEvent(input$lock_filter, {
+      lock_filter_rv(input$lock_filter %||% character(0))
+    }, ignoreNULL = FALSE, ignoreInit = TRUE)
+    state_filter_rv <- reactiveVal(unname(ANNOTATE_STATE_CHOICES))
+    observeEvent(input$state_filter, {
+      state_filter_rv(input$state_filter %||% character(0))
+    }, ignoreNULL = FALSE, ignoreInit = TRUE)
+
     # CSS class for a togglable column. Added to both body cells and the
     # header cell so the whole column collapses when the group is hidden.
     .grp <- function(col) {
@@ -151,13 +198,21 @@ annotate_server <- function(id) {
     # Inject a <style> tag that display:nones unselected column groups.
     # Hiding via CSS keeps columns mounted, so filters, sort, page, and
     # selection survive toggling.
+    # Also hide rows whose lock / state code is unselected. Rows are tagged
+    # with mp-lock-<v> / mp-state-<v> classes (see rowClass below); hiding via
+    # CSS keeps every row mounted, so sort, search, other column filters,
+    # page, and selection all survive toggling.
     output$col_css <- renderUI({
-      hidden <- setdiff(names(ANNOTATE_COL_GROUPS), col_groups_rv())
-      if (length(hidden) == 0) return(NULL)
-      rules <- paste0(".mp-grp-", hidden,
-                      " { display: none !important; }",
-                      collapse = "\n")
-      tags$style(HTML(rules))
+      hidden_grp   <- setdiff(names(ANNOTATE_COL_GROUPS), col_groups_rv())
+      hidden_lock  <- setdiff(unname(ANNOTATE_LOCK_CHOICES), lock_filter_rv())
+      hidden_state <- setdiff(unname(ANNOTATE_STATE_CHOICES), state_filter_rv())
+      rules <- c(
+        if (length(hidden_grp))   paste0(".mp-grp-",   hidden_grp,   " { display: none !important; }"),
+        if (length(hidden_lock))  paste0(".mp-lock-",  hidden_lock,  " { display: none !important; }"),
+        if (length(hidden_state)) paste0(".mp-state-", hidden_state, " { display: none !important; }")
+      )
+      if (length(rules) == 0) return(NULL)
+      tags$style(HTML(paste(rules, collapse = "\n")))
     })
 
     # Render table ----
@@ -183,6 +238,10 @@ annotate_server <- function(id) {
         wrap = FALSE,
         pageSizeOptions = c(25, 50, 100, 200, 500),
         rowStyle = rt_highlight_row(),
+        rowClass = JS("function(rowInfo) {
+          return 'mp-lock-' + rowInfo.values['annotate_lock'] +
+                 ' mp-state-' + rowInfo.values['annotate_switch'];
+        }"),
         defaultColDef = colDef(align = "left", show = FALSE),
         columns = list(
           `.selection` = colDef(show = T, sticky = "left", width = 28),

--- a/R/app_annotate.R
+++ b/R/app_annotate.R
@@ -248,6 +248,7 @@ annotate_server <- function(id) {
         pageSizeOptions = c(25, 50, 100, 200, 500),
         rowStyle = rt_highlight_row(),
         rowClass = JS("function(rowInfo) {
+          if (!rowInfo || !rowInfo.values) return '';
           return 'mp-lock-' + rowInfo.values['annotate_lock'] +
                  ' mp-state-' + rowInfo.values['annotate_switch'];
         }"),

--- a/R/app_annotate.R
+++ b/R/app_annotate.R
@@ -53,7 +53,8 @@ annotate_ui <- function(id) {
           multiple = TRUE,
           options  = list(
             `actions-box`          = TRUE,
-            `selected-text-format` = "count > 0"
+            `selected-text-format` = "count > 0",
+            width                  = "140px"
           ),
           inline = TRUE
         ),
@@ -65,7 +66,8 @@ annotate_ui <- function(id) {
           multiple = TRUE,
           options  = list(
             `actions-box`          = TRUE,
-            `selected-text-format` = "count > 0"
+            `selected-text-format` = "count > 0",
+            width                  = "140px"
           ),
           inline = TRUE
         ),
@@ -77,7 +79,8 @@ annotate_ui <- function(id) {
           multiple = TRUE,
           options  = list(
             `actions-box`          = TRUE,
-            `selected-text-format` = "count > 0"
+            `selected-text-format` = "count > 0",
+            width                  = "150px"
           ),
           inline = TRUE
         ),

--- a/R/app_annotate.R
+++ b/R/app_annotate.R
@@ -53,8 +53,8 @@ annotate_ui <- function(id) {
           multiple = TRUE,
           options  = list(
             `actions-box`          = TRUE,
-            selectAllText          = "All",
-            deselectAllText        = "None",
+            `select-all-text`      = "All",
+            `deselect-all-text`    = "None",
             `selected-text-format` = "count > 0",
             width                  = "140px"
           ),
@@ -68,8 +68,8 @@ annotate_ui <- function(id) {
           multiple = TRUE,
           options  = list(
             `actions-box`          = TRUE,
-            selectAllText          = "All",
-            deselectAllText        = "None",
+            `select-all-text`      = "All",
+            `deselect-all-text`    = "None",
             `selected-text-format` = "count > 0",
             width                  = "140px"
           ),
@@ -83,8 +83,8 @@ annotate_ui <- function(id) {
           multiple = TRUE,
           options  = list(
             `actions-box`          = TRUE,
-            selectAllText          = "All",
-            deselectAllText        = "None",
+            `select-all-text`      = "All",
+            `deselect-all-text`    = "None",
             `selected-text-format` = "count > 0",
             width                  = "150px"
           ),

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -1212,13 +1212,7 @@ annotations_details_server <- function(id, rv) {
       )
       trigger("align_now")
     })
-    # Debounce align_now: rapid codon-edit clicks collapse into one MSA rebuild
-    # after the user pauses for ~250ms.
-    align_now_dbnc <- shiny::debounce(
-      shiny::reactive(gargoyle::watch("align_now")),
-      250
-    )
-    observeEvent(align_now_dbnc(), ignoreInit = TRUE, {
+    on("align_now", {
       # check if user wants to use fewer reference samples in alignment
       if (isTRUE(input$reduce_align)){ n_hits = 5 } else { n_hits = Inf }
 
@@ -1274,6 +1268,9 @@ annotations_details_server <- function(id, rv) {
         paste("<span>", as.character(icon("warning")), "<b>Internal Stop Detected</b>", as.character(icon("warning")), "<span>"),
         ""
       )
+      # Nonce so each edit invalidates: reactiveValues dedupes via identical(),
+      # which misses XStringSet content changes when the codon string repeats.
+      new_alignment$render_nonce <- isolate(rv$alignment$render_nonce %||% 0L) + 1L
       rv$alignment <- new_alignment
     })
     output$msa_header <- renderUI({
@@ -1713,7 +1710,10 @@ annotations_details_server <- function(id, rv) {
         dplyr::pull(params) |>
         json_parse() |>
         {
-          \(x) modifyList(x$rules[[rv$annotations$gene[selected()]]], x$default_rules[[rv$annotations$type[selected()]]])
+          \(x) modifyList(
+            x$default_rules[[rv$annotations$type[selected()]]] %||% list(),
+            x$rules[[rv$annotations$gene[selected()]]] %||% list()
+          )
         }()
       rv$editing$assembly <- get_assembly(
         ID = rv$annotations$ID[selected()],
@@ -1729,56 +1729,36 @@ annotations_details_server <- function(id, rv) {
     })
 
     ## Edit start-add ----
+    # Step magnitude (codons per click) comes from a numeric box (separate for
+    # START and STOP); clamp to [1, 50] and fall back to 1 for empty/invalid.
+    edit_step_size <- function(id) {
+      n <- suppressWarnings(as.integer(input[[id]]))
+      if (length(n) == 0 || is.na(n) || n < 1L) 1L else min(n, 50L)
+    }
+    # Keep the displayed box value inside [1, 50] when the user types directly.
+    for (.id in c("start_step_size", "stop_step_size")) {
+      local({
+        id <- .id
+        observeEvent(input[[id]], {
+          n <- input[[id]]
+          if (length(n) == 0 || is.na(n)) return()
+          clamped <- max(1, min(as.integer(n), 50))
+          if (!identical(as.integer(n), as.integer(clamped))) {
+            updateNumericInput(session, id, value = clamped)
+          }
+        })
+      })
+    }
     init("start-add-simple")
     on("start-add-simple", {
       rv$editing$stop_aln <- FALSE
       codon <- "INIT"
+      n_steps <- edit_step_size("start_step_size")
       pos1 <- rv$annotations$pos1[selected()]
       pos2 <- rv$annotations$pos2[selected()]
       if (rv$annotations$direction[selected()] == "+") {
-        while (codon %nin% rv$editing$params$start_codons) {
-          pos1 <- pos1 - 3
-          req(pos1 > 0)
-          codon <- rv$editing$assembly |>
-            Biostrings::subseq(pos1, pos1 + 2) |>
-            as.character()
-          if (isTRUE(input$single_codon)) break
-        }
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1, pos2 - nchar(rv$annotations$stop_codon[selected()])) |>
-          Biostrings::translate(genetic.code = session$userData$gcode)
-      }
-      if (rv$annotations$direction[selected()] == "-") {
-        while (codon %nin% rv$editing$params$start_codons) {
-          pos2 <- pos2 + 3
-          req(pos2 <= rv$editing$assembly@ranges@width)
-          codon <- rv$editing$assembly |>
-            Biostrings::subseq(pos2 - 2, pos2) |>
-            Biostrings::reverseComplement() |>
-            as.character()
-          if (isTRUE(input$single_codon)) break
-        }
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1 + nchar(rv$annotations$stop_codon[selected()]), pos2) |>
-          Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = session$userData$gcode) |>
-          as.character()
-      }
-      rv$annotations$pos1[selected()] <- pos1
-      rv$annotations$pos2[selected()] <- pos2
-      rv$annotations$start_codon[selected()] <- codon
-      rv$annotations$length[selected()] <- abs(pos1 - pos2) + 1
-      rv$annotations$start_codon[selected()] <- unname(codon)
-    })
-    init("start-add-simple-5") # speed things up and avoid making big alignments lots of times
-    on("start-add-simple-5", {
-      rv$editing$stop_aln <- FALSE
-      codon <- "INIT"
-      pos1 <- rv$annotations$pos1[selected()]
-      pos2 <- rv$annotations$pos2[selected()]
-      if (rv$annotations$direction[selected()] == "+") {
-        for(counter in 1:5){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
+        for (counter in seq_len(n_steps)) {
+          keep_going <- TRUE
           while (keep_going) {
             pos1 <- pos1 - 3
             req(pos1 > 0)
@@ -1794,8 +1774,8 @@ annotations_details_server <- function(id, rv) {
           Biostrings::translate(genetic.code = session$userData$gcode)
       }
       if (rv$annotations$direction[selected()] == "-") {
-        for(counter in 1:5){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
+        for (counter in seq_len(n_steps)) {
+          keep_going <- TRUE
           while (keep_going) {
             pos2 <- pos2 + 3
             req(pos2 <= rv$editing$assembly@ranges@width)
@@ -1815,78 +1795,14 @@ annotations_details_server <- function(id, rv) {
       }
       rv$annotations$pos1[selected()] <- pos1
       rv$annotations$pos2[selected()] <- pos2
-      rv$annotations$start_codon[selected()] <- codon
       rv$annotations$length[selected()] <- abs(pos1 - pos2) + 1
       rv$annotations$start_codon[selected()] <- unname(codon)
-    })
-    init("start-add-simple-10") # speed things up and avoid making big alignments lots of times
-    on("start-add-simple-10", {
-      rv$editing$stop_aln <- FALSE
-      codon <- "INIT"
-      pos1 <- rv$annotations$pos1[selected()]
-      pos2 <- rv$annotations$pos2[selected()]
-      if (rv$annotations$direction[selected()] == "+") {
-        for(counter in 1:10){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
-          while (keep_going) {
-            pos1 <- pos1 - 3
-            req(pos1 > 0)
-            codon <- rv$editing$assembly |>
-              Biostrings::subseq(pos1, pos1 + 2) |>
-              as.character()
-            if (isTRUE(input$single_codon)) break
-            keep_going <- codon %nin% rv$editing$params$start_codons
-          }
-        }
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1, pos2 - nchar(rv$annotations$stop_codon[selected()])) |>
-          Biostrings::translate(genetic.code = session$userData$gcode)
-      }
-      if (rv$annotations$direction[selected()] == "-") {
-        for(counter in 1:10){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
-          while (keep_going) {
-            pos2 <- pos2 + 3
-            req(pos2 <= rv$editing$assembly@ranges@width)
-            codon <- rv$editing$assembly |>
-              Biostrings::subseq(pos2 - 2, pos2) |>
-              Biostrings::reverseComplement() |>
-              as.character()
-            if (isTRUE(input$single_codon)) break
-            keep_going <- codon %nin% rv$editing$params$start_codons
-          }
-        }
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1 + nchar(rv$annotations$stop_codon[selected()]), pos2) |>
-          Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = session$userData$gcode) |>
-          as.character()
-      }
-      rv$annotations$pos1[selected()] <- pos1
-      rv$annotations$pos2[selected()] <- pos2
-      rv$annotations$start_codon[selected()] <- codon
-      rv$annotations$length[selected()] <- abs(pos1 - pos2) + 1
-      rv$annotations$start_codon[selected()] <- unname(codon)
-    })
-    observeEvent(input$`start-add-10`, {
-      message("moving start position +10...")
-      trigger("start-add-simple-10")
-      shinyjs::delay(50, {
-        trigger("re_align")
-        message("DONE")
-      })
-    })
-    observeEvent(input$`start-add-5`, {
-      message("moving start position +5...")
-      trigger("start-add-simple-5")
-      shinyjs::delay(50, {
-        trigger("re_align")
-        message("DONE")
-      })
     })
     observeEvent(input$`start-add`, {
       trigger("start-add-simple")
-      trigger("re_align")
+      shinyjs::delay(50, {
+        trigger("re_align")
+      })
     })
 
     ## Edit start-minus ----
@@ -1894,55 +1810,15 @@ annotations_details_server <- function(id, rv) {
     on("start-minus-simple", {
       rv$editing$stop_aln <- FALSE
       codon <- "INIT"
+      n_steps <- edit_step_size("start_step_size")
       pos1 <- rv$annotations$pos1[selected()]
       pos2 <- rv$annotations$pos2[selected()]
       if (rv$annotations$direction[selected()] == "+") {
-        while (codon %nin% rv$editing$params$start_codons) {
-          pos1 <- pos1 + 3
-          req(pos1 < pos2)
-          codon <- rv$editing$assembly |>
-            Biostrings::subseq(pos1, pos1 + 2) |>
-            as.character()
-          if (isTRUE(input$single_codon)) break
-        }
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1, pos2 - nchar(rv$annotations$stop_codon[selected()])) |>
-          Biostrings::translate(genetic.code = session$userData$gcode) |>
-          as.character()
-      }
-      if (rv$annotations$direction[selected()] == "-") {
-        while (codon %nin% rv$editing$params$start_codons) {
-          pos2 <- pos2 - 3
-          req(pos2 > pos1)
-          codon <- rv$editing$assembly |>
-            Biostrings::subseq(pos2 - 2, pos2) |>
-            Biostrings::reverseComplement() |>
-            as.character()
-          if (isTRUE(input$single_codon)) break
-        }
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1 + nchar(rv$annotations$stop_codon[selected()]), pos2) |>
-          Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = session$userData$gcode) |>
-          as.character()
-      }
-      rv$annotations$pos1[selected()] <- pos1
-      rv$annotations$pos2[selected()] <- pos2
-      rv$annotations$length[selected()] <- abs(pos1 - pos2) + 1
-      rv$annotations$start_codon[selected()] <- unname(codon)
-    })
-    init("start-minus-simple-5") # speed things up and avoid making big alignments lots of times
-    on("start-minus-simple-5", {
-      rv$editing$stop_aln <- FALSE
-      codon <- "INIT"
-      pos1 <- rv$annotations$pos1[selected()]
-      pos2 <- rv$annotations$pos2[selected()]
-      if (rv$annotations$direction[selected()] == "+") {
-        for(counter in 1:5){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
+        for (counter in seq_len(n_steps)) {
+          keep_going <- TRUE
           while (keep_going) {
             pos1 <- pos1 + 3
-            req(pos1 > 0)
+            req(pos1 < pos2)
             codon <- rv$editing$assembly |>
               Biostrings::subseq(pos1, pos1 + 2) |>
               as.character()
@@ -1952,14 +1828,15 @@ annotations_details_server <- function(id, rv) {
         }
         rv$annotations$translation[selected()] <- rv$editing$assembly |>
           Biostrings::subseq(pos1, pos2 - nchar(rv$annotations$stop_codon[selected()])) |>
-          Biostrings::translate(genetic.code = session$userData$gcode)
+          Biostrings::translate(genetic.code = session$userData$gcode) |>
+          as.character()
       }
       if (rv$annotations$direction[selected()] == "-") {
-        for(counter in 1:5){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
+        for (counter in seq_len(n_steps)) {
+          keep_going <- TRUE
           while (keep_going) {
             pos2 <- pos2 - 3
-            req(pos2 <= rv$editing$assembly@ranges@width)
+            req(pos2 > pos1)
             codon <- rv$editing$assembly |>
               Biostrings::subseq(pos2 - 2, pos2) |>
               Biostrings::reverseComplement() |>
@@ -1976,78 +1853,14 @@ annotations_details_server <- function(id, rv) {
       }
       rv$annotations$pos1[selected()] <- pos1
       rv$annotations$pos2[selected()] <- pos2
-      rv$annotations$start_codon[selected()] <- codon
       rv$annotations$length[selected()] <- abs(pos1 - pos2) + 1
       rv$annotations$start_codon[selected()] <- unname(codon)
-    })
-    init("start-minus-simple-10") # speed things up and avoid making big alignments lots of times
-    on("start-minus-simple-10", {
-      rv$editing$stop_aln <- FALSE
-      codon <- "INIT"
-      pos1 <- rv$annotations$pos1[selected()]
-      pos2 <- rv$annotations$pos2[selected()]
-      if (rv$annotations$direction[selected()] == "+") {
-        for(counter in 1:10){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
-          while (keep_going) {
-            pos1 <- pos1 + 3
-            req(pos1 > 0)
-            codon <- rv$editing$assembly |>
-              Biostrings::subseq(pos1, pos1 + 2) |>
-              as.character()
-            if (isTRUE(input$single_codon)) break
-            keep_going <- codon %nin% rv$editing$params$start_codons
-          }
-        }
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1, pos2 - nchar(rv$annotations$stop_codon[selected()])) |>
-          Biostrings::translate(genetic.code = session$userData$gcode)
-      }
-      if (rv$annotations$direction[selected()] == "-") {
-        for(counter in 1:10){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
-          while (keep_going) {
-            pos2 <- pos2 - 3
-            req(pos2 <= rv$editing$assembly@ranges@width)
-            codon <- rv$editing$assembly |>
-              Biostrings::subseq(pos2 - 2, pos2) |>
-              Biostrings::reverseComplement() |>
-              as.character()
-            if (isTRUE(input$single_codon)) break
-            keep_going <- codon %nin% rv$editing$params$start_codons
-          }
-        }
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1 + nchar(rv$annotations$stop_codon[selected()]), pos2) |>
-          Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = session$userData$gcode) |>
-          as.character()
-      }
-      rv$annotations$pos1[selected()] <- pos1
-      rv$annotations$pos2[selected()] <- pos2
-      rv$annotations$start_codon[selected()] <- codon
-      rv$annotations$length[selected()] <- abs(pos1 - pos2) + 1
-      rv$annotations$start_codon[selected()] <- unname(codon)
-    })
-    observeEvent(input$`start-minus-10`, {
-      message("moving start position -10...")
-      trigger("start-minus-simple-10")
-      shinyjs::delay(50, {
-        trigger("re_align")
-        message("DONE")
-      })
-    })
-    observeEvent(input$`start-minus-5`, {
-      message("moving start position -5...")
-      trigger("start-minus-simple-5")
-      shinyjs::delay(50, {
-        trigger("re_align")
-        message("DONE")
-      })
     })
     observeEvent(input$`start-minus`, {
       trigger("start-minus-simple")
-      trigger("re_align")
+      shinyjs::delay(50, {
+        trigger("re_align")
+      })
     })
 
     ## Edit stop-add ----
@@ -2055,78 +1868,13 @@ annotations_details_server <- function(id, rv) {
     on("stop-add-simple" , {
       rv$editing$stop_aln <- TRUE
       codon <- "INIT"
+      n_steps <- edit_step_size("stop_step_size")
       pos1 <- rv$annotations$pos1[selected()]
       pos2 <- rv$annotations$pos2[selected()]
       if (rv$annotations$direction[selected()] == "+") {
         pos2 <- pos2 + (3 - nchar(rv$annotations$stop_codon[selected()]))
-        while (!any(stringr::str_detect(rv$editing$params$stop_codons, paste0("^", codon)))) {
-          pos2 <- pos2 + 3
-          req(pos2 <= rv$editing$assembly@ranges@width)
-          codon <- rv$editing$assembly |>
-            Biostrings::subseq(pos2 - 2, pos2) |>
-            as.character() |>
-            stringr::str_extract(paste0("^", rv$editing$params$stop_codons)) |>
-            na.omit() |>
-            purrr::pluck(1)
-          if (isTRUE(input$single_codon) && length(codon) > 0) break
-          if (isTRUE(input$single_codon) && length(codon) == 0) {
-            codon <- rv$editing$assembly |>
-              Biostrings::subseq(pos2 - 2, pos2) |>
-              as.character()
-            break
-          }
-          codon <- codon %||% "INIT"
-        }
-        pos2 <- pos2 - (3 - nchar(codon))
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1, pos2 - nchar(codon)) |>
-          Biostrings::translate(genetic.code = session$userData$gcode) |>
-          as.character()
-      }
-      if (rv$annotations$direction[selected()] == "-") {
-        pos1 <- pos1 - (3 - nchar(rv$annotations$stop_codon[selected()]))
-        while (!any(stringr::str_detect(rv$editing$params$stop_codons, paste0("^", codon)))) {
-          pos1 <- pos1 - 3
-          req(pos1 >= 1)
-          codon <- rv$editing$assembly |>
-            Biostrings::subseq(pos1, pos1 + 2) |>
-            Biostrings::reverseComplement() |>
-            as.character() |>
-            stringr::str_extract(paste0("^", rv$editing$params$stop_codons)) |>
-            na.omit() |>
-            purrr::pluck(1)
-          if (isTRUE(input$single_codon) && length(codon) > 0) break
-          if (isTRUE(input$single_codon) && length(codon) == 0) {
-            codon <- rv$editing$assembly |>
-              Biostrings::subseq(pos1, pos1 + 2) |>
-              Biostrings::reverseComplement() |>
-              as.character()
-            break
-          }
-          codon <- codon %||% "INIT"
-        }
-        pos1 <- pos1 + (3 - nchar(codon))
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1 + nchar(codon), pos2) |>
-          Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = session$userData$gcode) |>
-          as.character()
-      }
-      rv$annotations$pos1[selected()] <- pos1
-      rv$annotations$pos2[selected()] <- pos2
-      rv$annotations$length[selected()] <- abs(pos1 - pos2) + 1
-      rv$annotations$stop_codon[selected()] <- unname(codon)
-    })
-    init("stop-add-simple-5")
-    on("stop-add-simple-5" , {
-      rv$editing$stop_aln <- TRUE
-      codon <- "INIT"
-      pos1 <- rv$annotations$pos1[selected()]
-      pos2 <- rv$annotations$pos2[selected()]
-      if (rv$annotations$direction[selected()] == "+") {
-        pos2 <- pos2 + (3 - nchar(rv$annotations$stop_codon[selected()]))
-        for(counter in 1:5){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
+        for (counter in seq_len(n_steps)) {
+          keep_going <- TRUE
           while (keep_going) {
             pos2 <- pos2 + 3
             req(pos2 <= rv$editing$assembly@ranges@width)
@@ -2155,8 +1903,8 @@ annotations_details_server <- function(id, rv) {
       }
       if (rv$annotations$direction[selected()] == "-") {
         pos1 <- pos1 - (3 - nchar(rv$annotations$stop_codon[selected()]))
-        for(counter in 1:5){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
+        for (counter in seq_len(n_steps)) {
+          keep_going <- TRUE
           while (keep_going) {
             pos1 <- pos1 - 3
             req(pos1 >= 1)
@@ -2190,100 +1938,12 @@ annotations_details_server <- function(id, rv) {
       rv$annotations$pos2[selected()] <- pos2
       rv$annotations$length[selected()] <- abs(pos1 - pos2) + 1
       rv$annotations$stop_codon[selected()] <- unname(codon)
-    })
-    init("stop-add-simple-10")
-    on("stop-add-simple-10" , {
-      rv$editing$stop_aln <- TRUE
-      codon <- "INIT"
-      pos1 <- rv$annotations$pos1[selected()]
-      pos2 <- rv$annotations$pos2[selected()]
-      if (rv$annotations$direction[selected()] == "+") {
-        pos2 <- pos2 + (3 - nchar(rv$annotations$stop_codon[selected()]))
-        for(counter in 1:10){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
-          while (keep_going) {
-            pos2 <- pos2 + 3
-            req(pos2 <= rv$editing$assembly@ranges@width)
-            codon <- rv$editing$assembly |>
-              Biostrings::subseq(pos2 - 2, pos2) |>
-              as.character() |>
-              stringr::str_extract(paste0("^", rv$editing$params$stop_codons)) |>
-              na.omit() |>
-              purrr::pluck(1)
-            if (isTRUE(input$single_codon) && length(codon) > 0) break
-            if (isTRUE(input$single_codon) && length(codon) == 0) {
-              codon <- rv$editing$assembly |>
-                Biostrings::subseq(pos2 - 2, pos2) |>
-                as.character()
-              break
-            }
-            codon <- codon %||% "INIT"
-            keep_going <- !any(stringr::str_detect(rv$editing$params$stop_codons, paste0("^", codon)))
-          }
-        }
-        pos2 <- pos2 - (3 - nchar(codon))
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1, pos2 - nchar(codon)) |>
-          Biostrings::translate(genetic.code = session$userData$gcode) |>
-          as.character()
-      }
-      if (rv$annotations$direction[selected()] == "-") {
-        pos1 <- pos1 - (3 - nchar(rv$annotations$stop_codon[selected()]))
-        for(counter in 1:10){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
-          while (keep_going) {
-            pos1 <- pos1 - 3
-            req(pos1 >= 1)
-            codon <- rv$editing$assembly |>
-              Biostrings::subseq(pos1, pos1 + 2) |>
-              Biostrings::reverseComplement() |>
-              as.character() |>
-              stringr::str_extract(paste0("^", rv$editing$params$stop_codons)) |>
-              na.omit() |>
-              purrr::pluck(1)
-            if (isTRUE(input$single_codon) && length(codon) > 0) break
-            if (isTRUE(input$single_codon) && length(codon) == 0) {
-              codon <- rv$editing$assembly |>
-                Biostrings::subseq(pos1, pos1 + 2) |>
-                Biostrings::reverseComplement() |>
-                as.character()
-              break
-            }
-            codon <- codon %||% "INIT"
-            keep_going <- !any(stringr::str_detect(rv$editing$params$stop_codons, paste0("^", codon)))
-          }
-        }
-        pos1 <- pos1 + (3 - nchar(codon))
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1 + nchar(codon), pos2) |>
-          Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = session$userData$gcode) |>
-          as.character()
-      }
-      rv$annotations$pos1[selected()] <- pos1
-      rv$annotations$pos2[selected()] <- pos2
-      rv$annotations$length[selected()] <- abs(pos1 - pos2) + 1
-      rv$annotations$stop_codon[selected()] <- unname(codon)
-    })
-    observeEvent(input$`stop-add-10`, {
-      message("moving stop position +10...")
-      trigger("stop-add-simple-10")
-      shinyjs::delay(50, {
-        trigger("re_align")
-        message("DONE")
-      })
-    })
-    observeEvent(input$`stop-add-5`, {
-      message("moving stop position +5...")
-      trigger("stop-add-simple-5")
-      shinyjs::delay(50, {
-        trigger("re_align")
-        message("DONE")
-      })
     })
     observeEvent(input$`stop-add`, {
       trigger("stop-add-simple")
-      trigger("re_align")
+      shinyjs::delay(50, {
+        trigger("re_align")
+      })
     })
 
     ## Edit stop-minus ----
@@ -2291,82 +1951,13 @@ annotations_details_server <- function(id, rv) {
     on("stop-minus-simple", {
       rv$editing$stop_aln <- TRUE
       codon <- "INIT"
+      n_steps <- edit_step_size("stop_step_size")
       pos1 <- rv$annotations$pos1[selected()]
       pos2 <- rv$annotations$pos2[selected()]
       if (rv$annotations$direction[selected()] == "+") {
         pos2 <- pos2 + (3 - nchar(rv$annotations$stop_codon[selected()]))
-        while (!any(stringr::str_detect(rv$editing$params$stop_codons, paste0("^", codon)))) {
-          pos2 <- pos2 - 3
-          req(pos2 <= rv$editing$assembly@ranges@width)
-          codon <- rv$editing$assembly |>
-            Biostrings::subseq(pos2 - 2, pos2) |>
-            as.character() |>
-            stringr::str_extract(paste0("^", rv$editing$params$stop_codons)) |>
-            na.omit() |>
-            purrr::pluck(1)
-          if (isTRUE(input$single_codon) && length(codon) > 0){
-            break
-          }
-          if (isTRUE(input$single_codon) && length(codon) == 0) {
-            codon <- rv$editing$assembly |>
-              Biostrings::subseq(pos2 - 2, pos2) |>
-              as.character()
-            break
-          }
-          codon <- codon %||% "INIT"
-        }
-        pos2 <- pos2 - (3 - nchar(codon))
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1, pos2 - nchar(codon)) |>
-          Biostrings::translate(genetic.code = session$userData$gcode) |>
-          as.character()
-      }
-      if (rv$annotations$direction[selected()] == "-") {
-        pos1 <- pos1 - (3 - nchar(rv$annotations$stop_codon[selected()]))
-        while (!any(stringr::str_detect(rv$editing$params$stop_codons, paste0("^", codon)))) {
-          pos1 <- pos1 + 3
-          req(pos1 >= 1)
-          codon <- rv$editing$assembly |>
-            Biostrings::subseq(pos1, pos1 + 2) |>
-            Biostrings::reverseComplement() |>
-            as.character() |>
-            stringr::str_extract(paste0("^", rv$editing$params$stop_codons)) |>
-            na.omit() |>
-            purrr::pluck(1)
-          if (isTRUE(input$single_codon) && length(codon) > 0){
-            break
-          }
-          if (isTRUE(input$single_codon) && length(codon) == 0) {
-            codon <- rv$editing$assembly |>
-              Biostrings::subseq(pos1, pos1 + 2) |>
-              Biostrings::reverseComplement() |>
-              as.character()
-            break
-          }
-          codon <- codon %||% "INIT"
-        }
-        pos1 <- pos1 + (3 - nchar(codon))
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1 + nchar(codon), pos2) |>
-          Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = session$userData$gcode) |>
-          as.character()
-      }
-      rv$annotations$pos1[selected()] <- pos1
-      rv$annotations$pos2[selected()] <- pos2
-      rv$annotations$length[selected()] <- abs(pos1 - pos2) + 1
-      rv$annotations$stop_codon[selected()] <- unname(codon)
-    })
-    init("stop-minus-simple-5")
-    on("stop-minus-simple-5", {
-      rv$editing$stop_aln <- TRUE
-      codon <- "INIT"
-      pos1 <- rv$annotations$pos1[selected()]
-      pos2 <- rv$annotations$pos2[selected()]
-      if (rv$annotations$direction[selected()] == "+") {
-        pos2 <- pos2 + (3 - nchar(rv$annotations$stop_codon[selected()]))
-        for(counter in 1:5){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
+        for (counter in seq_len(n_steps)) {
+          keep_going <- TRUE
           while (keep_going) {
             pos2 <- pos2 - 3
             req(pos2 <= rv$editing$assembly@ranges@width)
@@ -2397,8 +1988,8 @@ annotations_details_server <- function(id, rv) {
       }
       if (rv$annotations$direction[selected()] == "-") {
         pos1 <- pos1 - (3 - nchar(rv$annotations$stop_codon[selected()]))
-        for(counter in 1:5){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
+        for (counter in seq_len(n_steps)) {
+          keep_going <- TRUE
           while (keep_going) {
             pos1 <- pos1 + 3
             req(pos1 >= 1)
@@ -2434,105 +2025,12 @@ annotations_details_server <- function(id, rv) {
       rv$annotations$pos2[selected()] <- pos2
       rv$annotations$length[selected()] <- abs(pos1 - pos2) + 1
       rv$annotations$stop_codon[selected()] <- unname(codon)
-    })
-    init("stop-minus-simple-10")
-    on("stop-minus-simple-10", {
-      rv$editing$stop_aln <- TRUE
-      codon <- "INIT"
-      pos1 <- rv$annotations$pos1[selected()]
-      pos2 <- rv$annotations$pos2[selected()]
-      if (rv$annotations$direction[selected()] == "+") {
-        pos2 <- pos2 + (3 - nchar(rv$annotations$stop_codon[selected()]))
-        for(counter in 1:10){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
-          while (keep_going) {
-            pos2 <- pos2 - 3
-            req(pos2 <= rv$editing$assembly@ranges@width)
-            codon <- rv$editing$assembly |>
-              Biostrings::subseq(pos2 - 2, pos2) |>
-              as.character() |>
-              stringr::str_extract(paste0("^", rv$editing$params$stop_codons)) |>
-              na.omit() |>
-              purrr::pluck(1)
-            if (isTRUE(input$single_codon) && length(codon) > 0){
-              break
-            }
-            if (isTRUE(input$single_codon) && length(codon) == 0) {
-              codon <- rv$editing$assembly |>
-                Biostrings::subseq(pos2 - 2, pos2) |>
-                as.character()
-              break
-            }
-            codon <- codon %||% "INIT"
-            keep_going <- !any(stringr::str_detect(rv$editing$params$stop_codons, paste0("^", codon)))
-          }
-        }
-        pos2 <- pos2 - (3 - nchar(codon))
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1, pos2 - nchar(codon)) |>
-          Biostrings::translate(genetic.code = session$userData$gcode) |>
-          as.character()
-      }
-      if (rv$annotations$direction[selected()] == "-") {
-        pos1 <- pos1 - (3 - nchar(rv$annotations$stop_codon[selected()]))
-        for(counter in 1:10){
-          keep_going <- TRUE # modified loop logic to avoid premature exit
-          while (keep_going) {
-            pos1 <- pos1 + 3
-            req(pos1 >= 1)
-            codon <- rv$editing$assembly |>
-              Biostrings::subseq(pos1, pos1 + 2) |>
-              Biostrings::reverseComplement() |>
-              as.character() |>
-              stringr::str_extract(paste0("^", rv$editing$params$stop_codons)) |>
-              na.omit() |>
-              purrr::pluck(1)
-            if (isTRUE(input$single_codon) && length(codon) > 0){
-              break
-            }
-            if (isTRUE(input$single_codon) && length(codon) == 0) {
-              codon <- rv$editing$assembly |>
-                Biostrings::subseq(pos1, pos1 + 2) |>
-                Biostrings::reverseComplement() |>
-                as.character()
-              break
-            }
-            codon <- codon %||% "INIT"
-            keep_going <- !any(stringr::str_detect(rv$editing$params$stop_codons, paste0("^", codon)))
-          }
-        }
-        pos1 <- pos1 + (3 - nchar(codon))
-        rv$annotations$translation[selected()] <- rv$editing$assembly |>
-          Biostrings::subseq(pos1 + nchar(codon), pos2) |>
-          Biostrings::reverseComplement() |>
-          Biostrings::translate(genetic.code = session$userData$gcode) |>
-          as.character()
-      }
-      rv$annotations$pos1[selected()] <- pos1
-      rv$annotations$pos2[selected()] <- pos2
-      rv$annotations$length[selected()] <- abs(pos1 - pos2) + 1
-      rv$annotations$stop_codon[selected()] <- unname(codon)
-    })
-
-    observeEvent(input$`stop-minus-10`, {
-      message("moving start position -10...")
-      trigger("stop-minus-simple-10")
-      shinyjs::delay(50, {
-        trigger("re_align")
-        message("DONE")
-      })
-    })
-    observeEvent(input$`stop-minus-5`, {
-      message("moving start position -5...")
-      trigger("stop-minus-simple-5")
-      shinyjs::delay(50, {
-        trigger("re_align")
-        message("DONE")
-      })
     })
     observeEvent(input$`stop-minus`, {
       trigger("stop-minus-simple")
-      trigger("re_align")
+      shinyjs::delay(50, {
+        trigger("re_align")
+      })
     })
 
     ## RE-align after edit ----
@@ -3213,119 +2711,84 @@ annotate_details_modal <- function(rv, session = getDefaultReactiveDomain()) {
           ),
           div(
             id = ns("edit_mode_ctrls"),
-            style = "display: flex; flex-flow: row nowrap; align-items: center; gap: 3em;",
+            class = "mp-edit-ctrls",
+            style = "display: flex; flex-flow: row nowrap; align-items: center; gap: 1.5em;",
+            # Separate step boxes (codons per click) for START and STOP, each
+            # clamped to [1, 50] both in the UI and server-side. The - / +
+            # buttons sit to the left of each box; all on a single row.
+            # Zero the numericInput's default bottom margin and the pretty
+            # checkbox's vertical margin so every element lines up vertically.
+            tags$style(HTML(stringr::str_glue(
+              ".mp-step-box .form-group {{ margin-bottom: 0; }}",
+              ".mp-step-box .form-control {{ height: 28px; padding: 2px 4px; }}"
+            ))),
             div(
-              style = "display: flex; flex-flow: row nowrap; align-items: center;",
-              tags$button(
-                class = "icon-circle grow",
-                onclick = stringr::str_glue("Shiny.setInputValue('{ns('start-add-10')}', 'plus-10', {{priority: 'event'}})"),
-                tags$span(
-                  style = "font-size: 0.75em;",  # This matches fa-xs sizing
-                  "+10"
-                )
-              ),
-              tags$button(
-                class = "icon-circle grow",
-                onclick = stringr::str_glue("Shiny.setInputValue('{ns('start-add-5')}', 'plus-5', {{priority: 'event'}})"),
-                tags$span(
-                  style = "font-size: 0.75em;",  # This matches fa-xs sizing
-                  "+5"
-                )
-              ),
+              style = "display: flex; flex-flow: row nowrap; align-items: center; gap: 0.4em;",
+              tags$span(style = "font-weight: bold;", "START"),
               tags$button(
                 class = "icon-circle grow",
                 onclick = stringr::str_glue("Shiny.setInputValue('{ns('start-add')}', 'plus', {{priority: 'event'}})"),
-                tags$span(
-                  style = "font-size: 0.75em;",  # This matches fa-xs sizing
-                  "+1"
-                )
+                tags$span(style = "font-size: 0.75em;", "+")
               ),
-              div(style = "margin: 00.5em;", "START"),
               tags$button(
                 class = "icon-circle grow",
                 onclick = stringr::str_glue("Shiny.setInputValue('{ns('start-minus')}', 'minus', {{priority: 'event'}})"),
-                tags$span(
-                  style = "font-size: 0.75em;",  # This matches fa-xs sizing
-                  "-1"
-                )
+                tags$span(style = "font-size: 0.75em;", "\u2212")
               ),
-              tags$button(
-                class = "icon-circle grow",
-                onclick = stringr::str_glue("Shiny.setInputValue('{ns('start-minus-5')}', 'minus-5', {{priority: 'event'}})"),
-                tags$span(
-                  style = "font-size: 0.75em;",  # This matches fa-xs sizing
-                  "-5"
-                )
-              ),
-              tags$button(
-                class = "icon-circle grow",
-                onclick = stringr::str_glue("Shiny.setInputValue('{ns('start-minus-10')}', 'minus-10', {{priority: 'event'}})"),
-                tags$span(
-                  style = "font-size: 0.75em;",  # This matches fa-xs sizing
-                  "-10"
+              div(
+                class = "mp-step-box",
+                style = "width: 48px;",
+                numericInput(
+                  ns("start_step_size"),
+                  label = NULL,
+                  value = 1,
+                  min = 1,
+                  max = 50,
+                  step = 1,
+                  width = "48px"
                 )
               )
             ),
             div(
-              style = "display: flex; flex-flow: row nowrap; align-items: center;",
-              tags$button(
-                class = "icon-circle grow",
-                onclick = stringr::str_glue("Shiny.setInputValue('{ns('stop-minus-10')}', 'minus-10', {{priority: 'event'}})"),
-                tags$span(
-                  style = "font-size: 0.75em;",  # This matches fa-xs sizing
-                  "-10"
-                )
-              ),
-              tags$button(
-                class = "icon-circle grow",
-                onclick = stringr::str_glue("Shiny.setInputValue('{ns('stop-minus-5')}', 'minus-5', {{priority: 'event'}})"),
-                tags$span(
-                  style = "font-size: 0.75em;",  # This matches fa-xs sizing
-                  "-5"
-                )
-              ),
+              style = "display: flex; flex-flow: row nowrap; align-items: center; gap: 0.4em;",
+              tags$span(style = "font-weight: bold;", "STOP"),
               tags$button(
                 class = "icon-circle grow",
                 onclick = stringr::str_glue("Shiny.setInputValue('{ns('stop-minus')}', 'minus', {{priority: 'event'}})"),
-                tags$span(
-                  style = "font-size: 0.75em;",  # This matches fa-xs sizing
-                  "-1"
-                )
+                tags$span(style = "font-size: 0.75em;", "\u2212")
               ),
-              div(style = "margin: 00.5em;", "STOP"),
               tags$button(
                 class = "icon-circle grow",
                 onclick = stringr::str_glue("Shiny.setInputValue('{ns('stop-add')}', 'plus', {{priority: 'event'}})"),
-                tags$span(
-                  style = "font-size: 0.75em;",  # This matches fa-xs sizing
-                  "+1"
-                )
+                tags$span(style = "font-size: 0.75em;", "+")
               ),
-              tags$button(
-                class = "icon-circle grow",
-                onclick = stringr::str_glue("Shiny.setInputValue('{ns('stop-add-5')}', 'plus-5', {{priority: 'event'}})"),
-                tags$span(
-                  style = "font-size: 0.75em;",  # This matches fa-xs sizing
-                  "+5"
-                )
-              ),
-              tags$button(
-                class = "icon-circle grow",
-                onclick = stringr::str_glue("Shiny.setInputValue('{ns('stop-add-10')}', 'plus-10', {{priority: 'event'}})"),
-                tags$span(
-                  style = "font-size: 0.75em;",  # This matches fa-xs sizing
-                  "+10"
+              div(
+                class = "mp-step-box",
+                style = "width: 48px;",
+                numericInput(
+                  ns("stop_step_size"),
+                  label = NULL,
+                  value = 1,
+                  min = 1,
+                  max = 50,
+                  step = 1,
+                  width = "48px"
                 )
               )
             ),
-            div(
-              style = "padding-top: 14px;",
-              shinyWidgets::prettyCheckbox(
-                ns("single_codon"),
-                label = "single codon",
-                status = "primary",
-                inline = TRUE
-              )
+            tags$label(
+              style = paste(
+                "display: flex; align-items: center; gap: 4px;",
+                "margin: 0; font-weight: normal; cursor: pointer;"
+              ),
+              tags$input(
+                type = "checkbox",
+                style = "margin: 0; vertical-align: middle;",
+                onchange = stringr::str_glue(
+                  "Shiny.setInputValue('{ns('single_codon')}', this.checked, {{priority: 'event'}})"
+                )
+              ),
+              "single codon"
             )
           ) |> shinyjs::hidden()
         ),

--- a/R/app_assemble.R
+++ b/R/app_assemble.R
@@ -19,6 +19,19 @@ ASSEMBLE_COL_GROUP_LOOKUP <- {
   out
 }
 
+# Status-filter pickers. Values match the assemble_lock / assemble_switch
+# codes; each row is tagged with mp-lock-<v> / mp-state-<v> classes so
+# unselected codes can be hidden via CSS (same mechanism as the column
+# picker, so sort order, search, other filters, page, and selection survive).
+ASSEMBLE_LOCK_CHOICES <- c("Unlocked" = "0", "Locked" = "1")
+ASSEMBLE_STATE_CHOICES <- c(
+  "Pre-Assembly" = "0",
+  "Ready"        = "1",
+  "In Progress"  = "4",
+  "Success"      = "2",
+  "Failed"       = "3"
+)
+
 #' assemble UI
 #'
 #' @param id,input,output,session Internal parameters for {shiny}.
@@ -28,6 +41,30 @@ assemble_ui <- function(id) {
   ns <- NS(id)
   tagList(
     uiOutput(ns("col_css")),
+    shinyWidgets::pickerInput(
+      inputId  = ns("lock_filter"),
+      label    = "Lock:",
+      choices  = ASSEMBLE_LOCK_CHOICES,
+      selected = ASSEMBLE_LOCK_CHOICES,
+      multiple = TRUE,
+      options  = list(
+        `actions-box`          = TRUE,
+        `selected-text-format` = "count > 0"
+      ),
+      inline = TRUE
+    ),
+    shinyWidgets::pickerInput(
+      inputId  = ns("state_filter"),
+      label    = "State:",
+      choices  = ASSEMBLE_STATE_CHOICES,
+      selected = ASSEMBLE_STATE_CHOICES,
+      multiple = TRUE,
+      options  = list(
+        `actions-box`          = TRUE,
+        `selected-text-format` = "count > 0"
+      ),
+      inline = TRUE
+    ),
     shinyWidgets::pickerInput(
       inputId  = ns("col_groups"),
       label    = "Show columns:",
@@ -93,6 +130,17 @@ assemble_server <- function(id) {
       col_groups_rv(input$col_groups %||% character(0))
     }, ignoreNULL = FALSE, ignoreInit = TRUE)
 
+    # Mirror the lock / state status pickers the same way, so clearing all
+    # is distinguishable from the pre-init state. Default: all codes shown.
+    lock_filter_rv <- reactiveVal(unname(ASSEMBLE_LOCK_CHOICES))
+    observeEvent(input$lock_filter, {
+      lock_filter_rv(input$lock_filter %||% character(0))
+    }, ignoreNULL = FALSE, ignoreInit = TRUE)
+    state_filter_rv <- reactiveVal(unname(ASSEMBLE_STATE_CHOICES))
+    observeEvent(input$state_filter, {
+      state_filter_rv(input$state_filter %||% character(0))
+    }, ignoreNULL = FALSE, ignoreInit = TRUE)
+
     # CSS class for a togglable column. Returned class is added to both the
     # body cell (class) and the header cell (headerClass) so the
     # whole column collapses when the matching group is unselected.
@@ -104,13 +152,21 @@ assemble_server <- function(id) {
     # Inject a <style> tag that display:nones unselected column groups.
     # Hiding via CSS keeps the columns mounted in the DOM, so filters,
     # sort order, current page, and selection all survive toggling.
+    # Also hide rows whose lock / state code is unselected. Rows are tagged
+    # with mp-lock-<v> / mp-state-<v> classes (see rowClass below); hiding via
+    # CSS keeps every row mounted, so sort, search, other column filters,
+    # page, and selection all survive toggling.
     output$col_css <- renderUI({
-      hidden <- setdiff(names(ASSEMBLE_COL_GROUPS), col_groups_rv())
-      if (length(hidden) == 0) return(NULL)
-      rules <- paste0(".mp-grp-", hidden,
-                      " { display: none !important; }",
-                      collapse = "\n")
-      tags$style(HTML(rules))
+      hidden_grp   <- setdiff(names(ASSEMBLE_COL_GROUPS), col_groups_rv())
+      hidden_lock  <- setdiff(unname(ASSEMBLE_LOCK_CHOICES), lock_filter_rv())
+      hidden_state <- setdiff(unname(ASSEMBLE_STATE_CHOICES), state_filter_rv())
+      rules <- c(
+        if (length(hidden_grp))   paste0(".mp-grp-",   hidden_grp,   " { display: none !important; }"),
+        if (length(hidden_lock))  paste0(".mp-lock-",  hidden_lock,  " { display: none !important; }"),
+        if (length(hidden_state)) paste0(".mp-state-", hidden_state, " { display: none !important; }")
+      )
+      if (length(rules) == 0) return(NULL)
+      tags$style(HTML(paste(rules, collapse = "\n")))
     })
 
     # Render table ----
@@ -131,6 +187,10 @@ assemble_server <- function(id) {
           wrap = FALSE,
           pageSizeOptions = c(25, 50, 100, 200, 500),
           rowStyle = rt_highlight_row(),
+          rowClass = JS("function(rowInfo) {
+            return 'mp-lock-' + rowInfo.values['assemble_lock'] +
+                   ' mp-state-' + rowInfo.values['assemble_switch'];
+          }"),
           defaultColDef = colDef(align = "left", show = F),
           columns = list(
             `.selection` = colDef(show = T, sticky = "left", width = 28),

--- a/R/app_assemble.R
+++ b/R/app_assemble.R
@@ -49,7 +49,8 @@ assemble_ui <- function(id) {
       multiple = TRUE,
       options  = list(
         `actions-box`          = TRUE,
-        `selected-text-format` = "count > 0"
+        `selected-text-format` = "count > 0",
+        width                  = "140px"
       ),
       inline = TRUE
     ),
@@ -61,7 +62,8 @@ assemble_ui <- function(id) {
       multiple = TRUE,
       options  = list(
         `actions-box`          = TRUE,
-        `selected-text-format` = "count > 0"
+        `selected-text-format` = "count > 0",
+        width                  = "140px"
       ),
       inline = TRUE
     ),
@@ -73,7 +75,8 @@ assemble_ui <- function(id) {
       multiple = TRUE,
       options  = list(
         `actions-box`          = TRUE,
-        `selected-text-format` = "count > 0"
+        `selected-text-format` = "count > 0",
+        width                  = "150px"
       ),
       inline = TRUE
     ),

--- a/R/app_assemble.R
+++ b/R/app_assemble.R
@@ -197,6 +197,7 @@ assemble_server <- function(id) {
           pageSizeOptions = c(25, 50, 100, 200, 500),
           rowStyle = rt_highlight_row(),
           rowClass = JS("function(rowInfo) {
+            if (!rowInfo || !rowInfo.values) return '';
             return 'mp-lock-' + rowInfo.values['assemble_lock'] +
                    ' mp-state-' + rowInfo.values['assemble_switch'];
           }"),

--- a/R/app_assemble.R
+++ b/R/app_assemble.R
@@ -49,6 +49,8 @@ assemble_ui <- function(id) {
       multiple = TRUE,
       options  = list(
         `actions-box`          = TRUE,
+        selectAllText          = "All",
+        deselectAllText        = "None",
         `selected-text-format` = "count > 0",
         width                  = "140px"
       ),
@@ -62,6 +64,8 @@ assemble_ui <- function(id) {
       multiple = TRUE,
       options  = list(
         `actions-box`          = TRUE,
+        selectAllText          = "All",
+        deselectAllText        = "None",
         `selected-text-format` = "count > 0",
         width                  = "140px"
       ),
@@ -75,6 +79,8 @@ assemble_ui <- function(id) {
       multiple = TRUE,
       options  = list(
         `actions-box`          = TRUE,
+        selectAllText          = "All",
+        deselectAllText        = "None",
         `selected-text-format` = "count > 0",
         width                  = "150px"
       ),

--- a/R/app_assemble.R
+++ b/R/app_assemble.R
@@ -49,8 +49,8 @@ assemble_ui <- function(id) {
       multiple = TRUE,
       options  = list(
         `actions-box`          = TRUE,
-        selectAllText          = "All",
-        deselectAllText        = "None",
+        `select-all-text`      = "All",
+        `deselect-all-text`    = "None",
         `selected-text-format` = "count > 0",
         width                  = "140px"
       ),
@@ -64,8 +64,8 @@ assemble_ui <- function(id) {
       multiple = TRUE,
       options  = list(
         `actions-box`          = TRUE,
-        selectAllText          = "All",
-        deselectAllText        = "None",
+        `select-all-text`      = "All",
+        `deselect-all-text`    = "None",
         `selected-text-format` = "count > 0",
         width                  = "140px"
       ),
@@ -79,8 +79,8 @@ assemble_ui <- function(id) {
       multiple = TRUE,
       options  = list(
         `actions-box`          = TRUE,
-        selectAllText          = "All",
-        deselectAllText        = "None",
+        `select-all-text`      = "All",
+        `deselect-all-text`    = "None",
         `selected-text-format` = "count > 0",
         width                  = "150px"
       ),

--- a/R/app_export.R
+++ b/R/app_export.R
@@ -35,8 +35,8 @@ export_ui <- function(id) {
       multiple = TRUE,
       options  = list(
         `actions-box`          = TRUE,
-        selectAllText          = "All",
-        deselectAllText        = "None",
+        `select-all-text`      = "All",
+        `deselect-all-text`    = "None",
         `selected-text-format` = "count > 0",
         width                  = "150px"
       ),

--- a/R/app_export.R
+++ b/R/app_export.R
@@ -35,7 +35,8 @@ export_ui <- function(id) {
       multiple = TRUE,
       options  = list(
         `actions-box`          = TRUE,
-        `selected-text-format` = "count > 0"
+        `selected-text-format` = "count > 0",
+        width                  = "150px"
       ),
       inline = TRUE
     ),

--- a/R/app_export.R
+++ b/R/app_export.R
@@ -35,6 +35,8 @@ export_ui <- function(id) {
       multiple = TRUE,
       options  = list(
         `actions-box`          = TRUE,
+        selectAllText          = "All",
+        deselectAllText        = "None",
         `selected-text-format` = "count > 0",
         width                  = "150px"
       ),

--- a/R/export.R
+++ b/R/export.R
@@ -193,6 +193,7 @@ export_files <- function(
     purrr::pwalk(annotations, function(...) {
       cur <- list(...)
       note <- NULL
+      transl_except <- NULL
       pos <- c(cur$pos1, cur$pos2) |> as.character()
       if (cur$direction == "-") {
         pos <- rev(pos)
@@ -298,6 +299,20 @@ export_files <- function(
           }
           if (nchar(cur$stop_codon) < 3) {
             note <- paste(c(note, "TAA stop codon is completed by the addition of 3' A residues to the mRNA"), collapse = "; ")
+            # transl_except marks the partial stop codon position(s) completed by poly-A
+            n_stop <- nchar(cur$stop_codon)
+            if (cur$direction == "+") {
+              te_end <- max(cur$pos1, cur$pos2)
+              te_start <- te_end - n_stop + 1
+            } else {
+              te_end <- min(cur$pos1, cur$pos2)
+              te_start <- te_end + n_stop - 1
+            }
+            if (n_stop == 1) {
+              transl_except <- paste0("(pos:", te_end, ",aa:TERM)")
+            } else {
+              transl_except <- paste0("(pos:", te_start, "..", te_end, ",aa:TERM)")
+            }
           }
 
           # write to .tbl
@@ -331,6 +346,10 @@ export_files <- function(
             cat(file = tbl_fn, sep = "\n", append = TRUE)
           paste("\t\t\ttransl_table\t", dat$genetic_code) |>
             cat(file = tbl_fn, sep = "\n", append = TRUE)
+          if (length(transl_except) > 0) {
+            paste0("\t\t\ttransl_except\t", transl_except) |>
+              cat(file = tbl_fn, sep = "\n", append = TRUE)
+          }
           if (!cur$start_codon %in% start_codons) {
             paste("\t\t\tcodon_start\t", 1) |>
               cat(file = tbl_fn, sep = "\n", append = TRUE)
@@ -428,6 +447,17 @@ export_files <- function(
               cat(file = gene_tbl_fn, sep = "\n", append = TRUE)
             paste("\t\t\ttransl_table\t", dat$genetic_code) |>
               cat(file = gene_tbl_fn, sep = "\n", append = TRUE)
+            if (nchar(cur$stop_codon) < 3) {
+              # extracted gene is oriented 5'->3', partial stop is the last base(s)
+              n_stop <- nchar(cur$stop_codon)
+              if (n_stop == 1) {
+                gene_transl_except <- paste0("(pos:", pos2_new, ",aa:TERM)")
+              } else {
+                gene_transl_except <- paste0("(pos:", pos2_new - n_stop + 1, "..", pos2_new, ",aa:TERM)")
+              }
+              paste0("\t\t\ttransl_except\t", gene_transl_except) |>
+                cat(file = gene_tbl_fn, sep = "\n", append = TRUE)
+            }
             if (!cur$start_codon %in% start_codons) {
               paste("\t\t\tcodon_start\t", 1) |>
                 cat(file = gene_tbl_fn, sep = "\n", append = TRUE)
@@ -478,6 +508,20 @@ export_files <- function(
           }
           if (nchar(cur$stop_codon) < 3) {
             note <- paste(c(note, "TAA stop codon is completed by the addition of 3' A residues to the mRNA"), collapse = "; ")
+            # transl_except marks the partial stop codon position(s) completed by poly-A
+            n_stop <- nchar(cur$stop_codon)
+            if (cur$direction == "+") {
+              te_end <- max(cur$pos1, cur$pos2)
+              te_start <- te_end - n_stop + 1
+            } else {
+              te_end <- min(cur$pos1, cur$pos2)
+              te_start <- te_end + n_stop - 1
+            }
+            if (n_stop == 1) {
+              transl_except <- paste0("(pos:", te_end, ",aa:TERM)")
+            } else {
+              transl_except <- paste0("(pos:", te_start, "..", te_end, ",aa:TERM)")
+            }
           }
 
           # write to .tbl
@@ -491,6 +535,10 @@ export_files <- function(
             cat(file = tbl_fn, sep = "\n", append = TRUE)
           paste("\t\t\ttransl_table\t", dat$genetic_code) |>
             cat(file = tbl_fn, sep = "\n", append = TRUE)
+          if (length(transl_except) > 0) {
+            paste0("\t\t\ttransl_except\t", transl_except) |>
+              cat(file = tbl_fn, sep = "\n", append = TRUE)
+          }
           if (!cur$start_codon %in% start_codons) {
             paste("\t\t\tcodon_start\t", 1) |>
               cat(file = tbl_fn, sep = "\n", append = TRUE)
@@ -573,6 +621,17 @@ export_files <- function(
               cat(file = gene_tbl_fn, sep = "\n", append = TRUE)
             paste("\t\t\ttransl_table\t", dat$genetic_code) |>
               cat(file = gene_tbl_fn, sep = "\n", append = TRUE)
+            if (nchar(cur$stop_codon) < 3) {
+              # extracted gene is oriented 5'->3', partial stop is the last base(s)
+              n_stop <- nchar(cur$stop_codon)
+              if (n_stop == 1) {
+                gene_transl_except <- paste0("(pos:", pos2_new, ",aa:TERM)")
+              } else {
+                gene_transl_except <- paste0("(pos:", pos2_new - n_stop + 1, "..", pos2_new, ",aa:TERM)")
+              }
+              paste0("\t\t\ttransl_except\t", gene_transl_except) |>
+                cat(file = gene_tbl_fn, sep = "\n", append = TRUE)
+            }
             if (!cur$start_codon %in% start_codons) {
               paste("\t\t\tcodon_start\t", 1) |>
                 cat(file = gene_tbl_fn, sep = "\n", append = TRUE)


### PR DESCRIPTION
## Summary

Two changes against the Assemble/Annotate/Export sample tables and the GenBank export:

1. **Lock & State status filters** on the Assemble and Annotate sample tables.
2. **\`/transl_except\` qualifier** for poly-A-completed PCG stop codons in exported feature tables.

## Lock / State status filters

- Adds **Lock** and **State** picker dropdowns (same style as the existing "Show columns" picker), placed to its left, on the Assemble and Annotate tables.
- Each row is tagged with \`mp-lock-<v>\` / \`mp-state-<v>\` classes via reactable \`rowClass\`; deselecting a code injects \`display:none\` CSS for that class.
- This mirrors the column picker's CSS-hide mechanism, so **sort order, search, other column filters, current page, and row selection all survive toggling** (rows stay mounted in the DOM rather than re-rendering the table).
- Picker button widths are pinned via \`data-width\` so they don't resize with the number of selected items; select/deselect-all buttons shortened to "All"/"None" to avoid overflow.

Choice -> switch-code mapping:
- Lock: Unlocked=0, Locked=1
- Assemble State: Pre-Assembly=0, Ready=1, In Progress=4, Success=2, Failed=3
- Annotate State: Pre-Annotate=0, In Progress=1, Success=2, Failed=3

**Known tradeoff** (same as the existing column picker): hidden rows still count toward pagination, so a page may display fewer than its page-size while filters are active.

## transl_except export qualifier

- Writes \`/transl_except=(pos:..,aa:TERM)\` to \`.tbl\` feature tables alongside the existing poly-A note when a PCG stop codon is completed by 3' A-tail addition (\`nchar(stop_codon) < 3\`).
- Covers intron, non-intron, and single-gene (gene-export) tables.