### PR TITLE
Progress-window fixes missed by PR #94 squash merge

### DIFF
--- a/R/app_export.R
+++ b/R/app_export.R
@@ -787,7 +787,7 @@ export_server <- function(id) {
               style = paste(
                 "min-width: 0; background: #000; color: #fff;",
                 "font-family: monospace; font-size: 0.8em; padding: 0.5em 0.6em; border-radius: 4px;",
-                "white-space: normal; word-break: break-all; text-align: left;"
+                "white-space: normal; word-break: break-all; text-align: center;"
               ),
               path
             ),

--- a/R/app_run_pipline.R
+++ b/R/app_run_pipline.R
@@ -233,6 +233,7 @@ pipeline_server <- function(id) {
       prog_header(NULL)
       prog_executor(NULL)
       prog_process(list())
+      prog_frame(list())
       prog_footer(NULL)
       shinyjs::hide("start_button_ui") # Hide the container with the start buttons
       shinyjs::show("stop")

--- a/R/app_run_pipline.R
+++ b/R/app_run_pipline.R
@@ -507,79 +507,75 @@ pipeline_server <- function(id) {
     # Monitor progress ----
     prog_header <- reactiveVal()
     prog_executor <- reactiveVal()
-    prog_process <- reactiveVal(list())
+    prog_process <- reactiveVal(list())   # last complete board (what we render)
+    prog_frame <- reactiveVal(list())     # board currently being reprinted
     prog_footer <- reactiveVal()
+    # Reduce a Nextflow board token to a stable key: the process simple name.
+    # Nextflow truncates the workflow-path prefix with an ellipsis and varies the
+    # name-column width between redraws. When a long task tag truncates the name
+    # away entirely, fall back to the raw token so distinct processes stay
+    # distinct within a frame instead of collapsing to an empty/1-char key.
+    process_key <- function(token) {
+      k <- sub("^.*:", "", token)                      # drop path prefix up to last ':'
+      stripped <- sub("^.*(\u2026|\\.\\.\\.)", "", k)  # drop leading ellipsis truncation
+      if (nchar(stripped) >= 3) stripped else token
+    }
     progress_update <- function(process_out,
                                 prog_header,
                                 prog_executor,
                                 prog_process,
+                                prog_frame,
                                 prog_footer) {
       remaining <- rep(T, length(process_out))
       process_out <- cli::ansi_strip(process_out) # clean up ansi encoded output
       executor_lines <- stringr::str_detect(process_out, "^executor")
-      # Key on the full "WF..." process-name token (not a fixed 4-char tail):
-      # per-scaffold BLAST tasks carry long tags that force Nextflow to truncate
-      # names down to a few chars, which broke the old 4-char-minimum pattern and
-      # dumped every redraw snapshot into the footer.
       keys <- stringr::str_match(process_out,
                                  "^(?<prefix>\\[.+?\\]) (?<key>WF\\S*) +(?<suffix>.*)")
       progress_lines <- !is.na(keys[, 1])
-      if (length(prog_process) == 0) {
+      # Header = the Nextflow banner printed before the first executor/progress
+      # line; captured once, before any executor line has been seen.
+      if (is.null(prog_executor)) {
         header_stop <- which(executor_lines | progress_lines)
         header_stop <- ifelse(length(header_stop) == 0,
                               length(process_out),
                               min(header_stop) - 1)
-        prog_header <- paste(na.omit(c(
-          prog_header, collapse_empty_lines(process_out[seq_len(header_stop)])
-        )), collapse = "\n")
-        remaining[1:header_stop] <- F
+        if (header_stop >= 1) {
+          prog_header <- paste(na.omit(c(
+            prog_header, collapse_empty_lines(process_out[seq_len(header_stop)])
+          )), collapse = "\n")
+          remaining[seq_len(header_stop)] <- F
+        }
       }
       if (any(executor_lines)) {
         prog_executor <- process_out[max(which(executor_lines))]
         remaining[executor_lines] <- F
       }
-      # Key each process by its stable simple name. Nextflow truncates the
-      # workflow-path prefix with an ellipsis and varies the name-column width
-      # between redraws, so the raw "WF..." token is unstable and the pending
-      # board (full names) would never collapse onto the running board. Reduce
-      # to the process simple name (text after the last ':' or ellipsis).
-      process_key <- function(token) {
-        k <- sub("^.*:", "", token)                 # drop path prefix up to last ':'
-        sub("^.*(\u2026|\\.\\.\\.)", "", k)  # drop leading ellipsis truncation
-      }
-      for (raw_key in na.omit(unique(keys[, 'key']))) {
-        rows <- which(keys[, 'key'] == raw_key)
-        line <- keys[rows[length(rows)], 1]          # latest full line for this token
-        simple <- process_key(raw_key)
-        # Suffix-merge names that Nextflow truncated into (e.g. 'st_genbank' and
-        # 'blast_genbank') so both redraws land on one row, keyed by the fuller name.
-        existing <- names(prog_process)
-        match_k <- existing[vapply(existing, function(e)
-          endsWith(e, simple) || endsWith(simple, e), logical(1))]
-        canonical <- simple
-        if (length(match_k) > 0) {
-          canonical <- match_k[which.max(nchar(match_k))]
-          if (nchar(simple) > nchar(canonical)) {
-            prog_process[[simple]] <- prog_process[[canonical]]
-            prog_process[[canonical]] <- NULL
-            canonical <- simple
-          }
+      # Frame reconstruction: Nextflow reprints the whole board on each redraw.
+      # Rather than accumulate rows across redraws (which piles up stale rows when
+      # a long task tag truncates a process name to an unstable stub), rebuild the
+      # current board. Within a frame each process is listed once in order, so a
+      # repeated key marks the next frame: commit the finished frame as the
+      # rendered board and start a fresh one.
+      for (i in which(progress_lines)) {
+        key <- process_key(keys[i, 'key'])
+        if (key %in% names(prog_frame)) {
+          prog_process <- prog_frame
+          prog_frame <- list()
         }
-        prog_process[[canonical]] <- line
+        prog_frame[[key]] <- keys[i, 1]   # full line
       }
-      remaining[!is.na(keys[, 1])] <- F
+      remaining[progress_lines] <- F
       remaining <- process_out[remaining] |> collapse_empty_lines()
       if (any(nchar(remaining) > 0)) {
         prog_footer <- paste(na.omit(c(prog_footer, remaining)), collapse = "\n")
       }
-      return({
-        list(
-          prog_header = prog_header,
-          prog_executor = prog_executor,
-          prog_process = prog_process,
-          prog_footer = prog_footer
-        )
-      })
+      list(
+        prog_header = prog_header,
+        prog_executor = prog_executor,
+        prog_process = prog_process,
+        prog_frame = prog_frame,
+        prog_footer = prog_footer
+      )
     }
     collapse_empty_lines <- function(x) {
       is_empty <- grepl("^\\s*$", x)
@@ -606,11 +602,13 @@ pipeline_server <- function(id) {
             prog_header(),
             prog_executor(),
             prog_process(),
+            prog_frame(),
             prog_footer()
           )
           prog_header(update$prog_header)
           prog_executor(update$prog_executor)
           prog_process(update$prog_process)
+          prog_frame(update$prog_frame)
           prog_footer(update$prog_footer)
         }
       } else {
@@ -621,12 +619,16 @@ pipeline_server <- function(id) {
             prog_header(),
             prog_executor(),
             prog_process(),
+            prog_frame(),
             prog_footer()
           )
           prog_header(update$prog_header)
           prog_executor(update$prog_executor)
-          prog_process(update$prog_process)
+          prog_frame(update$prog_frame)
           prog_footer(update$prog_footer)
+          # Run finished: the last board sits in the in-progress frame with no
+          # following redraw to commit it, so show it as the final board.
+          prog_process(if (length(update$prog_frame)) update$prog_frame else update$prog_process)
         }
         process(NULL)
         shinyjs::hide("stop")
@@ -644,7 +646,11 @@ pipeline_server <- function(id) {
       req(prog_executor())
     })
     output$progress_process <- renderText({
-      paste(prog_process(), collapse = "\n")
+      # Render the last complete board; fall back to the board being built (the
+      # very first frame, before any redraw has committed a complete one).
+      board <- prog_process()
+      if (length(board) == 0) board <- prog_frame()
+      paste(board, collapse = "\n")
     })
     output$progress_footer <- renderText({
       req(prog_footer())

--- a/R/app_run_pipline_userAsmb.R
+++ b/R/app_run_pipline_userAsmb.R
@@ -228,6 +228,7 @@ pipeline_server_userAsmb <- function(id) {
       prog_header(NULL)
       prog_executor(NULL)
       prog_process(list())
+      prog_frame(list())
       prog_footer(NULL)
       shinyjs::hide("start_button_ui") # Hide the container with the start buttons
       shinyjs::show("stop")

--- a/R/app_run_pipline_userAsmb.R
+++ b/R/app_run_pipline_userAsmb.R
@@ -398,78 +398,71 @@ pipeline_server_userAsmb <- function(id) {
     # Monitor progress ----
     prog_header <- reactiveVal()
     prog_executor <- reactiveVal()
-    prog_process <- reactiveVal(list())
+    prog_process <- reactiveVal(list())   # last complete board (what we render)
+    prog_frame <- reactiveVal(list())     # board currently being reprinted
     prog_footer <- reactiveVal()
-    progress_update <- function(process_out, prog_header, prog_executor, prog_process, prog_footer) {
+    # Reduce a Nextflow board token to a stable key: the process simple name.
+    # When a long task tag truncates the name away entirely, fall back to the raw
+    # token so distinct processes stay distinct within a frame.
+    process_key <- function(token) {
+      k <- sub("^.*:", "", token)                      # drop path prefix up to last ':'
+      stripped <- sub("^.*(\u2026|\\.\\.\\.)", "", k)  # drop leading ellipsis truncation
+      if (nchar(stripped) >= 3) stripped else token
+    }
+    progress_update <- function(process_out, prog_header, prog_executor, prog_process, prog_frame, prog_footer) {
       remaining <- rep(T, length(process_out))
       process_out <- cli::ansi_strip(process_out) # clean up ansi encoded output
       executor_lines <- stringr::str_detect(process_out, "^executor")
-      # Key on the full "WF..." process-name token (not a fixed 4-char tail); see
-      # app_run_pipline.R for why truncated names broke the old pattern.
       keys <- stringr::str_match(
         process_out,
         "^(?<prefix>\\[.+?\\]) (?<key>WF\\S*) +(?<suffix>.*)"
       )
       progress_lines <- !is.na(keys[,1])
-      if (length(prog_process)==0) {
+      # Header = the Nextflow banner before the first executor/progress line;
+      # captured once, before any executor line has been seen.
+      if (is.null(prog_executor)) {
         header_stop <- which(executor_lines|progress_lines)
         header_stop <- ifelse(length(header_stop)==0, length(process_out), min(header_stop) - 1)
-        prog_header <- paste(
-          na.omit(c(
-            prog_header,
-            collapse_empty_lines(process_out[seq_len(header_stop)])
-            )
-          ),
-          collapse = "\n"
-        )
-        remaining[1:header_stop] <- F
+        if (header_stop >= 1) {
+          prog_header <- paste(
+            na.omit(c(
+              prog_header,
+              collapse_empty_lines(process_out[seq_len(header_stop)])
+            )),
+            collapse = "\n"
+          )
+          remaining[seq_len(header_stop)] <- F
+        }
       }
       if(any(executor_lines)){
         prog_executor <- process_out[max(which(executor_lines))]
         remaining[executor_lines] <- F
       }
-      # Key each process by its stable simple name. Nextflow truncates the
-      # workflow-path prefix with an ellipsis and varies the name-column width
-      # between redraws, so the raw "WF..." token is unstable and the pending
-      # board (full names) would never collapse onto the running board. Reduce
-      # to the process simple name (text after the last ':' or ellipsis).
-      process_key <- function(token) {
-        k <- sub("^.*:", "", token)                 # drop path prefix up to last ':'
-        sub("^.*(\u2026|\\.\\.\\.)", "", k)          # drop leading ellipsis truncation
-      }
-      for(raw_key in na.omit(unique(keys[,'key']))){
-        rows <- which(keys[,'key'] == raw_key)
-        line <- keys[rows[length(rows)], 1]          # latest full line for this token
-        simple <- process_key(raw_key)
-        # Suffix-merge names that Nextflow truncated into (e.g. 'st_genbank' and
-        # 'blast_genbank') so both redraws land on one row, keyed by the fuller name.
-        existing <- names(prog_process)
-        match_k <- existing[vapply(existing, function(e)
-          endsWith(e, simple) || endsWith(simple, e), logical(1))]
-        canonical <- simple
-        if (length(match_k) > 0) {
-          canonical <- match_k[which.max(nchar(match_k))]
-          if (nchar(simple) > nchar(canonical)) {
-            prog_process[[simple]] <- prog_process[[canonical]]
-            prog_process[[canonical]] <- NULL
-            canonical <- simple
-          }
+      # Frame reconstruction: Nextflow reprints the whole board on each redraw.
+      # Within a frame each process is listed once in order, so a repeated key
+      # marks the next frame: commit the finished frame as the rendered board and
+      # start a fresh one. Avoids accumulating stale rows when long task tags
+      # truncate a process name to an unstable stub. See app_run_pipline.R.
+      for (i in which(progress_lines)) {
+        key <- process_key(keys[i, 'key'])
+        if (key %in% names(prog_frame)) {
+          prog_process <- prog_frame
+          prog_frame <- list()
         }
-        prog_process[[canonical]] <- line
+        prog_frame[[key]] <- keys[i, 1]   # full line
       }
-      remaining[!is.na(keys[,1])] <- F
+      remaining[progress_lines] <- F
       remaining <- process_out[remaining] |> collapse_empty_lines()
       if(any(nchar(remaining)>0)){
         prog_footer <- paste(na.omit(c(prog_footer, remaining)),collapse = "\n")
       }
-      return({
-        list(
-          prog_header = prog_header,
-          prog_executor = prog_executor,
-          prog_process = prog_process,
-          prog_footer = prog_footer
-        )
-      })
+      list(
+        prog_header = prog_header,
+        prog_executor = prog_executor,
+        prog_process = prog_process,
+        prog_frame = prog_frame,
+        prog_footer = prog_footer
+      )
     }
     collapse_empty_lines <- function(x) {
       is_empty <- grepl("^\\s*$", x)
@@ -490,20 +483,23 @@ pipeline_server_userAsmb <- function(id) {
       if (p$is_alive()) {
         new_output <- p$read_output_lines()
         if (length(new_output) > 0) {
-          update <- progress_update(new_output, prog_header(), prog_executor(), prog_process(), prog_footer())
+          update <- progress_update(new_output, prog_header(), prog_executor(), prog_process(), prog_frame(), prog_footer())
           prog_header(update$prog_header)
           prog_executor(update$prog_executor)
           prog_process(update$prog_process)
+          prog_frame(update$prog_frame)
           prog_footer(update$prog_footer)
         }
       } else {
         final_output <- p$read_output_lines()
         if (length(final_output) > 0) {
-          update <- progress_update(final_output, prog_header(), prog_executor(), prog_process(), prog_footer())
+          update <- progress_update(final_output, prog_header(), prog_executor(), prog_process(), prog_frame(), prog_footer())
           prog_header(update$prog_header)
           prog_executor(update$prog_executor)
-          prog_process(update$prog_process)
+          prog_frame(update$prog_frame)
           prog_footer(update$prog_footer)
+          # Run finished: show the last (uncommitted) board as the final board.
+          prog_process(if (length(update$prog_frame)) update$prog_frame else update$prog_process)
         }
         process(NULL)
         shinyjs::hide("stop")
@@ -521,7 +517,11 @@ pipeline_server_userAsmb <- function(id) {
       req(prog_executor())
     })
     output$progress_process <- renderText({
-      paste(prog_process(), collapse = "\n")
+      # Render the last complete board; fall back to the board being built (the
+      # very first frame, before any redraw has committed a complete one).
+      board <- prog_process()
+      if (length(board) == 0) board <- prog_frame()
+      paste(board, collapse = "\n")
     })
     output$progress_footer <- renderText({
       req(prog_footer())


### PR DESCRIPTION
## Overview

Three commits that were pushed to `gene-merge-rework` **after** PR #94 was squash-merged (at `e270df6`), so they didn't make it into `main` / v1.4.10. This PR brings them over.

## Changes
- **Render the Nextflow progress board frame-by-frame** (`0c73122`): keying rows across redraws piled up stale/garbled rows when long task tags force Nextflow to truncate a process name to an unstable stub (an empty key could even clobber a real process). The panel now reconstructs Nextflow's latest board (a repeated process key marks the next frame) and renders exactly that. Applied to both runners.
- **Clear the progress window on a new run** (`0abfa15`): `start_nf_process` reset the other progress reactives but not the new `prog_frame`, so a new run briefly showed the previous run's board.
- **Center the export path text** in the export-complete popup (`56deb36`).
