### PR TITLE
feat(ui): notify when files open in RStudio Server Files pane

### DIFF
--- a/R/app_annotate.R
+++ b/R/app_annotate.R
@@ -1273,13 +1273,7 @@ annotate_server <- function(id) {
         filtered_data()$ID[as.numeric(input$output)],
         "annotate"
       )
-      req(file.exists(pth))
-      if (tolower(Sys.getenv("RSTUDIO_PROGRAM_MODE")) == "server") {
-        rstudioapi::filesPaneNavigate(pth)
-        req(F)
-      } else {
-        utils::browseURL(pth)
-      }
+      open_path(pth)
     })
 
     # Open annotation details ----

--- a/R/app_assemble.R
+++ b/R/app_assemble.R
@@ -1029,13 +1029,7 @@ assemble_server <- function(id) {
         "assemble",
         rv$data$assemble_opts[as.numeric(input$output)]
       )
-      req(file.exists(pth))
-      if (tolower(Sys.getenv("RSTUDIO_PROGRAM_MODE")) == "server") {
-        rstudioapi::filesPaneNavigate(pth)
-        req(F)
-      } else {
-        utils::browseURL(pth)
-      }
+      open_path(pth)
     })
 
     # Open Assembly Details ----

--- a/R/app_assemble_userAsmb.R
+++ b/R/app_assemble_userAsmb.R
@@ -781,13 +781,7 @@ assemble_server_userAsmb <- function(id) {
         "assemble",
         rv$data$assemble_opts[as.numeric(input$output)]
       )
-      req(file.exists(pth))
-      if (tolower(Sys.getenv("RSTUDIO_PROGRAM_MODE")) == "server") {
-        rstudioapi::filesPaneNavigate(pth)
-        req(F)
-      } else {
-        utils::browseURL(pth)
-      }
+      open_path(pth)
     })
 
     # Open Assembly Details ----

--- a/R/utils_app.R
+++ b/R/utils_app.R
@@ -9,8 +9,9 @@ coming_soon <- function(text = "This feature is not yet implemented.") {
 
 #' Open a directory in an environment-aware way
 #'
-#' Local desktop opens the OS file browser; RStudio Server navigates the Files pane; headless
-#' sessions cannot open folders, so a warning notification with the path is shown instead.
+#' Local desktop opens the OS file browser; RStudio Server navigates the Files pane (and
+#' notifies the user, since that is not obvious); headless sessions cannot open folders, so a
+#' warning notification with the path is shown instead.
 #'
 #' @noRd
 open_path <- function(pth) {
@@ -23,13 +24,18 @@ open_path <- function(pth) {
   }
   if (!dir.exists(pth)) {
     showNotification(
-      paste0("Work directory not found (it may have been cleaned): ", pth),
+      paste0("Folder not found (it may have been cleaned or is on storage this host ",
+             "cannot see): ", pth),
       type = "warning", duration = 10
     )
     return(invisible(FALSE))
   }
   if (tolower(Sys.getenv("RSTUDIO_PROGRAM_MODE")) == "server") {
     if (requireNamespace("rstudioapi", quietly = TRUE)) rstudioapi::filesPaneNavigate(pth)
+    showNotification(
+      "Opened in the RStudio Files pane (bottom-right panel).",
+      type = "message", duration = 5
+    )
   } else {
     utils::browseURL(pth)
   }


### PR DESCRIPTION
open_path() now shows a brief notification on RStudio Server explaining the folder opened in the Files pane (bottom-right), since that is not obvious. Route the three "output folder" buttons (assemble, annotate, userAsmb assemble) through open_path() so they share this behavior plus the headless / missing-dir handling, replacing duplicated server-vs-local blocks.
