### PR TITLE
Feat/gui qol

### DIFF
--- a/R/app_annotate.R
+++ b/R/app_annotate.R
@@ -94,6 +94,10 @@ annotate_ui <- function(id) {
       ),
       div(class = "mp-table-resize", reactable::reactableOutput(ns("table"))),
       div(
+        style = "font-size: 0.85em; color: #555; margin-top: 4px;",
+        textOutput(ns("n_selected"), inline = TRUE)
+      ),
+      div(
         style = "margin-top: 12px; display: flex; gap: 8px;",
         downloadButton(ns("export_selected"), "Export Selected to CSV",
                        class = "btn-sm btn-default"),
@@ -516,6 +520,10 @@ annotate_server <- function(id) {
       visible <- as.character(rv$data$annotate_lock)   %in% lock_filter_rv() &
                  as.character(rv$data$annotate_switch) %in% state_filter_rv()
       intersect(sel, which(visible))
+    })
+
+    output$n_selected <- renderText({
+      paste0(length(selected()), " selected")
     })
 
     # Publish current selection so the work-dir browser can pre-select this sample

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -48,6 +48,74 @@ split_wrapped_genes <- function(df, x_lo, x_hi) {
   dplyr::bind_rows(pieces)
 }
 
+# Build an absolutely-positioned HTML overlay of gene-name labels for a static
+# plot image. Each gene becomes a block at its pixel x-range; the label inside
+# uses CSS `position: sticky; left: 0` so it stays pinned at the scroll
+# container's left edge while the block is in view, then hands off to the next
+# gene as blocks scroll past. `direction` ("+"/"-") prefixes a ">"/"<" marker.
+# x_lo/x_hi are the plot's x-scale limits; img_w is the image width in px.
+# `inset` is the fixed pixel gap between the image edge and the plot panel
+# (theme/patchwork margins), so labels track the panel rather than the image.
+gene_label_overlay <- function(df, img_w, x_lo, x_hi, track_top, track_height,
+                               scale_y = 2, scale_x = 1.5, inset = 0) {
+  if (is.null(df) || nrow(df) == 0) return(NULL)
+  df <- df[!is.na(df$gene) & nzchar(df$gene), , drop = FALSE]
+  if (nrow(df) == 0) return(NULL)
+  span_px <- (img_w - 2 * inset) / (x_hi - x_lo)
+  blocks <- lapply(seq_len(nrow(df)), function(i) {
+    r <- df[i, , drop = FALSE]
+    left  <- inset + (min(r$xmin, r$xmax) - x_lo) * span_px
+    width <- abs(r$xmax - r$xmin) * span_px
+    fwd <- identical(as.character(r$direction), "+")
+    marker <- if (fwd) ">" else "<"
+    marker_span <- htmltools::tags$span(
+      # Directional arrow, stretched to span the full block height; no bg.
+      style = sprintf(
+        paste0("font-size:%.0fpx; line-height:1; color:#808080; ",
+               "transform:scale(0.8,1.7); transform-origin:center;"),
+        track_height
+      ),
+      marker
+    )
+    name_span <- htmltools::tags$span(
+      # Gene name, size unchanged (scale_x/scale_y only).
+      style = sprintf(paste0(
+        "white-space:nowrap; font-size:10px; line-height:1; color:#000; ",
+        "padding:0 2px; transform:scale(%s,%s); transform-origin:%s center;"),
+        scale_x, scale_y, if (fwd) "left" else "right"
+      ),
+      r$gene
+    )
+    # + strand: arrow then name, left-justified, pinned to the viewport's left
+    # edge. - strand: name then arrow, right-justified, pinned to the right edge.
+    inner <- if (fwd) list(marker_span, name_span) else list(name_span, marker_span)
+    sticky_style <- sprintf(
+      "position:sticky; %s:0; z-index:1; display:flex; align-items:center; height:100%%; gap:4px;",
+      if (fwd) "left" else "right"
+    )
+    htmltools::div(
+      # No overflow:hidden here: an overflow-clipping ancestor would become the
+      # sticky label's scroll context and pin it to this (non-scrolling) block
+      # instead of the scroll viewport. Labels may overlap a neighbour, but stay
+      # visible for any annotation on screen.
+      style = sprintf(
+        paste0("position:absolute; left:%.2fpx; width:%.2fpx; top:%.0fpx; ",
+               "height:%.0fpx; display:flex; align-items:center; ",
+               "justify-content:%s; pointer-events:none;"),
+        left, width, track_top, track_height, if (fwd) "flex-start" else "flex-end"
+      ),
+      htmltools::div(style = sticky_style, inner)
+    )
+  })
+  htmltools::div(
+    style = sprintf(
+      "position:absolute; top:0; left:0; width:%.0fpx; height:100%%; pointer-events:none;",
+      img_w
+    ),
+    blocks
+  )
+}
+
 annotations_details_server <- function(id, rv) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
@@ -630,10 +698,6 @@ annotations_details_server <- function(id, rv) {
           arrowhead_width = ggplot2::unit(1, "mm"),
           alpha = gene_type_alpha
         ) +
-        gggenes::geom_gene_label(
-          align = "left",
-          height = ggplot2::unit(4, "mm")
-        ) +
         ggplot2::scale_fill_manual(values = gene_type_fill) +
         ggplot2::scale_x_continuous(
           expand = c(0, 0),
@@ -741,7 +805,15 @@ annotations_details_server <- function(id, rv) {
         )
       # plot with dynamic width
       #plotOutput(ns("coverage_plot"), width = paste0(rv$updating$length, "px"), height = "125px")  # OLD CODE, problems with Cairo
-      shiny::imageOutput(ns("coverage_plot"), width = paste0(fig_ctx()$length, "px"), height = "125px")
+      img_w <- fig_ctx()$length
+      x_hi  <- max(c(rv$coverage$Position, rv$annotations$pos2))
+      div(
+        style = sprintf("position:relative; width:%dpx; height:125px;", as.integer(img_w)),
+        shiny::imageOutput(ns("coverage_plot"), width = paste0(img_w, "px"), height = "125px"),
+        # Block = measured gene-arrow band (px 96-112 in the 125px cowplot image).
+        gene_label_overlay(genes_df, img_w = img_w, x_lo = 1, x_hi = x_hi,
+                           track_top = 96, track_height = 16, scale_y = 1.6)
+      )
     })
     # Use renderImage + ragg::agg_png to bypass Cairo's per-dimension image
     # surface limit (~16384 px on common libcairo builds), which silently
@@ -771,6 +843,9 @@ annotations_details_server <- function(id, rv) {
       deleteFile = TRUE
     )
     # BLAST Reference Synteny ----
+    # Gene-block coords (alignment-space %) stashed by the synteny image render,
+    # consumed by the sticky-label overlay (output$synteny_labels).
+    synteny_overlay <- reactiveVal(NULL)
     output$synteny_ui <- renderUI({
       req(rv$blast_ref)
       ctx <- req(fig_ctx())
@@ -854,8 +929,12 @@ annotations_details_server <- function(id, rv) {
             id = ns("syntenyScrollDiv"),
             style = paste0("overflow-x: auto; flex: 1;",
                            if (has_aln) " cursor: zoom-in;" else ""),
-            imageOutput(ns("synteny_plot"), width = paste0(w, "px"), height = plot_h,
-                       click = ns("synteny_click"))
+            div(
+              style = sprintf("position: relative; width: %dpx;", as.integer(w)),
+              imageOutput(ns("synteny_plot"), width = paste0(w, "px"), height = plot_h,
+                         click = ns("synteny_click")),
+              uiOutput(ns("synteny_labels"))
+            )
           )
         ),
         if (has_aln) {
@@ -903,7 +982,6 @@ annotations_details_server <- function(id, rv) {
           arrowhead_width   = ggplot2::unit(2, "mm"),
           alpha = gene_type_alpha
         ),
-        gggenes::geom_gene_label(align = "left", height = ggplot2::unit(6, "mm")),
         ggplot2::scale_fill_manual(values = gene_type_fill),
         ggplot2::scale_x_continuous(expand = c(0, 0), limits = c(0, 100)),
         ggplot2::coord_cartesian(clip = "off"),
@@ -1017,6 +1095,11 @@ annotations_details_server <- function(id, rv) {
                        fill = type, y = 0, label = gene) +
           gene_track
 
+        synteny_overlay(list(
+          has_aln = TRUE, img_w = img_w,
+          sample_df = sample_df, ref_df = ref_df
+        ))
+
         print(sample_plot / aln_plot / ref_plot +
                 patchwork::plot_layout(heights = c(3, 1, 3)))
 
@@ -1055,6 +1138,11 @@ annotations_details_server <- function(id, rv) {
         ref_plot <- ggplot2::ggplot(ref_pct) +
           ggplot2::aes(xmin = xmin, xmax = xmax, forward = direction == "+",
                        fill = type, y = 0, label = gene) + gene_track
+        synteny_overlay(list(
+          has_aln = FALSE, img_w = img_w,
+          sample_df = sample_pct, ref_df = ref_pct
+        ))
+
         print(sample_plot / ref_plot + patchwork::plot_layout(heights = c(1, 1)))
       }
       dev.off()
@@ -1069,7 +1157,31 @@ annotations_details_server <- function(id, rv) {
       deleteFile = TRUE
     )
 
+    # Sticky gene-name labels overlaid on the synteny image. Two gene tracks
+    # (sample on top, reference on bottom); band positions track the patchwork
+    # layout heights (3:1:3 with alignment, 1:1 without).
+    output$synteny_labels <- renderUI({
+      ov <- synteny_overlay()
+      req(ov)
+      # Block = measured gene-arrow bands (px). has_aln sample 41-74 / ref
+      # 194-227 (280px image); no_aln sample 30-63 / ref 125-158 (200px image).
+      if (ov$has_aln) {
+        sample_top <- 41; ref_top <- 194
+      } else {
+        sample_top <- 30; ref_top <- 125
+      }
+      tagList(
+        gene_label_overlay(ov$sample_df, img_w = ov$img_w, x_lo = 0, x_hi = 100,
+                           track_top = sample_top, track_height = 33, inset = 5),
+        gene_label_overlay(ov$ref_df, img_w = ov$img_w, x_lo = 0, x_hi = 100,
+                           track_top = ref_top, track_height = 33, inset = 5)
+      )
+    })
+
     # Zoomed base-pair view of selected gene's alignment region ----
+    # Gene-block coords (local alignment cols) stashed by the zoom plot render,
+    # consumed by the sticky-label overlay (output$synteny_zoom_labels).
+    zoom_overlay <- reactiveVal(NULL)
     output$synteny_zoom_ui <- renderUI({
       req(isTRUE(input$synteny_zoom))
       has_aln <- !is.null(rv$blast_ref_aln) && nrow(rv$blast_ref_aln) > 0 &&
@@ -1128,8 +1240,12 @@ annotations_details_server <- function(id, rv) {
           ),
           div(
             style = "overflow-x: auto; flex: 1;",
-            plotOutput(ns("synteny_zoom_plot"),
-                       width = paste0(plot_w, "px"), height = "180px")
+            div(
+              style = sprintf("position: relative; width: %dpx;", plot_w),
+              plotOutput(ns("synteny_zoom_plot"),
+                         width = paste0(plot_w, "px"), height = "180px"),
+              uiOutput(ns("synteny_zoom_labels"))
+            )
           )
         ),
         div(
@@ -1294,6 +1410,19 @@ annotations_details_server <- function(id, rv) {
         )
       } else NULL
 
+      # Stash gene blocks for the sticky-label overlay (forward -> +/- marker).
+      mk_ov <- function(d) {
+        if (is.null(d)) return(NULL)
+        d$direction <- ifelse(d$forward, "+", "-")
+        d
+      }
+      zoom_overlay(list(
+        sample_df = mk_ov(sample_gene_df),
+        ref_df    = mk_ov(ref_gene_df),
+        n_cols    = length(win_cols),
+        plot_w    = as.integer(win * 14L)
+      ))
+
       # Vertical guide lines every 10 cols (behind everything)
       guide_x <- seq(10L, length(win_cols), by = 10L)
 
@@ -1314,12 +1443,6 @@ annotations_details_server <- function(id, rv) {
             arrow_body_height = ggplot2::unit(6, "mm"),
             arrowhead_height  = ggplot2::unit(6, "mm"),
             arrowhead_width   = ggplot2::unit(3, "mm")
-          ),
-          gggenes::geom_gene_label(
-            data = sample_gene_df,
-            ggplot2::aes(xmin = xmin, xmax = xmax, y = 4, label = gene),
-            inherit.aes = FALSE, align = "left",
-            height = ggplot2::unit(4.5, "mm")
           )
         ) else NULL) +
         # Identity bar - merged runs reduce render items
@@ -1347,12 +1470,6 @@ annotations_details_server <- function(id, rv) {
             arrow_body_height = ggplot2::unit(6, "mm"),
             arrowhead_height  = ggplot2::unit(6, "mm"),
             arrowhead_width   = ggplot2::unit(3, "mm")
-          ),
-          gggenes::geom_gene_label(
-            data = ref_gene_df,
-            ggplot2::aes(xmin = xmin, xmax = xmax, y = 0, label = gene),
-            inherit.aes = FALSE, align = "left",
-            height = ggplot2::unit(4.5, "mm")
           )
         ) else NULL) +
         ggplot2::scale_fill_identity() +
@@ -1370,6 +1487,23 @@ annotations_details_server <- function(id, rv) {
           plot.margin     = ggplot2::margin(2, 2, 2, 2, "mm")
         )
       p
+    })
+
+    # Sticky gene-name labels overlaid on the zoom plot. Kept small to fit the
+    # ~16 px arrow blocks. Arrow centres (px): sample 34, ref 159 (180px plot);
+    # ~6 px panel inset from the 2 mm plot margin.
+    output$synteny_zoom_labels <- renderUI({
+      ov <- zoom_overlay()
+      req(ov)
+      x_lo <- 0.5; x_hi <- ov$n_cols + 0.5
+      tagList(
+        gene_label_overlay(ov$sample_df, img_w = ov$plot_w, x_lo = x_lo, x_hi = x_hi,
+                           track_top = 26, track_height = 16,
+                           scale_x = 1, scale_y = 1, inset = 6),
+        gene_label_overlay(ov$ref_df, img_w = ov$plot_w, x_lo = x_lo, x_hi = x_hi,
+                           track_top = 151, track_height = 16,
+                           scale_x = 1, scale_y = 1, inset = 6)
+      )
     })
 
     # Synteny overview click -> zoom centered at click x.

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -57,7 +57,8 @@ split_wrapped_genes <- function(df, x_lo, x_hi) {
 # `inset` is the fixed pixel gap between the image edge and the plot panel
 # (theme/patchwork margins), so labels track the panel rather than the image.
 gene_label_overlay <- function(df, img_w, x_lo, x_hi, track_top, track_height,
-                               scale_y = 2, scale_x = 1.5, inset = 0) {
+                               scale_y = 2, scale_x = 1.5, inset = 0,
+                               arrow_w = 0.3) {
   if (is.null(df) || nrow(df) == 0) return(NULL)
   df <- df[!is.na(df$gene) & nzchar(df$gene), , drop = FALSE]
   if (nrow(df) == 0) return(NULL)
@@ -67,30 +68,49 @@ gene_label_overlay <- function(df, img_w, x_lo, x_hi, track_top, track_height,
     left  <- inset + (min(r$xmin, r$xmax) - x_lo) * span_px
     width <- abs(r$xmax - r$xmin) * span_px
     fwd <- identical(as.character(r$direction), "+")
-    marker <- if (fwd) ">" else "<"
-    marker_span <- htmltools::tags$span(
-      # Directional arrow, stretched to span the full block height; no bg.
+    # Directional arrow drawn as a CSS border-triangle, not a text glyph: it is
+    # pure geometry, so it occupies the exact block height, stays narrow, and
+    # cannot be clipped the way a stretched glyph's ink is. The point faces the
+    # gene name (+ points right, - points left).
+    mk_w <- max(4L, round(track_height * arrow_w))
+    arrow_border <- if (fwd) {
+      sprintf("border-left:%dpx solid #808080;", mk_w)
+    } else {
+      sprintf("border-right:%dpx solid #808080;", mk_w)
+    }
+    marker_span <- htmltools::div(
       style = sprintf(
-        paste0("font-size:%.0fpx; line-height:1; color:#808080; ",
-               "transform:scale(0.8,1.7); transform-origin:center;"),
-        track_height
-      ),
-      marker
+        paste0("flex:none; width:0; height:0; opacity:0.5; ",
+               "border-top:%.1fpx solid transparent; ",
+               "border-bottom:%.1fpx solid transparent; %s"),
+        track_height / 2, track_height / 2, arrow_border
+      )
     )
+    # scale_x grows the name's visual width past its (unscaled) layout box toward
+    # the arrow; reserve that overflow as margin on the arrow-facing side so the
+    # name and arrow don't overlap (~6 px per char at 10 px font, less the gap).
+    name_overflow <- max(0, (scale_x - 1) * nchar(r$gene) * 6 - 4)
+    name_margin <- if (fwd) {
+      sprintf(" margin-right:%.0fpx;", name_overflow)
+    } else {
+      sprintf(" margin-left:%.0fpx;", name_overflow)
+    }
     name_span <- htmltools::tags$span(
       # Gene name, size unchanged (scale_x/scale_y only).
       style = sprintf(paste0(
         "white-space:nowrap; font-size:10px; line-height:1; color:#000; ",
-        "padding:0 2px; transform:scale(%s,%s); transform-origin:%s center;"),
-        scale_x, scale_y, if (fwd) "left" else "right"
+        "padding:0 2px; transform:scale(%s,%s); transform-origin:%s center;%s"),
+        scale_x, scale_y, if (fwd) "left" else "right", name_margin
       ),
       r$gene
     )
-    # + strand: arrow then name, left-justified, pinned to the viewport's left
-    # edge. - strand: name then arrow, right-justified, pinned to the right edge.
-    inner <- if (fwd) list(marker_span, name_span) else list(name_span, marker_span)
+    # + strand: name then arrow, left-justified, pinned to the viewport's left
+    # edge. - strand: arrow then name, right-justified, pinned to the right edge.
+    inner <- if (fwd) list(name_span, marker_span) else list(marker_span, name_span)
+    # Inset a few px so a pinned label is not flush against the scroll
+    # container's clip edge (which would shave the arrow ink).
     sticky_style <- sprintf(
-      "position:sticky; %s:0; z-index:1; display:flex; align-items:center; height:100%%; gap:4px;",
+      "position:sticky; %s:3px; z-index:1; display:flex; align-items:center; height:100%%; gap:4px;",
       if (fwd) "left" else "right"
     )
     htmltools::div(
@@ -812,7 +832,8 @@ annotations_details_server <- function(id, rv) {
         shiny::imageOutput(ns("coverage_plot"), width = paste0(img_w, "px"), height = "125px"),
         # Block = measured gene-arrow band (px 96-112 in the 125px cowplot image).
         gene_label_overlay(genes_df, img_w = img_w, x_lo = 1, x_hi = x_hi,
-                           track_top = 96, track_height = 16, scale_y = 1.6)
+                           track_top = 96, track_height = 16, scale_y = 1.6,
+                           arrow_w = 0.6)
       )
     })
     # Use renderImage + ragg::agg_png to bypass Cairo's per-dimension image
@@ -1499,10 +1520,10 @@ annotations_details_server <- function(id, rv) {
       tagList(
         gene_label_overlay(ov$sample_df, img_w = ov$plot_w, x_lo = x_lo, x_hi = x_hi,
                            track_top = 26, track_height = 16,
-                           scale_x = 1, scale_y = 1, inset = 6),
+                           scale_x = 1, scale_y = 1, inset = 6, arrow_w = 0.6),
         gene_label_overlay(ov$ref_df, img_w = ov$plot_w, x_lo = x_lo, x_hi = x_hi,
                            track_top = 151, track_height = 16,
-                           scale_x = 1, scale_y = 1, inset = 6)
+                           scale_x = 1, scale_y = 1, inset = 6, arrow_w = 0.6)
       )
     })
 

--- a/R/app_assemble.R
+++ b/R/app_assemble.R
@@ -91,6 +91,10 @@ assemble_ui <- function(id) {
     ),
     div(class = "mp-table-resize", reactableOutput(ns("table"))),
     div(
+      style = "font-size: 0.85em; color: #555; margin-top: 4px;",
+      textOutput(ns("n_selected"), inline = TRUE)
+    ),
+    div(
       style = "margin-top: 12px; display: flex; gap: 8px;",
       downloadButton(ns("export_selected"), "Export Selected to CSV",
                      class = "btn-sm btn-default"),
@@ -445,6 +449,10 @@ assemble_server <- function(id) {
       visible <- as.character(rv$data$assemble_lock)   %in% lock_filter_rv() &
                  as.character(rv$data$assemble_switch) %in% state_filter_rv()
       intersect(sel, which(visible))
+    })
+
+    output$n_selected <- renderText({
+      paste0(length(selected()), " selected")
     })
 
     # Publish current selection so the work-dir browser can pre-select this sample

--- a/R/app_assemble_userAsmb.R
+++ b/R/app_assemble_userAsmb.R
@@ -75,7 +75,11 @@ assemble_ui_userAsmb <- function(id) {
         )
       )
     ),
-    div(class = "mp-table-resize", reactableOutput(ns("table")))
+    div(class = "mp-table-resize", reactableOutput(ns("table"))),
+    div(
+      style = "font-size: 0.85em; color: #555; margin-top: 4px;",
+      textOutput(ns("n_selected"), inline = TRUE)
+    )
   )
 }
 
@@ -399,6 +403,10 @@ assemble_server_userAsmb <- function(id) {
       visible <- as.character(rv$data$assemble_lock)   %in% lock_filter_rv() &
                  as.character(rv$data$assemble_switch) %in% state_filter_rv()
       intersect(sel, which(visible))
+    })
+
+    output$n_selected <- renderText({
+      paste0(length(selected()), " selected")
     })
 
     # Publish current selection so the work-dir browser can pre-select this sample

--- a/R/app_export.R
+++ b/R/app_export.R
@@ -59,6 +59,10 @@ export_ui <- function(id) {
     ),
     div(class = "mp-table-resize", reactableOutput(ns("table"))),
     div(
+      style = "font-size: 0.85em; color: #555; margin-top: 4px;",
+      textOutput(ns("n_selected"), inline = TRUE)
+    ),
+    div(
       style = "margin-top: 12px; display: flex; gap: 8px;",
       downloadButton(ns("export_selected"), "Export Selected to CSV",
                      class = "btn-sm btn-default"),
@@ -219,6 +223,10 @@ export_server <- function(id) {
 
     # table selection ----
     selected <- reactive(reactable::getReactableState("table", "selected"))
+
+    output$n_selected <- renderText({
+      paste0(length(selected()), " selected")
+    })
 
     # Publish current selection so the work-dir browser can pre-select this sample
     observe({

--- a/R/export.R
+++ b/R/export.R
@@ -1,3 +1,12 @@
+# Map internal rRNA gene names to their export convention (rrnS -> rrn12,
+# rrnL -> rrn16). Operates on the prefix so make.unique suffixes are preserved
+# (rrnS.1 -> rrn12.1); non-rRNA names pass through unchanged.
+.export_rrna_name <- function(x) {
+  x <- sub("^rrnS", "rrn12", x)
+  x <- sub("^rrnL", "rrn16", x)
+  x
+}
+
 #' Generate export NCBI files
 #'
 #' @param group (optional) export group names
@@ -791,6 +800,9 @@ export_files <- function(
       }
 
       if (cur$type == "rRNA") {
+        # Export naming: rrnS -> rrn12, rrnL -> rrn16
+        rrna_gene      <- .export_rrna_name(cur$gene)
+        rrna_gene_uniq <- .export_rrna_name(cur$gene_uniq)
         # Manual 5'/3' partial flags: '<' prepends the start coord, '>' the stop
         # coord (pos is already strand-oriented: pos[1] = 5', pos[2] = 3').
         rrna_note <- NULL
@@ -805,7 +817,7 @@ export_files <- function(
         # write to .tbl
         paste(c(pos, "gene"), collapse = "\t") |>
           cat(file = tbl_fn, sep = "\n", append = TRUE)
-        paste0("\t\t\tgene\t", ifelse(cur$gene == "rrnS", "s-rRNA", "l-rRNA")) |>
+        paste0("\t\t\tgene\t", rrna_gene) |>
           cat(file = tbl_fn, sep = "\n", append = TRUE)
         paste(c(pos, "rRNA"), collapse = "\t") |>
           cat(file = tbl_fn, sep = "\n", append = TRUE)
@@ -818,7 +830,7 @@ export_files <- function(
 
         # write to GFF
         # rRNA feature
-        f9 = paste0("ID=rna-",seq_name,":",cur$pos1,"..",cur$pos2,";Name=",cur$gene,";gbkey=rRNA;product=",cur$product)
+        f9 = paste0("ID=rna-",seq_name,":",cur$pos1,"..",cur$pos2,";Name=",rrna_gene,";gbkey=rRNA;product=",cur$product)
         # logic to deal with annotations that wrap around the end of a circular assembly
         if(dat$topology == "circular" && cur$pos1 > cur$pos2 && cur$length != (cur$pos1 - cur$pos2 + 1)){ # annotation wraps
           pos2_fix <- asmb_len + cur$pos2
@@ -844,7 +856,7 @@ export_files <- function(
         if(gene_export){
           # EXTRACT GENE FROM ASSEMBLY
           # make directory for gene if it doesn't exist
-          group_geneName_pth <- file.path(group_pth, "genes", cur$gene)
+          group_geneName_pth <- file.path(group_pth, "genes", rrna_gene)
           dir.create(group_geneName_pth, recursive = T, showWarnings = F)
 
           # get gene region from assembly
@@ -852,7 +864,7 @@ export_files <- function(
 
           # update FASTA header with gene name
           head_split <- strsplit(fasta_header_gene, "\\s+")
-          head_split[[1]][1] <- paste0(head_split[[1]][1], "_", cur$gene_uniq)
+          head_split[[1]][1] <- paste0(head_split[[1]][1], "_", rrna_gene_uniq)
           head_split[[1]][length(head_split[[1]])] <- paste0(head_split[[1]][length(head_split[[1]])], ", ", cur$product)
           head <- paste(c(head_split[[1]]), sep=" ", collapse=" ")
           names(gene) <- stringr::str_glue_data(dat, head)
@@ -863,7 +875,7 @@ export_files <- function(
           }
 
           # write FASTA
-          gene_fn <- file.path(export_path, paste0(.x, "_", cur$gene_uniq, ".fasta"))
+          gene_fn <- file.path(export_path, paste0(.x, "_", rrna_gene_uniq, ".fasta"))
           Biostrings::writeXStringSet(gene, filepath = gene_fn)
 
           # fix the start and stop position; carry the 5'/3' partial markers
@@ -876,14 +888,14 @@ export_files <- function(
           if (isTRUE(as.integer(cur$partial_stop) == 1L)) gene_p2 <- paste0(">", gene_p2)
 
           # write gene feature table
-          gene_tbl_fn <- file.path(export_path, paste0(.x, "_", cur$gene_uniq, ".tbl"))
+          gene_tbl_fn <- file.path(export_path, paste0(.x, "_", rrna_gene_uniq, ".tbl"))
           if (file.exists(gene_tbl_fn)) {
             file.remove(gene_tbl_fn)
           }
-          cat(paste0(">Feature ", .x, "_", cur$gene_uniq), file = gene_tbl_fn, sep = "\n")
+          cat(paste0(">Feature ", .x, "_", rrna_gene_uniq), file = gene_tbl_fn, sep = "\n")
           paste(c(gene_p1, gene_p2, "gene"), collapse = "\t") |>
             cat(file = gene_tbl_fn, sep = "\n", append = TRUE)
-          paste0("\t\t\tgene\t", cur$gene_uniq) |>
+          paste0("\t\t\tgene\t", rrna_gene_uniq) |>
             cat(file = gene_tbl_fn, sep = "\n", append = TRUE)
           paste(c(gene_p1, gene_p2, "rRNA"), collapse = "\t") |>
             cat(file = gene_tbl_fn, sep = "\n", append = TRUE)
@@ -896,11 +908,11 @@ export_files <- function(
 
           # concatenate sequences and tables by gene
           if (length(group) == 1) {
-            group_gene_tbl <- file.path(group_geneName_pth, paste0(group, "_", cur$gene, ".tbl"))
+            group_gene_tbl <- file.path(group_geneName_pth, paste0(group, "_", rrna_gene, ".tbl"))
             stringr::str_glue(
               "cat {gene_tbl_fn} >> {group_gene_tbl}"
             ) |> system()
-            group_gene_fasta <- file.path(group_geneName_pth, paste0(group, "_", cur$gene, ".fasta"))
+            group_gene_fasta <- file.path(group_geneName_pth, paste0(group, "_", rrna_gene, ".fasta"))
             stringr::str_glue(
               "cat {gene_fn} >> {group_gene_fasta}"
             ) |> system()

--- a/inst/app/www/custom.js
+++ b/inst/app/www/custom.js
@@ -81,6 +81,65 @@ $( document ).ready(function(){
   });
 });
 
+// Mousewheel -> horizontal scroll for the annotate-details alignment views.
+// The coverage map and synteny PNGs sit in overflow-x:auto containers
+// (coverageDiv / syntenyScrollDiv); the MSA viewer scrolls its own
+// .biojs_msa_rheader element. Translate vertical wheel delta into horizontal
+// scroll (down = right, up = left) and suppress page scroll over these views.
+$( document ).ready(function(){
+  document.addEventListener('wheel', function(e) {
+    if (!e.target.closest) return;
+    var delta = e.deltaY;
+    if (!delta) return;
+
+    var box = e.target.closest('[id$="coverageDiv"], [id$="syntenyScrollDiv"]');
+    if (box) {
+      box.scrollLeft += delta;
+      e.preventDefault();
+      return;
+    }
+
+    var msa = e.target.closest('.msaR');
+    if (msa) {
+      var header = msa.querySelector('.biojs_msa_rheader')
+                || document.getElementsByClassName('biojs_msa_rheader')[0];
+      if (header) {
+        header.scrollLeft += delta;
+        header.dispatchEvent(new Event('scroll'));
+        e.preventDefault();
+      }
+    }
+  }, { passive: false });
+});
+
+// Add an "All" choice to the sample-table page-size dropdowns. reactable
+// (0.4.5) has no native "All", so append an option with a very large page size
+// (shows every filtered row). A MutationObserver re-adds it after reactable
+// re-renders the select.
+$( document ).ready(function(){
+  var GATED_ALL = '#assemble-table, #annotate-table, #export-table';
+  var ALL_PAGE_SIZE = 1000000;
+
+  function addAllOption(select) {
+    if (!select || select.querySelector('option[data-mp-all]')) return;
+    var opt = document.createElement('option');
+    opt.value = String(ALL_PAGE_SIZE);
+    opt.text = 'All';
+    opt.setAttribute('data-mp-all', '1');
+    select.appendChild(opt);
+  }
+
+  function refreshAllOptions() {
+    document.querySelectorAll(GATED_ALL).forEach(function(tbl) {
+      tbl.querySelectorAll('.rt-page-size-select').forEach(addAllOption);
+    });
+  }
+
+  refreshAllOptions();
+  new MutationObserver(refreshAllOptions)
+    .observe(document.body, { childList: true, subtree: true });
+});
+
 // Shift-click range selection for the main sample reactable tables.
 // reactable (0.4.5) has no native range selection, so we drive it on the
 // client: a plain click stores an "anchor" row, and a shift-click selects


### PR DESCRIPTION
# GUI quality-of-life features + rRNA export naming

  ## Summary

  This branch adds several quality-of-life improvements to the MitoPilot GUI and changes how ribosomal RNA gene names are written on export.

  ## Sample tables (Assemble / Annotate / Export, incl. user-assembly mode)

  - Added a live "N selected" counter beneath each sample table, driven by the existing reactable selection state.
  - Added an "All" option to the reactable page-size dropdowns (client-side, re-applied via a MutationObserver after reactable re-renders).

  ## Annotate details modal

  - Mousewheel now scrolls the coverage map, BLAST synteny plot, and MSA alignment horizontally (wheel down = right, up = left); page scroll is suppressed while hovering these views.
  - Added "sticky" gene-name labels overlaid on the coverage map, synteny overview plot, and zoomed synteny plot. Each visible annotation keeps its name pinned to the edge of the view while
  any part of its block is on screen, then hands off to the next gene as blocks scroll past.
  - Removed the in-plot gggenes labels (replaced by the HTML overlay), so names no longer scroll off the far left of each block.
  - Labels include a directional arrow drawn as a CSS border-triangle (pure geometry, so it cannot be clipped like a stretched text glyph): full block height, narrow, 50% opacity, medium
  gray.
  - Strand-aware layout: `+` strand shows `name` then a right-pointing arrow, left-justified and pinned to the left edge; `-` strand shows a left-pointing arrow then `name`, right-justified
  and pinned to the right edge.
  - Arrow width is configurable per plot (coverage and zoomed-in synteny use wider arrows; synteny overview uses the default).
  - Overlay label bands are aligned to measured gene-arrow pixel positions, with a fixed panel inset so labels track the plot panel across the full width, and horizontal name scaling is
  reserved as margin so names never overlap their arrow.

  ## Export

  - rRNA gene names are now written as `rrn12` (small subunit / s-rRNA / 12S) and `rrn16` (large subunit / l-rRNA / 16S) across all export artifacts: main `.tbl` gene qualifier, GFF `Name=`,
  and per-gene exports (file/directory names, per-gene `.tbl` gene qualifier, FASTA headers).
  - Internal storage, annotation, curation, and display are unchanged; this is an export-only transformation. Product fields (`12S/16S ribosomal RNA`) are unchanged, and re-import stays safe
  because `normalize_rrna()` already maps `rrn12`/`rrn16` back to `rrnS`/`rrnL`.

