### PR TITLE
Dedup BLAST reference fetch by accession at the channel level

### DIFF
--- a/inst/nextflow/modules/blast_ref_fetch.nf
+++ b/inst/nextflow/modules/blast_ref_fetch.nf
@@ -1,11 +1,15 @@
+// Fetch the NCBI reference for one accession exactly once. Cross-sample dedup is
+// done at the channel level (see blast_ref_fetch_workflow.nf): the workflow feeds
+// this process the set of UNIQUE accessions, and the per-sample fan-out / metadata
+// stamping happens downstream in blast_ref_stamp. This removes the previous
+// filesystem cache, which required a shared writable mount (the publishDir), and
+// broke on HPC setups where that path is read-only inside the container.
 process blast_ref_fetch {
 
     executor params.blast_gb.executor
     container params.blast_gb.container
 
     maxForks params.blast_gb.maxForks
-
-    publishDir "${launchDir}/${params.publishDir}", overwrite: true, pattern: "${id}/assemble/${opts_id}/blast_ref_${blast_accession}/remote_blast_ref.json", mode: 'copy'
 
     cpus { (params.blast_gb.cpus instanceof Integer) ? params.blast_gb.cpus : 1 }
     memory = (params.blast_gb.memory instanceof Number) ? "${params.blast_gb.memory}.GB" : null
@@ -17,15 +21,67 @@ process blast_ref_fetch {
         opts ?: null
     }
 
-    // 'ignore' keeps other samples running when this one times out. Failed tasks are NOT
-    // cached as successful, so -resume will re-execute this step for the affected sample.
+    // 'ignore' keeps other accessions running when this one times out. Failed tasks are
+    // NOT cached as successful, so -resume re-executes this step. A dropped accession
+    // produces no fan-out, so every sample whose top hit was that accession is flagged
+    // as a fetch failure downstream (see the all_top_ids join in the workflow).
     errorStrategy { task.attempt <= 3 ? 'retry' : 'ignore' }
     maxRetries 3
+
+    tag "${blast_accession}"
+
+    input:
+        val(blast_accession)
+
+    output:
+        tuple val(blast_accession), path("${outDir}/blast_ref_annotations.csv"), path("${outDir}/blast_ref_sequence.txt"), path("${outDir}/blast_ref_genetic_code.txt"), path("${outDir}/remote_blast_ref.json")
+
+    shell:
+    outDir = "ref_${blast_accession}"
+    '''
+    mkdir -p !{outDir}
+
+    ann="!{outDir}/blast_ref_annotations.csv"
+    seq="!{outDir}/blast_ref_sequence.txt"
+    gc="!{outDir}/blast_ref_genetic_code.txt"
+    json="!{outDir}/remote_blast_ref.json"
+
+    # Back off on retries to give NCBI EFetch time to recover from rate limits
+    if [ "!{task.attempt}" -gt 1 ]; then
+        sleep $(( (!{task.attempt} - 1) * 30 ))
+    fi
+    # Optional NCBI API key raises EFetch rate limit (3 -> 10 req/s).
+    # Read inside R via Sys.getenv("NCBI_API_KEY").
+    export NCBI_API_KEY='!{params.ncbi_api_key ?: ""}'
+    # Accession-derived data only; per-sample blast_species/blast_evalue are stamped
+    # later by blast_ref_stamp via MitoPilot::patch_blast_ref_meta.
+    Rscript -e "MitoPilot::fetch_blast_ref('!{blast_accession}', '$ann', '$seq', '$gc', '$json')"
+    '''
+}
+
+// Per-sample fan-out for one fetched accession. Copies the accession-derived files
+// into this sample's publish path and re-stamps the per-sample BLAST hit metadata
+// (blast_species, blast_evalue) onto the shared JSON. Pure local work (no network),
+// so it never hits NCBI rate limits and cannot fail an otherwise-good fetch.
+process blast_ref_stamp {
+
+    executor params.blast_gb.executor
+    container params.blast_gb.container
+
+    clusterOptions {
+        def opts = [
+            (params.blast_gb.executor == 'sge') ? '-S /bin/bash' : '',
+            (params.blast_gb.clusterOptions instanceof String) ? params.blast_gb.clusterOptions : ''
+        ].findAll { it }.join(' ')
+        opts ?: null
+    }
+
+    publishDir "${launchDir}/${params.publishDir}", overwrite: true, pattern: "${id}/assemble/${opts_id}/blast_ref_${blast_accession}/remote_blast_ref.json", mode: 'copy'
 
     tag "${id}"
 
     input:
-        tuple val(id), val(blast_accession), val(blast_species), val(blast_evalue), val(opts_id), val(is_top)
+        tuple val(id), val(blast_accession), val(blast_species), val(blast_evalue), val(opts_id), val(is_top), path(base_ann), path(base_seq), path(base_gc), path(base_json)
 
     output:
         tuple val(id), val(blast_accession), val(is_top), path("${outDir}/blast_ref_annotations.csv"), path("${outDir}/blast_ref_sequence.txt"), path("${outDir}/blast_ref_genetic_code.txt"), path("${outDir}/remote_blast_ref.json")
@@ -41,77 +97,13 @@ process blast_ref_fetch {
     gc="!{outDir}/blast_ref_genetic_code.txt"
     json="!{outDir}/remote_blast_ref.json"
 
-    # Per-accession shared cache to dedupe NCBI EFetch calls across samples whose top
-    # hit is the same accession. The fetched data is accession-derived; the only
-    # per-sample field (blast_evalue, plus blast_species) is re-stamped into the
-    # copied JSON. Concurrency: an atomic `mkdir` lock makes the first task fetch the
-    # accession while later tasks wait and then copy the cached result.
-    CACHE_DIR="!{launchDir}/!{params.publishDir}/.blast_ref_cache/!{blast_accession}"
-    DONE="$CACHE_DIR/.done"
-    LOCK="$CACHE_DIR/.lock"
-    MAX_WAIT=600   # seconds to wait for an in-progress fetch before fetching independently
-    mkdir -p "$CACHE_DIR"
+    cp "!{base_ann}"  "$ann"
+    cp "!{base_seq}"  "$seq"
+    cp "!{base_gc}"   "$gc"
+    cp "!{base_json}" "$json"
 
-    copy_from_cache() {
-        cp "$CACHE_DIR/blast_ref_annotations.csv"  "$ann" &&
-        cp "$CACHE_DIR/blast_ref_sequence.txt"     "$seq" &&
-        cp "$CACHE_DIR/blast_ref_genetic_code.txt" "$gc"  &&
-        cp "$CACHE_DIR/remote_blast_ref.json"      "$json" || return 1
-        # Re-stamp this sample's BLAST hit metadata onto the shared JSON (best-effort:
-        # a stale evalue is preferable to discarding a valid cached copy)
-        Rscript -e "MitoPilot::patch_blast_ref_meta('$json', '!{blast_species}', !{blast_evalue})" || true
-    }
-
-    # Fast path: accession already cached by a prior task / run
-    if [ -f "$DONE" ]; then
-        copy_from_cache && exit 0
-    fi
-
-    # Try to become the fetcher; otherwise wait for the in-progress fetch to finish.
-    HOLD=0
-    waited=0
-    while true; do
-        if mkdir "$LOCK" 2>/dev/null; then
-            HOLD=1
-            trap 'rmdir "$LOCK" 2>/dev/null || true' EXIT
-            break
-        fi
-        if [ -f "$DONE" ]; then
-            copy_from_cache && exit 0
-        fi
-        if [ "$waited" -ge "$MAX_WAIT" ]; then
-            # In-progress fetch did not finish in time (holder may have died);
-            # fall back to fetching independently without touching the cache.
-            break
-        fi
-        sleep 30
-        waited=$(( waited + 30 ))
-    done
-
-    # It may have completed between our last check and acquiring the lock
-    if [ -f "$DONE" ]; then
-        copy_from_cache && exit 0
-    fi
-
-    # Back off on retries to give NCBI EFetch time to recover from rate limits
-    if [ "!{task.attempt}" -gt 1 ]; then
-        sleep $(( (!{task.attempt} - 1) * 30 ))
-    fi
-    # Optional NCBI API key raises EFetch rate limit (3 -> 10 req/s).
-    # Read inside R via Sys.getenv("NCBI_API_KEY").
-    export NCBI_API_KEY='!{params.ncbi_api_key ?: ""}'
-    Rscript -e "MitoPilot::fetch_blast_ref('!{blast_accession}', '$ann', '$seq', '$gc', '$json', '!{blast_species}', !{blast_evalue})"
-
-    # Populate the cache for other samples, but only if we hold the lock. Write the
-    # data files first and the .done marker last so readers never see a partial cache.
-    # Cache population is best-effort: its failure must not fail an otherwise-good
-    # sample (|| true), and .done is only touched after all files are copied.
-    if [ "$HOLD" -eq 1 ]; then
-        { cp "$ann"  "$CACHE_DIR/blast_ref_annotations.csv"  &&
-          cp "$seq"  "$CACHE_DIR/blast_ref_sequence.txt"     &&
-          cp "$gc"   "$CACHE_DIR/blast_ref_genetic_code.txt" &&
-          cp "$json" "$CACHE_DIR/remote_blast_ref.json"      &&
-          touch "$DONE"; } || true
-    fi
+    # Stamp this sample's BLAST hit metadata onto the shared JSON (best-effort:
+    # a stale evalue is preferable to discarding a valid reference copy)
+    Rscript -e "MitoPilot::patch_blast_ref_meta('$json', '!{blast_species}', !{blast_evalue})" || true
     '''
 }

--- a/inst/nextflow/modules/blast_ref_fetch.nf
+++ b/inst/nextflow/modules/blast_ref_fetch.nf
@@ -1,11 +1,15 @@
+// Fetch the NCBI reference for one accession exactly once. Cross-sample dedup is
+// done at the channel level (see blast_ref_fetch_workflow.nf): the workflow feeds
+// this process the set of UNIQUE accessions, and the per-sample fan-out / metadata
+// stamping happens downstream in blast_ref_stamp. This removes the previous
+// filesystem cache, which required a shared writable mount (the publishDir), and
+// broke on HPC setups where that path is read-only inside the container.
 process blast_ref_fetch {
 
     executor params.blast_gb.executor
     container params.blast_gb.container
 
     maxForks params.blast_gb.maxForks
-
-    publishDir "${launchDir}/${params.publishDir}", overwrite: true, pattern: "${id}/assemble/${opts_id}/blast_ref_${blast_accession}/remote_blast_ref.json", mode: 'copy'
 
     cpus { (params.blast_gb.cpus instanceof Integer) ? params.blast_gb.cpus : 1 }
     memory = (params.blast_gb.memory instanceof Number) ? "${params.blast_gb.memory}.GB" : null
@@ -17,15 +21,67 @@ process blast_ref_fetch {
         opts ?: null
     }
 
-    // 'ignore' keeps other samples running when this one times out. Failed tasks are NOT
-    // cached as successful, so -resume will re-execute this step for the affected sample.
+    // 'ignore' keeps other accessions running when this one times out. Failed tasks are
+    // NOT cached as successful, so -resume re-executes this step. A dropped accession
+    // produces no fan-out, so every sample whose top hit was that accession is flagged
+    // as a fetch failure downstream (see the all_top_ids join in the workflow).
     errorStrategy { task.attempt <= 3 ? 'retry' : 'ignore' }
     maxRetries 3
+
+    tag "${blast_accession}"
+
+    input:
+        val(blast_accession)
+
+    output:
+        tuple val(blast_accession), path("${outDir}/blast_ref_annotations.csv"), path("${outDir}/blast_ref_sequence.txt"), path("${outDir}/blast_ref_genetic_code.txt"), path("${outDir}/remote_blast_ref.json")
+
+    shell:
+    outDir = "ref_${blast_accession}"
+    '''
+    mkdir -p !{outDir}
+
+    ann="!{outDir}/blast_ref_annotations.csv"
+    seq="!{outDir}/blast_ref_sequence.txt"
+    gc="!{outDir}/blast_ref_genetic_code.txt"
+    json="!{outDir}/remote_blast_ref.json"
+
+    # Back off on retries to give NCBI EFetch time to recover from rate limits
+    if [ "!{task.attempt}" -gt 1 ]; then
+        sleep $(( (!{task.attempt} - 1) * 30 ))
+    fi
+    # Optional NCBI API key raises EFetch rate limit (3 -> 10 req/s).
+    # Read inside R via Sys.getenv("NCBI_API_KEY").
+    export NCBI_API_KEY='!{params.ncbi_api_key ?: ""}'
+    # Accession-derived data only; per-sample blast_species/blast_evalue are stamped
+    # later by blast_ref_stamp via MitoPilot::patch_blast_ref_meta.
+    Rscript -e "MitoPilot::fetch_blast_ref('!{blast_accession}', '$ann', '$seq', '$gc', '$json')"
+    '''
+}
+
+// Per-sample fan-out for one fetched accession. Copies the accession-derived files
+// into this sample's publish path and re-stamps the per-sample BLAST hit metadata
+// (blast_species, blast_evalue) onto the shared JSON. Pure local work (no network),
+// so it never hits NCBI rate limits and cannot fail an otherwise-good fetch.
+process blast_ref_stamp {
+
+    executor params.blast_gb.executor
+    container params.blast_gb.container
+
+    clusterOptions {
+        def opts = [
+            (params.blast_gb.executor == 'sge') ? '-S /bin/bash' : '',
+            (params.blast_gb.clusterOptions instanceof String) ? params.blast_gb.clusterOptions : ''
+        ].findAll { it }.join(' ')
+        opts ?: null
+    }
+
+    publishDir "${launchDir}/${params.publishDir}", overwrite: true, pattern: "${id}/assemble/${opts_id}/blast_ref_${blast_accession}/remote_blast_ref.json", mode: 'copy'
 
     tag "${id}"
 
     input:
-        tuple val(id), val(blast_accession), val(blast_species), val(blast_evalue), val(opts_id), val(is_top)
+        tuple val(id), val(blast_accession), val(blast_species), val(blast_evalue), val(opts_id), val(is_top), path(base_ann), path(base_seq), path(base_gc), path(base_json)
 
     output:
         tuple val(id), val(blast_accession), val(is_top), path("${outDir}/blast_ref_annotations.csv"), path("${outDir}/blast_ref_sequence.txt"), path("${outDir}/blast_ref_genetic_code.txt"), path("${outDir}/remote_blast_ref.json")
@@ -41,84 +97,13 @@ process blast_ref_fetch {
     gc="!{outDir}/blast_ref_genetic_code.txt"
     json="!{outDir}/remote_blast_ref.json"
 
-    # Per-accession shared cache to dedupe NCBI EFetch calls across samples whose top
-    # hit is the same accession. The fetched data is accession-derived; the only
-    # per-sample field (blast_evalue, plus blast_species) is re-stamped into the
-    # copied JSON. Concurrency: an atomic `mkdir` lock makes the first task fetch the
-    # accession while later tasks wait and then copy the cached result.
-    CACHE_DIR="!{launchDir}/!{params.publishDir}/.blast_ref_cache/!{blast_accession}"
-    DONE="$CACHE_DIR/.done"
-    LOCK="$CACHE_DIR/.lock"
-    MAX_WAIT=600   # seconds to wait for an in-progress fetch before fetching independently
-    # The cache lives under the publishDir, which on some HPC setups is not
-    # bind-mounted writable inside the container (read-only filesystem). Treat
-    # the cache as best-effort: if we cannot create it, skip caching entirely
-    # and fetch directly into the always-writable task work dir.
-    CACHE_OK=1
-    mkdir -p "$CACHE_DIR" 2>/dev/null || CACHE_OK=0
+    cp "!{base_ann}"  "$ann"
+    cp "!{base_seq}"  "$seq"
+    cp "!{base_gc}"   "$gc"
+    cp "!{base_json}" "$json"
 
-    copy_from_cache() {
-        cp "$CACHE_DIR/blast_ref_annotations.csv"  "$ann" &&
-        cp "$CACHE_DIR/blast_ref_sequence.txt"     "$seq" &&
-        cp "$CACHE_DIR/blast_ref_genetic_code.txt" "$gc"  &&
-        cp "$CACHE_DIR/remote_blast_ref.json"      "$json" || return 1
-        # Re-stamp this sample's BLAST hit metadata onto the shared JSON (best-effort:
-        # a stale evalue is preferable to discarding a valid cached copy)
-        Rscript -e "MitoPilot::patch_blast_ref_meta('$json', '!{blast_species}', !{blast_evalue})" || true
-    }
-
-    HOLD=0
-    if [ "$CACHE_OK" -eq 1 ]; then
-        # Fast path: accession already cached by a prior task / run
-        if [ -f "$DONE" ]; then
-            copy_from_cache && exit 0
-        fi
-
-        # Try to become the fetcher; otherwise wait for the in-progress fetch to finish.
-        waited=0
-        while true; do
-            if mkdir "$LOCK" 2>/dev/null; then
-                HOLD=1
-                trap 'rmdir "$LOCK" 2>/dev/null || true' EXIT
-                break
-            fi
-            if [ -f "$DONE" ]; then
-                copy_from_cache && exit 0
-            fi
-            if [ "$waited" -ge "$MAX_WAIT" ]; then
-                # In-progress fetch did not finish in time (holder may have died);
-                # fall back to fetching independently without touching the cache.
-                break
-            fi
-            sleep 30
-            waited=$(( waited + 30 ))
-        done
-
-        # It may have completed between our last check and acquiring the lock
-        if [ -f "$DONE" ]; then
-            copy_from_cache && exit 0
-        fi
-    fi
-
-    # Back off on retries to give NCBI EFetch time to recover from rate limits
-    if [ "!{task.attempt}" -gt 1 ]; then
-        sleep $(( (!{task.attempt} - 1) * 30 ))
-    fi
-    # Optional NCBI API key raises EFetch rate limit (3 -> 10 req/s).
-    # Read inside R via Sys.getenv("NCBI_API_KEY").
-    export NCBI_API_KEY='!{params.ncbi_api_key ?: ""}'
-    Rscript -e "MitoPilot::fetch_blast_ref('!{blast_accession}', '$ann', '$seq', '$gc', '$json', '!{blast_species}', !{blast_evalue})"
-
-    # Populate the cache for other samples, but only if we hold the lock. Write the
-    # data files first and the .done marker last so readers never see a partial cache.
-    # Cache population is best-effort: its failure must not fail an otherwise-good
-    # sample (|| true), and .done is only touched after all files are copied.
-    if [ "$HOLD" -eq 1 ]; then
-        { cp "$ann"  "$CACHE_DIR/blast_ref_annotations.csv"  &&
-          cp "$seq"  "$CACHE_DIR/blast_ref_sequence.txt"     &&
-          cp "$gc"   "$CACHE_DIR/blast_ref_genetic_code.txt" &&
-          cp "$json" "$CACHE_DIR/remote_blast_ref.json"      &&
-          touch "$DONE"; } || true
-    fi
+    # Stamp this sample's BLAST hit metadata onto the shared JSON (best-effort:
+    # a stale evalue is preferable to discarding a valid reference copy)
+    Rscript -e "MitoPilot::patch_blast_ref_meta('$json', '!{blast_species}', !{blast_evalue})" || true
     '''
 }

--- a/inst/nextflow/modules/blast_ref_fetch_workflow.nf
+++ b/inst/nextflow/modules/blast_ref_fetch_workflow.nf
@@ -1,6 +1,6 @@
 import groovy.json.JsonSlurper
 
-include {blast_ref_fetch} from './blast_ref_fetch.nf'
+include {blast_ref_fetch; blast_ref_stamp} from './blast_ref_fetch.nf'
 
 // SQL fragment: assemble_notes with any segment starting at `tag` stripped
 // (and a preceding '; ' if present). Mirrors the helper in
@@ -86,7 +86,29 @@ workflow BLAST_REF_FETCH {
             .map    { id, accession, species, evalue, opts_id, is_top -> tuple(id, true) }
             .set { all_top_ids }
 
-        blast_ref_fetch(input).set { ref_out }
+        // Cross-sample dedup: fetch each unique accession from NCBI exactly once.
+        // unique() streams (emits an accession the moment its first sample arrives),
+        // so fetches start without waiting for all samples to finish remote BLAST.
+        input
+            .map { id, accession, species, evalue, opts_id, is_top -> accession }
+            .unique()
+            .set { uniq_accessions }
+
+        blast_ref_fetch(uniq_accessions).set { fetched }
+        // fetched: tuple(accession, csv_file, seq_file, gc_file, json_file)
+
+        // Fan back out to every sample sharing an accession via a per-key join. A
+        // sample waits only for ITS accession's single fetch, not for any global
+        // barrier. blast_ref_stamp does the cheap per-sample copy + metadata stamp.
+        input
+            .map { id, accession, species, evalue, opts_id, is_top ->
+                tuple(accession, id, species, evalue, opts_id, is_top) }
+            .combine(fetched, by: 0)
+            .map { accession, id, species, evalue, opts_id, is_top, csv_file, seq_file, gc_file, json_file ->
+                tuple(id, accession, species, evalue, opts_id, is_top, csv_file, seq_file, gc_file, json_file) }
+            .set { stamp_input }
+
+        blast_ref_stamp(stamp_input).set { ref_out }
         // ref_out: tuple(id, accession, is_top, csv_file, seq_file, gc_file, json_file)
 
         // Parse annotations CSV; only write for the per-ID top hit so the


### PR DESCRIPTION
# Dedup BLAST reference fetch by accession at the channel level

## Summary

WF1's `blast_ref_fetch` step was failing on every sample with `mkdir: cannot create directory '.../out': Read-only file system` (exit 1, all retries). The shared dedup cache wrote into `launchDir/<publishDir>/.blast_ref_cache`, which is not bind-mounted writable inside the Singularity container on some HPC setups, so the first `mkdir` aborted the task under `set -e`. This PR removes the filesystem cache entirely and moves cross-sample dedup into the Nextflow dataflow, which needs no shared writable mount.

This supersedes the `CACHE_OK` best-effort hotfix on `main` (commit `c449c96`): that fix kept the pipeline running by skipping the cache when the path was read-only, but every sample then fetched its accession independently. This PR restores true dedup without depending on a writable publishDir.

## What changed

- `blast_ref_fetch` now takes a single `val(blast_accession)` and runs the NCBI eutils fetch once per unique accession. No cache logic, no per-sample fields, no publishDir. Retry/backoff and `errorStrategy ignore` are unchanged.
- New `blast_ref_stamp` process does the per-sample fan-out: copies the accession-derived files into the sample's publish path and re-stamps `blast_species`/`blast_evalue` onto the JSON via `MitoPilot::patch_blast_ref_meta`. Pure local work (no network), owns the publishDir.
- `blast_ref_fetch_workflow.nf` rewired: `input.map{ accession }.unique()` feeds the fetch; `input.map{...}.combine(fetched, by: accession)` fans each fetched accession back out to every sample sharing it, then into `blast_ref_stamp`. The `ref_out` tuple shape is unchanged, so all downstream SQL writes, lineage handling, failure detection, and `ref_seq` emit are untouched.

## Behavior

- Each unique accession is fetched from eutils exactly once per run. Dedup happens in the driver via `unique()` before any task is submitted, so two samples with the same top hit can never both fetch, and the old `mkdir` lock / `.done` marker / 600s busy-wait are gone.
- No global barrier: `unique()` and `combine` stream, so fetches start as soon as the first sample for an accession clears remote BLAST, and a sample waits only for its own accession's fetch, not for all samples.
- A fetch that fails after all retries is dropped from the fan-out, so every sample whose top hit was that accession is flagged as a fetch failure by the existing `all_top_ids` join, same as before.
- On `-resume` (MitoPilot's default for reruns): already-fetched accessions are Nextflow cache hits (no eutils call), failed accessions re-execute, new accessions fetch. A new sample whose top hit is an already-fetched accession costs zero extra eutils traffic, only its cheap `blast_ref_stamp` runs.

## Behavioral change to note

Cross-run dedup now relies on Nextflow's `-resume` cache (work dir) rather than the persisted publishDir cache. A truly fresh run without `-resume`, or a resumed run whose work dir was purged (e.g. HPC scratch cleanup), will refetch. In practice MitoPilot reruns use `-resume`, so this is rarely an issue.

## Deploy

Reinstall the R package so the updated `.nf` modules land in the library. No container rebuild needed: the `.nf` shell wrappers are staged host-side, and the in-container `fetch_blast_ref` / `patch_blast_ref_meta` R code is unchanged.

## Testing

Not yet validated on a real run. Needs a WF1 run (or `-resume`) on the HPC to confirm. Local lint was not possible standalone because the workflow depends on upstream DB / nf-sqldb context.

## Merge note

Branch is based on `52af587` (before the `c449c96` hotfix). Rebasing onto current `main` is recommended so the dedup change cleanly supersedes the `CACHE_OK` edit to `blast_ref_fetch.nf`.
