### PR TITLE
Resize

### DIFF
--- a/R/app_annotate.R
+++ b/R/app_annotate.R
@@ -92,7 +92,7 @@ annotate_ui <- function(id) {
         ),
         uiOutput(ns("warnings_select"))
       ),
-      reactable::reactableOutput(ns("table")),
+      div(class = "mp-table-resize", reactable::reactableOutput(ns("table"))),
       div(
         style = "margin-top: 12px; display: flex; gap: 8px;",
         downloadButton(ns("export_selected"), "Export Selected to CSV",
@@ -247,7 +247,7 @@ annotate_server <- function(id) {
         searchable = TRUE,
         filterable = TRUE,
         defaultSorted = list(time_stamp = "desc"),
-        height = 500,
+        height = "100%",
         wrap = FALSE,
         pageSizeOptions = c(25, 50, 100, 200, 500),
         rowStyle = rt_highlight_row(),

--- a/R/app_assemble.R
+++ b/R/app_assemble.R
@@ -89,7 +89,7 @@ assemble_ui <- function(id) {
         )
       )
     ),
-    reactableOutput(ns("table")),
+    div(class = "mp-table-resize", reactableOutput(ns("table"))),
     div(
       style = "margin-top: 12px; display: flex; gap: 8px;",
       downloadButton(ns("export_selected"), "Export Selected to CSV",
@@ -195,7 +195,7 @@ assemble_server <- function(id) {
           selection = "multiple",
           searchable = TRUE,
           defaultSorted = list(time_stamp = "desc"),
-          height = 550,
+          height = "100%",
           wrap = FALSE,
           pageSizeOptions = c(25, 50, 100, 200, 500),
           rowStyle = rt_highlight_row(),

--- a/R/app_export.R
+++ b/R/app_export.R
@@ -57,7 +57,7 @@ export_ui <- function(id) {
         width                  = "150px"
       )
     ),
-    reactableOutput(ns("table")),
+    div(class = "mp-table-resize", reactableOutput(ns("table"))),
     div(
       style = "margin-top: 12px; display: flex; gap: 8px;",
       downloadButton(ns("export_selected"), "Export Selected to CSV",
@@ -141,7 +141,7 @@ export_server <- function(id) {
         searchable = TRUE,
         resizable = TRUE,
         filterable = TRUE,
-        height = 550,
+        height = "100%",
         wrap = FALSE,
         pageSizeOptions = c(25, 50, 100, 200, 500),
         striped = TRUE,

--- a/README.Rmd
+++ b/README.Rmd
@@ -204,7 +204,24 @@ Note that all samples in a MitoPilot project created with `new_project_userAsmb(
 
 ### Nextflow Configuration File
 
-Initializing a new project will populate the `.config` file in the project directory that may include place holders for important parameters, in the format: `<<PARAMETER_NAME>>`. For example, all new configuration files will include the line `rawDir = '<<RAW_DIR>>'`, which should be  updated to `rawDir = '/path/to/your/data'` indicating the location of the raw data file specified in the mapping file. The configuration files can also be modified to specify custom docker images for one or more of the processing steps. After initializing a new project you should review the `.config` file to ensure that all necessary parameters are provided. 
+Initializing a new project will populate the `.config` file in the project directory that may include place holders for important parameters, in the format: `<<PARAMETER_NAME>>`. For example, all new configuration files will include the line `rawDir = '<<RAW_DIR>>'`, which should be  updated to `rawDir = '/path/to/your/data'` indicating the location of the raw data file specified in the mapping file. The configuration files can also be modified to specify custom docker images for one or more of the processing steps. After initializing a new project you should review the `.config` file to ensure that all necessary parameters are provided.
+
+### Container Cache Directory
+
+MitoPilot runs each processing step inside a container (Docker locally, or Singularity/Apptainer on most HPC clusters). The container image is fairly large, so on first use it must be downloaded and, for Singularity/Apptainer, converted to a single `.sif` file. By default Nextflow caches this image inside each project's `work/` directory, which means every new project re-downloads and rebuilds the same image. On shared cluster filesystems this can be slow enough to exceed the default pull timeout and cause the run to fail.
+
+To download the image once and reuse it across all projects, point Nextflow at a single, persistent cache directory by setting an environment variable before launching MitoPilot (e.g. in your `~/.bashrc` or job submission script):
+
+```bash
+# Singularity / Apptainer (most HPC clusters)
+export NXF_SINGULARITY_CACHEDIR=/path/to/persistent/singularity_cache
+export NXF_APPTAINER_CACHEDIR=/path/to/persistent/apptainer_cache
+
+# Docker (local)
+# Docker manages its own image cache, so no setting is required.
+```
+
+Choose a location with enough space that persists between sessions (not a per-project or temporary scratch directory). If image pulls still time out on a slow filesystem, increase `pullTimeout` in the `singularity { }` block of the `.config` file.
 
 ### Database Creation
 

--- a/README.md
+++ b/README.md
@@ -356,6 +356,36 @@ for one or more of the processing steps. After initializing a new
 project you should review the `.config` file to ensure that all
 necessary parameters are provided.
 
+### Container Cache Directory
+
+MitoPilot runs each processing step inside a container (Docker locally,
+or Singularity/Apptainer on most HPC clusters). The container image is
+fairly large, so on first use it must be downloaded and, for
+Singularity/Apptainer, converted to a single `.sif` file. By default
+Nextflow caches this image inside each project's `work/` directory, which
+means every new project re-downloads and rebuilds the same image. On
+shared cluster filesystems this can be slow enough to exceed the default
+pull timeout and cause the run to fail.
+
+To download the image once and reuse it across all projects, point
+Nextflow at a single, persistent cache directory by setting an
+environment variable before launching MitoPilot (e.g. in your
+`~/.bashrc` or job submission script):
+
+``` bash
+# Singularity / Apptainer (most HPC clusters)
+export NXF_SINGULARITY_CACHEDIR=/path/to/persistent/singularity_cache
+export NXF_APPTAINER_CACHEDIR=/path/to/persistent/apptainer_cache
+
+# Docker (local)
+# Docker manages its own image cache, so no setting is required.
+```
+
+Choose a location with enough space that persists between sessions (not a
+per-project or temporary scratch directory). If image pulls still time
+out on a slow filesystem, increase `pullTimeout` in the
+`singularity { }` block of the `.config` file.
+
 ### Database Creation
 
 MitoPilot makes use of the Nextflow plugin

--- a/inst/app/www/custom.css
+++ b/inst/app/www/custom.css
@@ -148,3 +148,18 @@ details[open] summary {
 .rt-tr-striped-sticky:not(.rt-tr-selected) {
   background-color: #e4e4e4 !important;
 }
+
+/* Sample tables: auto-fit window height, plus a drag handle to resize. */
+.mp-table-resize {
+  height: calc(100vh - 300px);
+  min-height: 240px;
+  resize: vertical;
+  overflow: hidden;
+}
+
+/* Make the shiny output container and reactable widget fill the wrapper so
+   height: "100%" on the table resolves against the resizable box. */
+.mp-table-resize > div,
+.mp-table-resize > div > .reactable {
+  height: 100% !important;
+}

--- a/inst/app/www/custom.js
+++ b/inst/app/www/custom.js
@@ -69,6 +69,18 @@ $( document ).ready(function(){
   });
 });
 
+// Sample-table resize: the CSS handle (resize: vertical) writes an inline
+// height, which then sticks and stops the table re-fitting the window. On
+// window resize, clear that inline height so the stylesheet calc() takes
+// over again and the table stays fully displayed.
+$( document ).ready(function(){
+  window.addEventListener('resize', function() {
+    document.querySelectorAll('.mp-table-resize').forEach(function(el) {
+      el.style.height = '';
+    });
+  });
+});
+
 // Shift-click range selection for the main sample reactable tables.
 // reactable (0.4.5) has no native range selection, so we drive it on the
 // client: a plain click stores an "anchor" row, and a shift-click selects

--- a/inst/config.NMNH_Hydra
+++ b/inst/config.NMNH_Hydra
@@ -10,6 +10,7 @@ executor {
 
 singularity {
   enabled = true
+  pullTimeout = '60 min'  // large image on Hydra's shared filesystem can exceed the 20 min default
 }
 
 process {


### PR DESCRIPTION
## Summary

  This branch makes the three main sample tables (Assemble, Annotate, Export) vertically resizable and window-aware, and fixes intermittent Singularity image-pull timeouts on the NMNH Hydra
  cluster.

  ## Sample table resizing
  
  Previously the sample tables were locked to a fixed `height = 500`. They now auto-fit the window height and can be manually resized via a drag handle.

  - The reactable output in each of the three table views (`R/app_annotate.R`, `R/app_assemble.R`, `R/app_export.R`) is wrapped in a `div.mp-table-resize`, and the table height changed from
  `500` to `"100%"` so it fills that wrapper.
  - `inst/app/www/custom.css`: `.mp-table-resize` sizes to `calc(100vh - 300px)` (with a `240px` minimum) and exposes a native vertical `resize` drag handle; the inner Shiny/reactable
  containers are forced to `height: 100%` so the table resolves against the resizable box.
  - `inst/app/www/custom.js`: on window resize, the inline height written by the drag handle is cleared so the stylesheet `calc()` takes over again and the table re-fits the new window size
  instead of staying stuck at the last dragged height.

  ## Hydra Singularity pull timeout

  On Hydra, `assemble` jobs intermittently failed during the Singularity image pull with `status: 143` (SIGTERM): Nextflow was killing the pull for exceeding the default `pullTimeout` of 20
  min. The MitoPilot image is large (MitoFinder bundles thousands of small files) and SIF creation on the shared `/scratch02` filesystem sits right around the 20 min limit, so success
  depended on filesystem load at that moment.

  - `inst/config.NMNH_Hydra`: added `pullTimeout = '60 min'` to the `singularity { }` block.
  - `README.Rmd` / `README.md`: new "Container Cache Directory" section explaining the default per-project cache behavior and how to set a persistent `NXF_SINGULARITY_CACHEDIR` /
  `NXF_APPTAINER_CACHEDIR` so the image is pulled once and reused across projects.

  ## Notes

  - `pullTimeout` was bumped only on the Hydra template, where the failure was observed; other cluster templates (slurm, sge, pbs, lsf, NOAA_SEDNA) still use the 20 min default.
  - Setting a shared cache directory is the more durable fix for the image-pull problem; raising the timeout is the safety net for slow filesystems.
