### PR TITLE
Devel

### DIFF
--- a/R/app_annotate.R
+++ b/R/app_annotate.R
@@ -219,10 +219,13 @@ annotate_server <- function(id) {
       hidden_grp   <- setdiff(names(ANNOTATE_COL_GROUPS), col_groups_rv())
       hidden_lock  <- setdiff(unname(ANNOTATE_LOCK_CHOICES), lock_filter_rv())
       hidden_state <- setdiff(unname(ANNOTATE_STATE_CHOICES), state_filter_rv())
+      # Scope to THIS module's table so rules don't hit the shared mp-lock /
+      # mp-state / mp-grp classes on the assemble, userAsmb, and export tables.
+      sel <- paste0("#", ns("table"), " ")
       rules <- c(
-        if (length(hidden_grp))   paste0(".mp-grp-",   hidden_grp,   " { display: none !important; }"),
-        if (length(hidden_lock))  paste0(".mp-lock-",  hidden_lock,  " { display: none !important; }"),
-        if (length(hidden_state)) paste0(".mp-state-", hidden_state, " { display: none !important; }")
+        if (length(hidden_grp))   paste0(sel, ".mp-grp-",   hidden_grp,   " { display: none !important; }"),
+        if (length(hidden_lock))  paste0(sel, ".mp-lock-",  hidden_lock,  " { display: none !important; }"),
+        if (length(hidden_state)) paste0(sel, ".mp-state-", hidden_state, " { display: none !important; }")
       )
       if (length(rules) == 0) return(NULL)
       tags$style(HTML(paste(rules, collapse = "\n")))
@@ -504,7 +507,33 @@ annotate_server <- function(id) {
     })
 
     # table selection ----
-    selected <- reactive(reactable::getReactableState("table", "selected"))
+    # Rows hidden by the lock/state filters stay mounted in reactable's row
+    # model, so a shift-click range can select them. Drop currently-hidden rows
+    # so bulk ops only ever touch visible samples.
+    selected <- reactive({
+      sel <- reactable::getReactableState("table", "selected")
+      if (is.null(sel) || length(sel) == 0) return(sel)
+      visible <- as.character(rv$data$annotate_lock)   %in% lock_filter_rv() &
+                 as.character(rv$data$annotate_switch) %in% state_filter_rv()
+      intersect(sel, which(visible))
+    })
+
+    # Prune hidden rows from reactable's actual selection whenever the
+    # selection OR the filters change. Triggering on the selection itself is
+    # what catches a shift-click range: hidden rows are removed immediately, so
+    # they never persist in reactable's state to reappear when later revealed.
+    observeEvent(
+      list(reactable::getReactableState("table", "selected"),
+           lock_filter_rv(), state_filter_rv()), {
+      sel <- reactable::getReactableState("table", "selected")
+      if (is.null(sel) || length(sel) == 0) return()
+      visible <- as.character(rv$data$annotate_lock)   %in% lock_filter_rv() &
+                 as.character(rv$data$annotate_switch) %in% state_filter_rv()
+      keep <- intersect(sel, which(visible))
+      if (length(keep) != length(sel)) {
+        reactable::updateReactable("table", selected = keep)
+      }
+    }, ignoreInit = TRUE)
 
     # Set State ----
     init("state")

--- a/R/app_assemble.R
+++ b/R/app_assemble.R
@@ -172,10 +172,13 @@ assemble_server <- function(id) {
       hidden_grp   <- setdiff(names(ASSEMBLE_COL_GROUPS), col_groups_rv())
       hidden_lock  <- setdiff(unname(ASSEMBLE_LOCK_CHOICES), lock_filter_rv())
       hidden_state <- setdiff(unname(ASSEMBLE_STATE_CHOICES), state_filter_rv())
+      # Scope to THIS module's table so rules don't hit the shared mp-lock /
+      # mp-state / mp-grp classes on the annotate, export, and userAsmb tables.
+      sel <- paste0("#", ns("table"), " ")
       rules <- c(
-        if (length(hidden_grp))   paste0(".mp-grp-",   hidden_grp,   " { display: none !important; }"),
-        if (length(hidden_lock))  paste0(".mp-lock-",  hidden_lock,  " { display: none !important; }"),
-        if (length(hidden_state)) paste0(".mp-state-", hidden_state, " { display: none !important; }")
+        if (length(hidden_grp))   paste0(sel, ".mp-grp-",   hidden_grp,   " { display: none !important; }"),
+        if (length(hidden_lock))  paste0(sel, ".mp-lock-",  hidden_lock,  " { display: none !important; }"),
+        if (length(hidden_state)) paste0(sel, ".mp-state-", hidden_state, " { display: none !important; }")
       )
       if (length(rules) == 0) return(NULL)
       tags$style(HTML(paste(rules, collapse = "\n")))
@@ -433,7 +436,33 @@ assemble_server <- function(id) {
     })
 
     # table selection ----
-    selected <- reactive(reactable::getReactableState("table", "selected"))
+    # Rows hidden by the lock/state filters stay mounted in reactable's row
+    # model, so a shift-click range can select them. Drop currently-hidden rows
+    # so bulk ops only ever touch visible samples.
+    selected <- reactive({
+      sel <- reactable::getReactableState("table", "selected")
+      if (is.null(sel) || length(sel) == 0) return(sel)
+      visible <- as.character(rv$data$assemble_lock)   %in% lock_filter_rv() &
+                 as.character(rv$data$assemble_switch) %in% state_filter_rv()
+      intersect(sel, which(visible))
+    })
+
+    # Prune hidden rows from reactable's actual selection whenever the
+    # selection OR the filters change. Triggering on the selection itself is
+    # what catches a shift-click range: hidden rows are removed immediately, so
+    # they never persist in reactable's state to reappear when later revealed.
+    observeEvent(
+      list(reactable::getReactableState("table", "selected"),
+           lock_filter_rv(), state_filter_rv()), {
+      sel <- reactable::getReactableState("table", "selected")
+      if (is.null(sel) || length(sel) == 0) return()
+      visible <- as.character(rv$data$assemble_lock)   %in% lock_filter_rv() &
+                 as.character(rv$data$assemble_switch) %in% state_filter_rv()
+      keep <- intersect(sel, which(visible))
+      if (length(keep) != length(sel)) {
+        reactable::updateReactable("table", selected = keep)
+      }
+    }, ignoreInit = TRUE)
 
     # Set State ----
     init("state")

--- a/R/app_assemble_userAsmb.R
+++ b/R/app_assemble_userAsmb.R
@@ -6,7 +6,7 @@
 assemble_ui_userAsmb <- function(id) {
   ns <- NS(id)
   tagList(
-    reactableOutput(ns("table"))
+    div(class = "mp-table-resize", reactableOutput(ns("table")))
   )
 }
 
@@ -53,7 +53,7 @@ assemble_server_userAsmb <- function(id) {
           selection = "multiple",
           searchable = TRUE,
           defaultSorted = list(time_stamp = "desc"),
-          height = 650,
+          height = "100%",
           wrap = FALSE,
           pageSizeOptions = c(25, 50, 100, 200, 500),
           rowStyle = rt_highlight_row(),

--- a/R/app_assemble_userAsmb.R
+++ b/R/app_assemble_userAsmb.R
@@ -1,3 +1,23 @@
+# Togglable column groups for the user-assemble table. Cols not listed here
+# (sticky cols, action buttons, the always-shown Input Assembly File) are
+# always visible. Mirrors ASSEMBLE_COL_GROUPS but drops assemble_opts (no
+# assembler step in user-assemble mode).
+ASSEMBLE_COL_GROUPS_USERASMB <- list(
+  Options  = c("pre_opts", "blast_opts"),
+  Stats    = c("trimmed_reads", "mean_length", "topology", "length",
+               "paths", "scaffolds"),
+  BLAST    = c("blast_accession", "blast_ref_status", "blast_species",
+               "blast_lineage", "blast_pident", "blast_qcovs"),
+  Metadata = c("time_stamp", "assemble_notes")
+)
+ASSEMBLE_COL_GROUP_LOOKUP_USERASMB <- {
+  out <- character()
+  for (.g in names(ASSEMBLE_COL_GROUPS_USERASMB)) {
+    for (.c in ASSEMBLE_COL_GROUPS_USERASMB[[.g]]) out[.c] <- .g
+  }
+  out
+}
+
 #' assemble UI
 #'
 #' @param id,input,output,session Internal parameters for {shiny}.
@@ -6,6 +26,55 @@
 assemble_ui_userAsmb <- function(id) {
   ns <- NS(id)
   tagList(
+    uiOutput(ns("col_css")),
+    div(
+      style = "display: flex; flex-flow: row wrap; gap: 1em; align-items: flex-end;",
+      shinyWidgets::pickerInput(
+        inputId  = ns("lock_filter"),
+        width    = "140px",
+        label    = "Lock:",
+        choices  = ASSEMBLE_LOCK_CHOICES,
+        selected = ASSEMBLE_LOCK_CHOICES,
+        multiple = TRUE,
+        options  = list(
+          `actions-box`          = TRUE,
+          `select-all-text`      = "All",
+          `deselect-all-text`    = "None",
+          `selected-text-format` = "count > 0",
+          width                  = "140px"
+        )
+      ),
+      shinyWidgets::pickerInput(
+        inputId  = ns("state_filter"),
+        width    = "140px",
+        label    = "State:",
+        choices  = ASSEMBLE_STATE_CHOICES,
+        selected = ASSEMBLE_STATE_CHOICES,
+        multiple = TRUE,
+        options  = list(
+          `actions-box`          = TRUE,
+          `select-all-text`      = "All",
+          `deselect-all-text`    = "None",
+          `selected-text-format` = "count > 0",
+          width                  = "140px"
+        )
+      ),
+      shinyWidgets::pickerInput(
+        inputId  = ns("col_groups"),
+        width    = "150px",
+        label    = "Show columns:",
+        choices  = names(ASSEMBLE_COL_GROUPS_USERASMB),
+        selected = names(ASSEMBLE_COL_GROUPS_USERASMB),
+        multiple = TRUE,
+        options  = list(
+          `actions-box`          = TRUE,
+          `select-all-text`      = "All",
+          `deselect-all-text`    = "None",
+          `selected-text-format` = "count > 0",
+          width                  = "150px"
+        )
+      )
+    ),
     div(class = "mp-table-resize", reactableOutput(ns("table")))
   )
 }
@@ -40,12 +109,55 @@ assemble_server_userAsmb <- function(id) {
       )
     })
 
+    # Column-group / status filters. Mirror the pickers so NULL (= user cleared
+    # all) is distinguishable from the pre-init state. Defaults: everything on.
+    col_groups_rv <- reactiveVal(names(ASSEMBLE_COL_GROUPS_USERASMB))
+    observeEvent(input$col_groups, {
+      col_groups_rv(input$col_groups %||% character(0))
+    }, ignoreNULL = FALSE, ignoreInit = TRUE)
+
+    lock_filter_rv <- reactiveVal(unname(ASSEMBLE_LOCK_CHOICES))
+    observeEvent(input$lock_filter, {
+      lock_filter_rv(input$lock_filter %||% character(0))
+    }, ignoreNULL = FALSE, ignoreInit = TRUE)
+    state_filter_rv <- reactiveVal(unname(ASSEMBLE_STATE_CHOICES))
+    observeEvent(input$state_filter, {
+      state_filter_rv(input$state_filter %||% character(0))
+    }, ignoreNULL = FALSE, ignoreInit = TRUE)
+
+    # CSS class for a togglable column, added to both body cell and header so
+    # the whole column collapses when its group is unselected.
+    .grp <- function(col) {
+      g <- ASSEMBLE_COL_GROUP_LOOKUP_USERASMB[col]
+      if (is.na(g)) NULL else paste0("mp-grp-", g)
+    }
+
+    # Hide unselected column groups and lock/state codes via CSS. Hiding (not
+    # removing) keeps columns/rows mounted, so filters, sort, page, and
+    # selection survive toggling.
+    output$col_css <- renderUI({
+      hidden_grp   <- setdiff(names(ASSEMBLE_COL_GROUPS_USERASMB), col_groups_rv())
+      hidden_lock  <- setdiff(unname(ASSEMBLE_LOCK_CHOICES), lock_filter_rv())
+      hidden_state <- setdiff(unname(ASSEMBLE_STATE_CHOICES), state_filter_rv())
+      # Scope to THIS module's table so rules don't hit the shared mp-lock /
+      # mp-state / mp-grp classes on the annotate, export, and assemble tables.
+      sel <- paste0("#", ns("table"), " ")
+      rules <- c(
+        if (length(hidden_grp))   paste0(sel, ".mp-grp-",   hidden_grp,   " { display: none !important; }"),
+        if (length(hidden_lock))  paste0(sel, ".mp-lock-",  hidden_lock,  " { display: none !important; }"),
+        if (length(hidden_state)) paste0(sel, ".mp-state-", hidden_state, " { display: none !important; }")
+      )
+      if (length(rules) == 0) return(NULL)
+      tags$style(HTML(paste(rules, collapse = "\n")))
+    })
+
     # Render table ----
     output$table <- renderReactable({
       isolate(req(rv$data)) |>
         reactable(
           resizable = TRUE,
           filterable = TRUE,
+          striped = TRUE,
           compact = TRUE,
           defaultPageSize = 100,
           showPageSizeOptions = TRUE,
@@ -57,17 +169,15 @@ assemble_server_userAsmb <- function(id) {
           wrap = FALSE,
           pageSizeOptions = c(25, 50, 100, 200, 500),
           rowStyle = rt_highlight_row(),
+          rowClass = JS("function(rowInfo) {
+            if (!rowInfo || !rowInfo.values) return '';
+            return 'mp-lock-' + rowInfo.values['assemble_lock'] +
+                   ' mp-state-' + rowInfo.values['assemble_switch'];
+          }"),
           theme = reactable::reactableTheme(
             headerStyle = list(whiteSpace = "normal", lineHeight = "1.2", textAlign = "left")
           ),
           defaultColDef = colDef(align = "left", show = F),
-          columnGroups = list(
-            reactable::colGroup(
-              name = "BLAST",
-              columns = c("blast_accession", "blast_ref_status", "blast_species",
-                          "blast_pident", "blast_qcovs", "blast_evalue", "blast_lineage")
-            )
-          ),
           columns = list(
             `.selection` = colDef(show = T, sticky = "left", width = 28),
             assemble_lock = colDef(
@@ -118,7 +228,7 @@ assemble_server_userAsmb <- function(id) {
               cell = rt_longtext()
             ),
             topology = colDef(
-              show = TRUE,
+              show = TRUE, class = .grp("topology"), headerClass = .grp("topology"),
               width = 100,
               name = "Topology"
             ),
@@ -130,33 +240,33 @@ assemble_server_userAsmb <- function(id) {
               cell = rt_longtext()
             ),
             pre_opts = colDef(
-              show = T,
+              show = T, class = .grp("pre_opts"), headerClass = .grp("pre_opts"),
               name = "Preprocess Opts.",
               html = T,
               width = 130,
               cell = rt_link(ns("set_pre_opts"))
             ),
             blast_opts = colDef(
-              show = T,
+              show = T, class = .grp("blast_opts"), headerClass = .grp("blast_opts"),
               name = "BLAST Opts.",
               html = T,
               width = 120,
               cell = rt_link(ns("set_blast_opts"))
             ),
             trimmed_reads = colDef(
-              show = T,
+              show = T, class = .grp("trimmed_reads"), headerClass = .grp("trimmed_reads"),
               name = "Reads",
               filterable = FALSE,
               minWidth = 100
             ),
             mean_length = colDef(
-              show = T,
+              show = T, class = .grp("mean_length"), headerClass = .grp("mean_length"),
               name = "Read Length",
               filterable = FALSE,
               minWidth = 100
             ),
             length = colDef(
-              show = TRUE,
+              show = TRUE, class = .grp("length"), headerClass = .grp("length"),
               minWidth = 140,
               name = "Asmb. Length (raw)",
               filterable = FALSE,
@@ -164,15 +274,17 @@ assemble_server_userAsmb <- function(id) {
               cell = rt_longtext()
             ),
             paths = colDef(
-              show = TRUE, width = 100, name = "# Paths", align = "center",
+              show = TRUE, class = .grp("paths"), headerClass = .grp("paths"),
+              width = 100, name = "# Paths", align = "center",
               cell = JS("function(cellInfo){if(cellInfo.value<0){return -cellInfo.value };return cellInfo.value}"),
               style = JS("function(rowInfo){ if (rowInfo.values.paths < 0) return { backgroundColor: '#00000020' }}")
             ),
             scaffolds = colDef(
-              show = TRUE, width = 100, name = "# Scaffolds", align = "center"
+              show = TRUE, class = .grp("scaffolds"), headerClass = .grp("scaffolds"),
+              width = 100, name = "# Scaffolds", align = "center"
             ),
             blast_accession = colDef(
-              show = TRUE,
+              show = TRUE, class = .grp("blast_accession"), headerClass = .grp("blast_accession"),
               name = "Top Hit",
               html = TRUE,
               width = 120,
@@ -180,7 +292,7 @@ assemble_server_userAsmb <- function(id) {
             ),
             poor_blast_ref = colDef(show = FALSE),
             blast_ref_status = colDef(
-              show = TRUE,
+              show = TRUE, class = .grp("blast_ref_status"), headerClass = .grp("blast_ref_status"),
               name = "Ref Align",
               html = TRUE,
               width = 100,
@@ -189,35 +301,35 @@ assemble_server_userAsmb <- function(id) {
               cell = rt_blast_ref_status()
             ),
             blast_species = colDef(
-              show = TRUE,
+              show = TRUE, class = .grp("blast_species"), headerClass = .grp("blast_species"),
               name = "Species",
               html = TRUE,
               minWidth = 160,
               cell = rt_longtext()
             ),
             blast_lineage = colDef(
-              show = TRUE,
+              show = TRUE, class = .grp("blast_lineage"), headerClass = .grp("blast_lineage"),
               name = "Lineage",
               html = TRUE,
               minWidth = 200,
               cell = rt_longtext()
             ),
             blast_pident = colDef(
-              show = TRUE,
+              show = TRUE, class = .grp("blast_pident"), headerClass = .grp("blast_pident"),
               name = "% Ident",
               filterable = FALSE,
               width = 90,
               align = "center"
             ),
             blast_qcovs = colDef(
-              show = TRUE,
+              show = TRUE, class = .grp("blast_qcovs"), headerClass = .grp("blast_qcovs"),
               name = "% Cov",
               filterable = FALSE,
               width = 90,
               align = "center"
             ),
             time_stamp = colDef(
-              show = TRUE,
+              show = TRUE, class = .grp("time_stamp"), headerClass = .grp("time_stamp"),
               name = "Last Updated",
               filterable = FALSE,
               html = T,
@@ -225,7 +337,7 @@ assemble_server_userAsmb <- function(id) {
               cell = rt_ts_date()
             ),
             assemble_notes = colDef(
-              show = TRUE,
+              show = TRUE, class = .grp("assemble_notes"), headerClass = .grp("assemble_notes"),
               name = "Notes",
               html = TRUE,
               align = "left",
@@ -278,7 +390,33 @@ assemble_server_userAsmb <- function(id) {
     })
 
     # table selection ----
-    selected <- reactive(reactable::getReactableState("table", "selected"))
+    # Rows hidden by the lock/state filters stay mounted in reactable's row
+    # model, so a shift-click range can select them. Drop currently-hidden rows
+    # so bulk ops only ever touch visible samples.
+    selected <- reactive({
+      sel <- reactable::getReactableState("table", "selected")
+      if (is.null(sel) || length(sel) == 0) return(sel)
+      visible <- as.character(rv$data$assemble_lock)   %in% lock_filter_rv() &
+                 as.character(rv$data$assemble_switch) %in% state_filter_rv()
+      intersect(sel, which(visible))
+    })
+
+    # Prune hidden rows from reactable's actual selection whenever the
+    # selection OR the filters change. Triggering on the selection itself is
+    # what catches a shift-click range: hidden rows are removed immediately, so
+    # they never persist in reactable's state to reappear when later revealed.
+    observeEvent(
+      list(reactable::getReactableState("table", "selected"),
+           lock_filter_rv(), state_filter_rv()), {
+      sel <- reactable::getReactableState("table", "selected")
+      if (is.null(sel) || length(sel) == 0) return()
+      visible <- as.character(rv$data$assemble_lock)   %in% lock_filter_rv() &
+                 as.character(rv$data$assemble_switch) %in% state_filter_rv()
+      keep <- intersect(sel, which(visible))
+      if (length(keep) != length(sel)) {
+        reactable::updateReactable("table", selected = keep)
+      }
+    }, ignoreInit = TRUE)
 
     # Set State ----
     init("state")

--- a/R/app_export.R
+++ b/R/app_export.R
@@ -120,7 +120,10 @@ export_server <- function(id) {
     output$col_css <- renderUI({
       hidden <- setdiff(names(EXPORT_COL_GROUPS), col_groups_rv())
       if (length(hidden) == 0) return(NULL)
-      rules <- paste0(".mp-grp-", hidden,
+      # Scope to THIS module's table so rules don't hit the shared mp-grp
+      # classes on the assemble, userAsmb, and annotate tables.
+      sel <- paste0("#", ns("table"), " ")
+      rules <- paste0(sel, ".mp-grp-", hidden,
                       " { display: none !important; }",
                       collapse = "\n")
       tags$style(HTML(rules))

--- a/R/blast_ref_utils.R
+++ b/R/blast_ref_utils.R
@@ -180,24 +180,28 @@ fetch_blast_ref <- function(accession, output_file, sequence_file = NULL,
       }
     }, error = function(e) NULL)
 
-    # Fetch taxonomy XML once; derive both species name and condensed lineage
+    # Fetch taxonomy XML once; derive both species name and condensed lineage.
+    # NCBI occasionally returns HTTP 200 with an error payload inside <TaxaSet>
+    # when its taxonomy backend times out. A valid record always carries a
+    # <ScientificName>, so treat its absence as a transient failure and stop()
+    # to let Nextflow's errorStrategy retry the task, rather than silently
+    # writing null organism/lineage.
     tax_xml <- if (!is.null(taxid)) {
-      tryCatch({
-        tax_url <- paste0(
-          "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi",
-          "?db=taxonomy&id=", taxid, "&retmode=xml",
-          api_key_qs
-        )
-        httr2::resp_body_string(
-          ncbi_efetch(tax_url, 60L, paste0("taxonomy/", taxid))
-        )
-      }, error = function(e) {
-        message(sprintf(
-          "[blast_ref_fetch] taxonomy/%s failed after all retries: %s - organism/lineage will be NULL",
-          taxid, conditionMessage(e)
-        ))
-        NULL
-      })
+      tax_url <- paste0(
+        "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi",
+        "?db=taxonomy&id=", taxid, "&retmode=xml",
+        api_key_qs
+      )
+      body <- httr2::resp_body_string(
+        ncbi_efetch(tax_url, 60L, paste0("taxonomy/", taxid))
+      )
+      if (!grepl("<ScientificName>", body, fixed = TRUE)) {
+        stop(sprintf(
+          "taxonomy/%s returned no usable record (likely NCBI backend timeout) - retrying via Nextflow",
+          taxid
+        ), call. = FALSE)
+      }
+      body
     } else NULL
 
     # Clean species name = first <ScientificName> before <LineageEx>


### PR DESCRIPTION
## Summary

  Bug fixes for the user-assembly (userAsmb) sample table UI and the BLAST reference taxonomy fetch in WF1. Three fixes: NCBI taxonomy retry on silent error responses, userAsmb table filter parity + scoping, and correct selection behavior under filters.

  ## Changes

  ### fix(blast-ref): retry on NCBI taxonomy 200-with-error-body

  NCBI taxonomy EFetch can return HTTP 200 with an error payload inside `<TaxaSet>` when its backend times out. The old code only checked the HTTP status, so it silently wrote `organism`/`lineage` as null and exited successfully (no retry). Intermittent
  backend timeouts left a few samples with missing lineage even though the genome download succeeded.

  - Validate the taxonomy body for `<ScientificName>`; if absent, `stop()` so the existing Nextflow `errorStrategy { retry }` on `blast_ref_fetch` re-runs the task.
  - The expensive genome FASTA download is fetched after the taxonomy step, so it isn't re-downloaded by these retries.

  ### fix(ui): userAsmb table filter parity, scope filters, prune hidden selections

  - Filter parity: the userAsmb assemble table was missing the Lock / State / Show-columns filters present in normal assemble. Added the filter bar and supporting server logic.
  - Horizontal scroll: removed reactable `columnGroups` from the userAsmb table, which broke horizontal scrolling when combined with sticky columns (normal assemble achieves grouping via CSS classes + the show-columns picker instead).
  - Cross-table filter leak: `col_css` injected global `display:none` rules on shared `mp-lock-*`/`mp-state-*`/`mp-grp-*` classes, so a filter set on one table hid matching rows/columns in the assemble, annotate, and export tables too. Scoped every rule
  to its own table's DOM id.
  - Shift-click selecting hidden rows: filtered rows stay mounted in reactable, so a shift-click range selected CSS-hidden samples. Added a read-time mask on `selected()` plus an observer that prunes hidden rows from reactable's selection on any
  selection/filter change, so hidden samples never enter (or resurface in) the selection.

  ### fix(ui): apply resizable wrapper to userAsmb sample table (prior commit)

  Applies the resizable table wrapper to the userAsmb sample table.
