### PR TITLE
Backwards-compat: regenerate .config from template + fix genetic_code type

### DIFF
--- a/R/backwards_compatibility.R
+++ b/R/backwards_compatibility.R
@@ -1,18 +1,19 @@
 #' Update old project database for backwards compatibility
 #'
-#' Update old project database for backwards compatibility.
-#' Adds "reviewed", "ID_verified", "genetic_code", and "problematic" columns to the annotate table,
-#' "start_gene" column to the annotate_opts table. Adds
-#' "assembler", "mitofinder_db", and "mitofinder" columns to the assemble_opts table.
-#' Adds "max_blast_hits" to the curate_opts table.
-#' Adds "asmbDir = 'NA'" to the .config params block
-#' and updates the container to the current MitoPilot version
-#' in the .config file.
-#' Updates the "ref_dir" and "ref_db" fields in the annotate_opts table
-#' adds these fields to the curate_opts table,
-#' and updates the curation rules in the curate_opts table.
+#' Migrates an old project's SQLite database to the current schema (adding any
+#' missing columns and tables, e.g. "reviewed"/"ID_verified"/"problematic" on
+#' annotate, "start_gene" on annotate_opts, "assembler"/"mitofinder_db"/
+#' "mitofinder" on assemble_opts, "max_blast_hits"/"ref_dir"/"ref_db" on
+#' curate_opts) and refreshes the curation rules.
 #'
-#
+#' The Nextflow `.config` is regenerated wholesale from the current built-in
+#' template for the project's executor (rather than patched line by line): the
+#' project-specific values (raw/asmb dirs, min depth, genetic code, NCBI key,
+#' queue, clusterOptions, container engine) are carried over, the container is
+#' bumped to the current MitoPilot version, and the previous `.config` is saved
+#' to a timestamped `.config.bak.<timestamp>` backup. If the executor cannot be
+#' detected the `.config` is left untouched and a warning is issued.
+#'
 #' @param path Path to the project directory (default = current working directory)
 #'
 #' @export
@@ -32,31 +33,32 @@ backwards_compatibility <- function(
 
   assemble_table <- DBI::dbReadTable(con, "assemble")
 
-  # check if .config file contains "asmbDir" parameter
+  # read .config; the .config is regenerated wholesale from the current built-in
+  # template (see migrate_config()) rather than patched line by line. Container
+  # version currency is the proxy for "config is already up to date".
   conf <- tryCatch({
     readLines(file.path(path, ".config"))
   }, error = function(e) {
     stop("Error reading .config file: ", e$message)
   })
-  asmbDir <- any(grep("asmbDir = ", conf))
-
-  # check if .config file contains "failOnIgnore = true"
-  conf <- tryCatch({
-    readLines(file.path(path, ".config"))
-  }, error = function(e) {
-    stop("Error reading .config file: ", e$message)
-  })
-  failOnIgnore <- any(grep("failOnIgnore = true", conf))
-  blast_gb_conf <- any(grepl("blast_gb", conf))
-  orffinder_conf <- any(grepl("orffinder_condaenv", conf))
-  orf_block_conf <- any(grepl("^\\s*orf \\{", conf))
-
-  # check if .config file contains latest container version
   new_container = paste0("macguigand/mitopilot:", utils::packageVersion("MitoPilot"))
-  containerVer <- any(grep(new_container, conf))
+  containerVer <- any(grep(new_container, conf, fixed = TRUE))
 
-  # check if annotate_opts or curate_params contains the ref_dir path
-  old_ref_str = ("/ref_dbs/Mitos2" %in% annotate_opts_table || any(grep("/ref_dbs/Mitos2", curate_opts_table$params)))
+  # genetic_code must be numeric: assemble.nf calls genetic_code.intValue(),
+  # which throws on a TEXT value. Older migrations stored it as TEXT.
+  genetic_code_numeric <- isTRUE(tryCatch(
+    !("text" %in% DBI::dbGetQuery(
+      con, "SELECT DISTINCT typeof(genetic_code) AS t FROM samples"
+    )$t),
+    error = function(e) TRUE
+  ))
+
+  # detect the old in-container Mitos2 ref path in the curate_opts params JSON.
+  # (Only the params JSON is a safe trigger: migration strips this exact path
+  # from params, and the replacement github-raw URL still contains the substring
+  # "/ref_dbs/Mitos2" so matching annotate_opts$ref_dir would re-fire the block
+  # on already-migrated projects.)
+  old_ref_str <- any(grepl("/ref_dbs/Mitos2", curate_opts_table$params))
 
   # the pre-{completeness} default export header, for detecting unmodified templates
   old_export_default <- sub("{completeness}", "complete genome",
@@ -68,10 +70,8 @@ backwards_compatibility <- function(
     error = function(e) TRUE
   )
 
-  if (asmbDir &&
-      failOnIgnore &&
-      blast_gb_conf &&
-      containerVer &&
+  if (containerVer &&
+      genetic_code_numeric &&
       !old_ref_str &&
       "arwen_opts" %in% names(annotate_opts_table) &&
       "use_arwen" %in% names(annotate_opts_table) &&
@@ -112,8 +112,6 @@ backwards_compatibility <- function(
       )) &&
       "orf_opts" %in% names(annotate_table) &&
       "orf_opts" %in% DBI::dbListTables(con) &&
-      orffinder_conf &&
-      orf_block_conf &&
       "assembly_blast" %in% DBI::dbListTables(con) &&
       "edit_positions" %in% DBI::dbListFields(con, "assemblies") &&
       isTRUE(tryCatch(
@@ -137,8 +135,10 @@ backwards_compatibility <- function(
     # update annotate ref_dir path
     annotate_opts_table$ref_dir <- rep("https://raw.githubusercontent.com/Smithsonian/MitoPilot/refs/heads/main/ref_dbs/Mitos2",
                                        nrow(annotate_opts_table))
-    # update annotate ref_db name
-    if("Metazoa" %in% annotate_opts_table){
+    # update annotate ref_db name (exact match on the ref_db column; the prior
+    # `%in% annotate_opts_table` compared against deparsed columns and never hit)
+    if("ref_db" %in% names(annotate_opts_table) &&
+       "Metazoa" %in% annotate_opts_table$ref_db){
       annotate_opts_table[which(annotate_opts_table$ref_db == "Metazoa"),]$ref_db <- "Metazoa_RefSeq89"
     }
     # update the annotate_opts table
@@ -187,101 +187,18 @@ backwards_compatibility <- function(
       )
   }
 
-  # update the Docker/Singularity container version to match the current package version
-  if(!(containerVer)){
-    conf <- readLines(file.path(path, ".config"))
-    # update the container version in the .config
-    container_index <- grep("container = .*mitopilot.*", conf)
-    if (length(container_index) == 1) {
-      conf[container_index] <- paste0("  container = \'", new_container, "\'")
-    } else {
-      stop("Container not found or multiple containers specificed in Nextflow .config")
-    }
-    message("updated container version in nextflow .config file")
-    writeLines(conf, file.path(path, ".config"))
-  }
-
-  # if .config does not contain "asmbDir" param, add it
-  if(!(asmbDir)){
-    conf <- readLines(file.path(path, ".config"))
-    message("added \"asmbDir = 'NA'\" to nextflow .config file")
-    rawDir_line <- grep("rawDir", conf) # find line containing "rawDir"
-    conf <- append(conf, "    asmbDir = 'NA'", after = rawDir_line) # add new line to conf after "rawDir" line
-    writeLines(conf, file.path(path, ".config"))
-  }
-
-  # if .config does not contain "failOnIgnore = true" param, add it
-  if(!(failOnIgnore)){
-    conf <- readLines(file.path(path, ".config"))
-    message("added \"failOnIgnore = true\" to nextflow .config file")
-    lines <- c("// pipeline will exit with a non-zero exit code if any failed tasks are ignored using the ignore error strategy",
-               "workflow {",
-               "  failOnIgnore = true",
-               "}")
-    conf <- append(conf, lines)
-    writeLines(conf, file.path(path, ".config"))
-  }
-
-  # if .config does not contain "orffinder_condaenv" param, add it. Anchor after
-  # the last *_condaenv line if present, otherwise just inside the params block.
-  if(!(orffinder_conf)){
-    conf <- readLines(file.path(path, ".config"))
-    anchor <- grep("_condaenv", conf)
-    anchor <- if (length(anchor) > 0) max(anchor) else grep("^\\s*params \\{", conf)[1]
-    if (length(anchor) == 1 && !is.na(anchor)) {
-      conf <- append(conf, "    orffinder_condaenv = 'orffinder'", after = anchor)
-      message("added \"orffinder_condaenv = 'orffinder'\" to nextflow .config file")
-      writeLines(conf, file.path(path, ".config"))
-    }
-  }
-
-  # if .config does not contain an "orf { }" process block, add one. Mirror the
-  # curate block when present (to inherit clusterOptions); otherwise insert a
-  # minimal block inside the params section.
-  if(!(orf_block_conf)){
-    conf <- readLines(file.path(path, ".config"))
-    cur_start <- grep("^\\s*curate \\{", conf)
-    if (length(cur_start) >= 1) {
-      cur_start <- cur_start[1]
-      cur_end <- cur_start
-      for (j in (cur_start + 1):length(conf)) {
-        if (grepl("^\\s*\\}", conf[j])) {
-          cur_end <- j
-          break
-        }
-      }
-      block <- conf[cur_start:cur_end]
-      block[1] <- sub("curate", "orf", block[1])
-      conf <- append(conf, block, after = cur_end)
-      message("added \"orf { }\" process block to nextflow .config file")
-      writeLines(conf, file.path(path, ".config"))
-    } else {
-      params_line <- grep("^\\s*params \\{", conf)[1]
-      if (!is.na(params_line)) {
-        block <- c(
-          "    orf {",
-          "        container = process.container",
-          "        executor = process.executor",
-          "    }"
-        )
-        conf <- append(conf, block, after = params_line)
-        message("added \"orf { }\" process block to nextflow .config file")
-        writeLines(conf, file.path(path, ".config"))
-      }
-    }
-  }
+  # NOTE: the .config is regenerated from the current built-in template at the
+  # end of this function (see migrate_config()), which adds asmbDir, failOnIgnore,
+  # the orffinder_condaenv param, the orf { } process block, blast_gb, and bumps
+  # the container version in one pass.
 
   # if genetic_code column doesn't exist, add it
   if(!("genetic_code" %in% names(samples_table))){
     message("added 'genetic_code' column to samples table")
-    samples_table$genetic_code <- rep("2", nrow(samples_table)) # add genetic_code column
-    # add new columns to database
-    glue::glue_sql(
-      "ALTER TABLE samples
-       ADD COLUMN genetic_code TEXT",
-      col = col,
-      .con = con
-    ) |> DBI::dbExecute(con, statement = _)
+    # store as INTEGER so assemble.nf's genetic_code.intValue() works (fresh
+    # projects store a number here; a TEXT value crashes assembly).
+    samples_table$genetic_code <- rep(2L, nrow(samples_table)) # add genetic_code column
+    DBI::dbExecute(con, "ALTER TABLE samples ADD COLUMN genetic_code INTEGER")
 
     dplyr::tbl(con, "samples") |> # update SQL database
       dplyr::rows_upsert(
@@ -290,6 +207,20 @@ backwards_compatibility <- function(
         copy = TRUE,
         by = "ID"
       )
+  }
+
+  # normalize any legacy TEXT genetic_code to INTEGER (idempotent). Projects
+  # migrated by older versions declared the column as TEXT, whose TEXT affinity
+  # stores values as strings and crashes the assemble step (assemble.nf calls
+  # genetic_code.intValue()). A plain UPDATE/CAST is not enough: the TEXT
+  # affinity coerces the result straight back to text, so the column itself must
+  # be rebuilt with INTEGER affinity.
+  if (!genetic_code_numeric) {
+    message("rebuilt TEXT 'genetic_code' column in samples table as integer")
+    DBI::dbExecute(con, "ALTER TABLE samples RENAME COLUMN genetic_code TO genetic_code_old")
+    DBI::dbExecute(con, "ALTER TABLE samples ADD COLUMN genetic_code INTEGER")
+    DBI::dbExecute(con, "UPDATE samples SET genetic_code = CAST(genetic_code_old AS INTEGER)")
+    DBI::dbExecute(con, "ALTER TABLE samples DROP COLUMN genetic_code_old")
   }
 
   # if poor_blast_ref column doesn't exist on assemble, add it (TEXT: good/poor/failed/NULL)
@@ -358,7 +289,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate
        ADD COLUMN reviewed TEXT",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -378,7 +308,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate
        ADD COLUMN ID_verified TEXT",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -398,7 +327,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate
        ADD COLUMN problematic TEXT",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -417,7 +345,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate
        ADD COLUMN partial TEXT",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -452,7 +379,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN use_arwen INTEGER",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -472,7 +398,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN arwen_opts TEXT",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -492,7 +417,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN use_mitos_best INTEGER",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -512,7 +436,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN use_mitos INTEGER",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -532,7 +455,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN use_trnaScan INTEGER",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -552,7 +474,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN use_aragorn INTEGER",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -572,7 +493,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN aragorn_opts TEXT",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -592,7 +512,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN use_mitofinder INTEGER",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -612,7 +531,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN mitofinder_db TEXT",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -632,7 +550,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN mitofinder_new_genes INTEGER",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -652,7 +569,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN mitofinder_allow_introns INTEGER",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -672,7 +588,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN mitofinder_opts TEXT",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -692,7 +607,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN coverage_trim INTEGER",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
     dplyr::tbl(con, "annotate_opts") |>
@@ -711,7 +625,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN feature_trim INTEGER",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
     dplyr::tbl(con, "annotate_opts") |>
@@ -730,7 +643,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN retain_low_conf_trna INTEGER",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
     dplyr::tbl(con, "annotate_opts") |>
@@ -825,7 +737,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE annotate_opts
        ADD COLUMN start_gene TEXT",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -846,7 +757,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE curate_opts
        ADD COLUMN max_blast_hits INTEGER",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -867,7 +777,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE curate_opts
        ADD COLUMN ref_dir TEXT",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -888,7 +797,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE curate_opts
        ADD COLUMN ref_db TEXT",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -909,7 +817,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE assemble_opts
        ADD COLUMN assembler TEXT",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -931,7 +838,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE assemble_opts
        ADD COLUMN mitofinder_db TEXT",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -953,7 +859,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE assemble_opts
        ADD COLUMN mitofinder TEXT",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -973,7 +878,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE assemble_opts
        ADD COLUMN max_paths INTEGER",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -993,7 +897,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE assemble_opts
        ADD COLUMN max_scaffolds INTEGER",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -1013,7 +916,6 @@ backwards_compatibility <- function(
     glue::glue_sql(
       "ALTER TABLE assemble_opts
        ADD COLUMN min_assembly_length INTEGER",
-      col = col,
       .con = con
     ) |> DBI::dbExecute(con, statement = _)
 
@@ -1231,22 +1133,11 @@ backwards_compatibility <- function(
     )
   }
 
-  # if .config does not contain "blast_gb" params section, add it
-  if (!blast_gb_conf) {
-    conf <- readLines(file.path(path, ".config"))
-    message("added 'blast_gb' section to nextflow .config file")
-    blast_gb_lines <- c(
-      "    blast_gb {",
-      "        cpus = 1",
-      "        maxForks = 10 // only allow 10 concurrent BLAST/ref-fetch runs to avoid NCBI timeout issues",
-      "        container = process.container",
-      "        executor = process.executor",
-      "    }"
-    )
-    # Insert after the last nested closing brace (end of the validate block)
-    last_nested_close <- max(grep("^    }$", conf))
-    conf <- append(conf, blast_gb_lines, after = last_nested_close)
-    writeLines(conf, file.path(path, ".config"))
+  # Regenerate the .config from the current built-in template (detect executor,
+  # port project values, bump container, back up the old config). Gated on the
+  # container being stale so an already-current config is left alone.
+  if (!containerVer) {
+    migrate_config(path, con)
   }
 
 }

--- a/R/backwards_compatibility.R
+++ b/R/backwards_compatibility.R
@@ -15,11 +15,15 @@
 #' detected the `.config` is left untouched and a warning is issued.
 #'
 #' @param path Path to the project directory (default = current working directory)
+#' @param update_config Regenerate the Nextflow `.config` from the current
+#'   built-in template (default `TRUE`). Set to `FALSE` to migrate only the
+#'   SQLite database and leave the existing `.config` untouched.
 #'
 #' @export
 #'
 backwards_compatibility <- function(
-    path = "."
+    path = ".",
+    update_config = TRUE
 ){
   # update SQL database with "reviewed" column for annotations table
   con <- DBI::dbConnect(RSQLite::SQLite(), dbname = file.path(path, ".sqlite")) # open connection
@@ -70,7 +74,7 @@ backwards_compatibility <- function(
     error = function(e) TRUE
   )
 
-  if (containerVer &&
+  if ((!update_config || containerVer) &&
       genetic_code_numeric &&
       !old_ref_str &&
       "arwen_opts" %in% names(annotate_opts_table) &&
@@ -1135,8 +1139,9 @@ backwards_compatibility <- function(
 
   # Regenerate the .config from the current built-in template (detect executor,
   # port project values, bump container, back up the old config). Gated on the
-  # container being stale so an already-current config is left alone.
-  if (!containerVer) {
+  # container being stale so an already-current config is left alone, and on the
+  # caller opting in (default on).
+  if (update_config && !containerVer) {
     migrate_config(path, con)
   }
 

--- a/R/generate_config.R
+++ b/R/generate_config.R
@@ -57,6 +57,161 @@ fill_config <- function(lines, replacements) {
   lines
 }
 
+#' Pull a single `key = value` setting out of an existing .config
+#'
+#' Matches the first `key = value` line (value may be quoted or bare),
+#' strips a trailing `// comment` and surrounding quotes.
+#'
+#' @return The value as a string, or `NULL` if absent / empty.
+#' @noRd
+config_get_param <- function(lines, key) {
+  pat <- paste0("^\\s*", key, "\\s*=\\s*(.*)$")
+  hit <- grep(pat, lines, value = TRUE)
+  if (length(hit) == 0) return(NULL)
+  val <- sub(pat, "\\1", hit[1])
+  val <- sub("//.*$", "", val)            # strip trailing comment
+  val <- trimws(val)
+  val <- gsub("^['\"]|['\"]$", "", val)   # strip surrounding quotes
+  if (nzchar(val)) val else NULL
+}
+
+#' Reconstruct the container-engine block from an existing .config
+#'
+#' Finds the first enabled `docker`/`singularity`/`apptainer` block and rebuilds
+#' it (preserving cacheDir / runOptions) via [container_engine_block()]. Falls
+#' back to a plain `singularity { enabled = true }` block (the HPC default).
+#'
+#' @param lines Character vector of the old .config.
+#' @return A single string for the `<<CONTAINER_ENGINE>>` placeholder.
+#' @noRd
+extract_container_engine <- function(lines) {
+  for (eng in c("singularity", "apptainer", "docker")) {
+    start <- grep(paste0("^\\s*", eng, "\\s*\\{"), lines)
+    if (length(start) == 0) next
+    start <- start[1]
+    end <- length(lines)
+    for (j in (start + 1):length(lines)) {
+      if (grepl("^\\s*\\}", lines[j])) { end <- j; break }
+    }
+    block <- lines[start:end]
+    if (!any(grepl("enabled\\s*=\\s*true", block))) next
+    cache <- config_get_param(block, "cacheDir")
+    run_options <- config_get_param(block, "runOptions")
+    return(container_engine_block(eng, cache, run_options))
+  }
+  container_engine_block("singularity")
+}
+
+#' Regenerate a project's .config from the current built-in template
+#'
+#' Backwards-compatibility helper. Rather than patch an old `.config` line by
+#' line, this detects the executor from the existing config, regenerates a fresh
+#' config from the matching built-in template (so every current section is
+#' present), then ports the project-specific values across (raw/asmb dirs, min
+#' depth, genetic code, NCBI key, queue, clusterOptions, container engine). The
+#' container is bumped to the current package version. The old config is backed
+#' up to a timestamped `.config.bak.<ts>` before the new one is written.
+#'
+#' If the executor cannot be detected, or regeneration would leave unfilled
+#' placeholders, the old config is left untouched and a warning is issued.
+#'
+#' @param path Project directory containing `.config`.
+#' @param con Optional open DB connection, used to default `genetic_code` from
+#'   the samples table when the old config does not set it.
+#'
+#' @return (invisibly) `TRUE` if the config was regenerated, `FALSE` otherwise.
+#' @noRd
+migrate_config <- function(path, con = NULL) {
+  conf_path <- file.path(path, ".config")
+  old <- readLines(conf_path)
+
+  # Detect executor: a quoted literal (ignores `executor = process.executor`).
+  hits <- regmatches(
+    old, regexpr("executor\\s*=\\s*['\"][A-Za-z0-9_]+['\"]", old)
+  )
+  exec <- if (length(hits) > 0) {
+    sub(".*['\"]([A-Za-z0-9_]+)['\"].*", "\\1", hits[1])
+  } else {
+    NA_character_
+  }
+  builtin <- c("local", "slurm", "sge", "pbs", "lsf", "awsbatch")
+  if (is.na(exec) || !(exec %in% builtin)) {
+    warning(
+      "Could not detect a known executor in .config; leaving .config unchanged. ",
+      "Regenerate it manually with new_project(..., force = TRUE) if needed.",
+      call. = FALSE
+    )
+    return(invisible(FALSE))
+  }
+
+  template <- app_sys(paste0("config.", exec))
+  if (!nzchar(template) || !file.exists(template)) {
+    warning("No built-in template for executor '", exec,
+            "'; leaving .config unchanged.", call. = FALSE)
+    return(invisible(FALSE))
+  }
+  lines <- readLines(template)
+
+  # Port project-specific values from the old config ----
+  raw_dir   <- config_get_param(old, "rawDir")
+  asmb_dir  <- config_get_param(old, "asmbDir") %||% "NA"
+  min_depth <- config_get_param(old, "minDepth")
+  gcode     <- config_get_param(old, "genetic_code")
+  api_key   <- config_get_param(old, "ncbi_api_key")
+  queue     <- config_get_param(old, "queue")
+  cluster_options <- config_get_param(old, "clusterOptions")
+
+  # Default genetic_code from the (already-migrated) samples table if absent.
+  if (is.null(gcode) && !is.null(con)) {
+    gcode <- tryCatch({
+      v <- DBI::dbGetQuery(
+        con,
+        "SELECT genetic_code FROM samples WHERE genetic_code IS NOT NULL LIMIT 1"
+      )$genetic_code
+      if (length(v) == 1) as.character(as.integer(v)) else NULL
+    }, error = function(e) NULL)
+  }
+
+  engine_repl <- NULL
+  if (any(grepl("<<CONTAINER_ENGINE>>", lines, fixed = TRUE))) {
+    engine_repl <- extract_container_engine(old)
+  }
+
+  new_container <- paste0("macguigand/mitopilot:", utils::packageVersion("MitoPilot"))
+
+  # Drop the queue directive if the old config had no queue (mirror generate_config).
+  if (is.null(queue)) {
+    lines <- lines[!grepl("<<QUEUE>>", lines, fixed = TRUE)]
+  }
+
+  lines <- fill_config(lines, list(
+    CONTAINER_ID     = new_container,
+    RAW_DIR          = raw_dir %||% "NA",
+    ASMB_DIR         = asmb_dir,
+    MIN_DEPTH        = min_depth %||% "2000000",
+    GENETIC_CODE     = gcode %||% "2",
+    NCBI_API_KEY     = api_key %||% "",
+    QUEUE            = queue,
+    CLUSTER_OPTIONS  = cluster_options %||% "",
+    CONTAINER_ENGINE = engine_repl
+  ))
+
+  # Fail safe: never write a config that still has unfilled placeholders.
+  if (any(grepl("<<[A-Z_]+>>", lines))) {
+    warning("Config regeneration left unfilled placeholders; leaving .config unchanged.",
+            call. = FALSE)
+    return(invisible(FALSE))
+  }
+
+  ts <- format(Sys.time(), "%Y%m%d-%H%M%S")
+  backup <- file.path(path, paste0(".config.bak.", ts))
+  file.copy(conf_path, backup, overwrite = FALSE)
+  writeLines(lines, conf_path)
+  message("regenerated .config from built-in '", exec,
+          "' template (old config backed up to ", basename(backup), ")")
+  invisible(TRUE)
+}
+
 #' Resolve an executor name to a config template path
 #'
 #' Resolution order: a saved user profile (`<profile_dir>/config.<executor>`)

--- a/man/backwards_compatibility.Rd
+++ b/man/backwards_compatibility.Rd
@@ -4,10 +4,14 @@
 \alias{backwards_compatibility}
 \title{Update old project database for backwards compatibility}
 \usage{
-backwards_compatibility(path = ".")
+backwards_compatibility(path = ".", update_config = TRUE)
 }
 \arguments{
 \item{path}{Path to the project directory (default = current working directory)}
+
+\item{update_config}{Regenerate the Nextflow `.config` from the current
+built-in template (default `TRUE`). Set to `FALSE` to migrate only the
+SQLite database and leave the existing `.config` untouched.}
 }
 \description{
 Migrates an old project's SQLite database to the current schema (adding any

--- a/man/backwards_compatibility.Rd
+++ b/man/backwards_compatibility.Rd
@@ -10,15 +10,18 @@ backwards_compatibility(path = ".")
 \item{path}{Path to the project directory (default = current working directory)}
 }
 \description{
-Update old project database for backwards compatibility.
-Adds "reviewed", "ID_verified", "genetic_code", and "problematic" columns to the annotate table,
-"start_gene" column to the annotate_opts table. Adds
-"assembler", "mitofinder_db", and "mitofinder" columns to the assemble_opts table.
-Adds "max_blast_hits" to the curate_opts table.
-Adds "asmbDir = 'NA'" to the .config params block
-and updates the container to the current MitoPilot version
-in the .config file.
-Updates the "ref_dir" and "ref_db" fields in the annotate_opts table
-adds these fields to the curate_opts table,
-and updates the curation rules in the curate_opts table.
+Migrates an old project's SQLite database to the current schema (adding any
+missing columns and tables, e.g. "reviewed"/"ID_verified"/"problematic" on
+annotate, "start_gene" on annotate_opts, "assembler"/"mitofinder_db"/
+"mitofinder" on assemble_opts, "max_blast_hits"/"ref_dir"/"ref_db" on
+curate_opts) and refreshes the curation rules.
+}
+\details{
+The Nextflow `.config` is regenerated wholesale from the current built-in
+template for the project's executor (rather than patched line by line): the
+project-specific values (raw/asmb dirs, min depth, genetic code, NCBI key,
+queue, clusterOptions, container engine) are carried over, the container is
+bumped to the current MitoPilot version, and the previous `.config` is saved
+to a timestamped `.config.bak.<timestamp>` backup. If the executor cannot be
+detected the `.config` is left untouched and a warning is issued.
 }

--- a/tests/testthat/test-backwards-compatibility.R
+++ b/tests/testthat/test-backwards-compatibility.R
@@ -471,6 +471,30 @@ test_that("backwards_compatibility migrates the old Mitos2 ref path (and is idem
 })
 
 
+test_that("backwards_compatibility(update_config = FALSE) migrates DB but not .config", {
+  td <- tempfile()
+  dir.create(td)
+  on.exit(unlink(td, recursive = TRUE))
+
+  create_v100_db(td)
+  make_config(td, version = "1.0.0")
+  before <- readLines(file.path(td, ".config"))
+
+  suppressMessages(MitoPilot::backwards_compatibility(path = td, update_config = FALSE))
+
+  # .config untouched, no backup written
+  expect_identical(readLines(file.path(td, ".config")), before)
+  expect_equal(length(list.files(td, pattern = "^\\.config\\.bak\\.", all.files = TRUE)), 0L)
+
+  # DB still migrated
+  con <- DBI::dbConnect(RSQLite::SQLite(), file.path(td, ".sqlite"))
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  expect_cols(con, "annotate", c("reviewed", "ID_verified", "problematic"))
+  expect_false("text" %in%
+    DBI::dbGetQuery(con, "SELECT DISTINCT typeof(genetic_code) AS t FROM samples")$t)
+})
+
+
 test_that("migrate_config leaves .config untouched when executor is undetectable", {
   td <- tempfile()
   dir.create(td)

--- a/tests/testthat/test-backwards-compatibility.R
+++ b/tests/testthat/test-backwards-compatibility.R
@@ -17,6 +17,7 @@ make_config <- function(path, version, has_asmb_dir = FALSE,
   process_block <- c(
     "",
     "process {",
+    "    executor = 'local'",
     paste0("    container = 'macguigand/mitopilot:", version, "'"),
     "    withName:getOrganelle {",
     "        cpus = 4",
@@ -339,4 +340,151 @@ test_that("backwards_compatibility is idempotent (early-exit on already-current 
     MitoPilot::backwards_compatibility(path = td),
     regexp = "nothing to update"
   )
+})
+
+
+test_that("backwards_compatibility stores genetic_code as a number (not TEXT)", {
+  td <- tempfile()
+  dir.create(td)
+  on.exit(unlink(td, recursive = TRUE))
+
+  # v1.0.0 has no genetic_code column; migration must add it as a number so
+  # assemble.nf's genetic_code.intValue() works.
+  create_v100_db(td)
+  make_config(td, version = "1.0.0")
+  suppressMessages(MitoPilot::backwards_compatibility(path = td))
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), file.path(td, ".sqlite"))
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  types <- DBI::dbGetQuery(con, "SELECT DISTINCT typeof(genetic_code) AS t FROM samples")$t
+  expect_false("text" %in% types)
+})
+
+
+test_that("backwards_compatibility normalizes legacy TEXT genetic_code on re-run", {
+  td <- tempfile()
+  dir.create(td)
+  on.exit(unlink(td, recursive = TRUE))
+
+  # Bring a v1.3.10 DB (genetic_code stored as TEXT) up to current.
+  create_v1310_db(td)
+  make_config(td, version = "1.3.10",
+              has_asmb_dir = TRUE, has_fail_on_ignore = TRUE)
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), file.path(td, ".sqlite"))
+  # confirm the fixture really stores it as TEXT
+  expect_true("text" %in%
+    DBI::dbGetQuery(con, "SELECT DISTINCT typeof(genetic_code) AS t FROM samples")$t)
+  DBI::dbDisconnect(con)
+
+  suppressMessages(MitoPilot::backwards_compatibility(path = td))
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), file.path(td, ".sqlite"))
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  types <- DBI::dbGetQuery(con, "SELECT DISTINCT typeof(genetic_code) AS t FROM samples")$t
+  expect_false("text" %in% types)
+  # value preserved
+  expect_equal(DBI::dbGetQuery(con, "SELECT genetic_code FROM samples")$genetic_code, 2L)
+})
+
+
+test_that("backwards_compatibility regenerates .config and backs up the old one", {
+  td <- tempfile()
+  dir.create(td)
+  on.exit(unlink(td, recursive = TRUE))
+
+  create_v100_db(td)
+  make_config(td, version = "1.0.0")  # process executor = 'local', rawDir = 'raw'
+
+  suppressMessages(MitoPilot::backwards_compatibility(path = td))
+
+  conf <- readLines(file.path(td, ".config"))
+  # regenerated from the built-in local template: current sections present
+  expect_true(any(grepl("orffinder_condaenv", conf)))
+  expect_true(any(grepl("^\\s*orf \\{", conf)))
+  expect_true(any(grepl("blast_gb", conf)))
+  expect_true(any(grepl("failOnIgnore", conf)))
+  # project value carried over from the old config
+  expect_true(any(grepl("rawDir = 'raw'", conf, fixed = TRUE)))
+  # container bumped to current version
+  current_ver <- as.character(utils::packageVersion("MitoPilot"))
+  expect_true(any(grepl(current_ver, conf, fixed = TRUE)))
+
+  # timestamped backup of the old config was written
+  backups <- list.files(td, pattern = "^\\.config\\.bak\\.", all.files = TRUE)
+  expect_true(length(backups) >= 1)
+})
+
+
+# Helper: a DB carrying the old in-container Mitos2 ref path (triggers the
+# old_ref_str branch). annotate_opts has ref_db="Metazoa"/ref_dir=old path;
+# curate_opts params embed the old path and the table lacks ref_dir/ref_db.
+create_old_ref_db <- function(path) {
+  con <- DBI::dbConnect(RSQLite::SQLite(), file.path(path, ".sqlite"))
+  on.exit(DBI::dbDisconnect(con))
+
+  DBI::dbExecute(con, "CREATE TABLE samples (ID TEXT NOT NULL PRIMARY KEY, sample TEXT, genetic_code INTEGER)")
+  DBI::dbExecute(con, "INSERT INTO samples VALUES ('s1', 'Sample1', 2)")
+  DBI::dbExecute(con, "CREATE TABLE annotate (ID TEXT NOT NULL PRIMARY KEY, gene TEXT)")
+  DBI::dbExecute(con, "INSERT INTO annotate VALUES ('s1', 'cox1')")
+  DBI::dbExecute(con, "CREATE TABLE assemble (ID TEXT NOT NULL PRIMARY KEY, assembly TEXT)")
+  DBI::dbExecute(con, "INSERT INTO assemble VALUES ('s1', 'ATCG')")
+  DBI::dbExecute(con, "CREATE TABLE assemble_opts (assemble_opts TEXT NOT NULL PRIMARY KEY, params TEXT)")
+  DBI::dbExecute(con, "INSERT INTO assemble_opts VALUES ('default', '{}')")
+  DBI::dbExecute(con, "CREATE TABLE annotate_opts (annotate_opts TEXT NOT NULL PRIMARY KEY, params TEXT, ref_db TEXT, ref_dir TEXT)")
+  DBI::dbExecute(con, "INSERT INTO annotate_opts VALUES ('default', '{}', 'Metazoa', '/ref_dbs/Mitos2')")
+  DBI::dbExecute(con, "CREATE TABLE curate_opts (curate_opts TEXT NOT NULL PRIMARY KEY, params TEXT)")
+  DBI::dbExecute(con, "INSERT INTO curate_opts VALUES ('default', '{\"ref_dbs\":{\"default\":[\"/ref_dbs/Mitos2/Metazoa/featureProt/{gene}.fas\"]},\"max_blast_hits\":100}')")
+  DBI::dbExecute(con, "CREATE TABLE annotations (ID TEXT NOT NULL, gene TEXT NOT NULL, PRIMARY KEY (ID, gene))")
+  DBI::dbExecute(con, "INSERT INTO annotations VALUES ('s1', 'cox1')")
+}
+
+
+test_that("backwards_compatibility migrates the old Mitos2 ref path (and is idempotent)", {
+  td <- tempfile()
+  dir.create(td)
+  on.exit(unlink(td, recursive = TRUE))
+
+  create_old_ref_db(td)
+  make_config(td, version = "1.0.0")
+
+  suppressMessages(MitoPilot::backwards_compatibility(path = td))
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), file.path(td, ".sqlite"))
+  ao <- DBI::dbReadTable(con, "annotate_opts")
+  co <- DBI::dbReadTable(con, "curate_opts")
+  # annotate_opts ref_db renamed (the previously-dead %in% check) and ref_dir bumped
+  expect_equal(ao$ref_db, "Metazoa_RefSeq89")
+  expect_match(ao$ref_dir, "githubusercontent")
+  # curate_opts gained ref_dir/ref_db and the old path was stripped from params
+  expect_true(all(c("ref_dir", "ref_db") %in% names(co)))
+  expect_equal(co$ref_db, "Metazoa_RefSeq89")
+  expect_false(grepl("/ref_dbs/Mitos2/Metazoa", co$params))
+  DBI::dbDisconnect(con)
+
+  # Re-run must not re-fire the block (no duplicate-column ALTER crash)
+  expect_message(
+    MitoPilot::backwards_compatibility(path = td),
+    regexp = "nothing to update"
+  )
+})
+
+
+test_that("migrate_config leaves .config untouched when executor is undetectable", {
+  td <- tempfile()
+  dir.create(td)
+  on.exit(unlink(td, recursive = TRUE))
+
+  # config with no recognizable `executor = '<name>'` literal
+  writeLines(c("params {", "    rawDir = 'raw'", "}"), file.path(td, ".config"))
+  before <- readLines(file.path(td, ".config"))
+
+  expect_warning(
+    res <- MitoPilot:::migrate_config(td),
+    regexp = "executor"
+  )
+  expect_false(res)
+  expect_identical(readLines(file.path(td, ".config")), before)
+  expect_equal(length(list.files(td, pattern = "^\\.config\\.bak\\.", all.files = TRUE)), 0L)
 })


### PR DESCRIPTION
## Summary

Reworks `backwards_compatibility()` config handling and fixes a migrated-project assembly crash.

### Config: regenerate instead of patch line-by-line
- New `migrate_config()` helper (in `generate_config.R`): detects the executor from the old `.config`, regenerates a fresh config from the current built-in template (so every current section, `orf`/`orffinder_condaenv`/`blast_gb`/`failOnIgnore`/etc., appears in one pass), then **ports project-specific values** over: raw/asmb dirs, min depth, genetic code, NCBI key, queue, clusterOptions, and the container-engine block (singularity/apptainer/docker incl. `cacheDir`/`runOptions`). Container is bumped to the current version.
- Old config is backed up to a **timestamped `.config.bak.<ts>`** and the user is notified.
- **Fail-safe:** if the executor can't be detected, or a `<<TOKEN>>` would be left unfilled, the `.config` is left untouched and a warning is issued.
- Replaces ~6 fragile line-by-line patch blocks (asmbDir, failOnIgnore, container bump, orffinder_condaenv, orf block, blast_gb).

### Fix: `samples.genetic_code` TEXT → numeric (assembly crash)
`assemble.nf` calls `genetic_code.intValue()`, which works on an Integer but throws on a String. Fresh projects store a number; the migration was adding/declaring `genetic_code` as `TEXT`, so **migrated projects crashed at assembly** while fresh ones never did. Now:
- add-column path uses `INTEGER`, and
- legacy `TEXT` columns are **rebuilt** to INTEGER affinity (a plain `CAST` is coerced right back to text by the column's TEXT affinity).

### `update_config` toggle
`backwards_compatibility(update_config = TRUE)` (default) regenerates the config; `update_config = FALSE` migrates only the SQLite database and leaves `.config` untouched.

### Cleanups
- Removed the dead `col = col` argument from all 29 `glue_sql` ALTERs (templates have no `{col}` placeholder).
- Made `old_ref_str` honest: the `annotate_opts` clause compared a string against deparsed data.frame columns and was always FALSE; the curate-params grep is the only substring-safe trigger (the replacement ref URL itself contains `/ref_dbs/Mitos2`, so matching `annotate_opts$ref_dir` would re-fire the block on already-migrated projects and crash the unconditional `ALTER ... ADD COLUMN`). Also fixed the never-hit `"Metazoa" %in% annotate_opts_table` ref_db rename.

## Tests
- genetic_code stored numeric; legacy TEXT normalized on re-run.
- config regenerated with old values carried over + timestamped backup.
- `update_config = FALSE` migrates DB but not config.
- undetectable-executor no-op (config untouched, warning).
- old Mitos2 ref-path migration + idempotency (no duplicate-column crash on re-run).
- existing v1.0.0 / v1.3.10 / export-template / idempotency tests still pass.