### PR TITLE
Annotate/Assemble/Export UX improvements: filters, export status, readable column names

### DIFF
--- a/R/app_annotate.R
+++ b/R/app_annotate.R
@@ -7,6 +7,7 @@ ANNOTATE_COL_GROUPS <- list(
                "blast_lineage", "blast_pident", "blast_qcovs"),
   Counts   = c("PCGCount", "tRNACount", "rRNACount", "ORFCount", "missing", "extra"),
   Review   = c("ID_verified", "reviewed", "problematic", "partial", "warnings"),
+  Export   = c("export_group", "export_time_stamp"),
   Metadata = c("time_stamp", "annotate_notes")
 )
 ANNOTATE_COL_GROUP_LOOKUP <- {
@@ -89,6 +90,15 @@ annotate_ui <- function(id) {
             `selected-text-format` = "count > 0",
             width                  = "150px"
           )
+        ),
+        shinyWidgets::airDatepickerInput(
+          inputId    = ns("date_filter"),
+          label      = "Updated between:",
+          range      = TRUE,
+          clearButton = TRUE,
+          value      = NULL,
+          width      = "220px",
+          placeholder = "any time"
         ),
         uiOutput(ns("warnings_select"))
       ),
@@ -177,7 +187,7 @@ annotate_server <- function(id) {
     filtered_data <- reactive({
       req(rv$data)
       selected <- input$warning_filters
-      rv$data |> dplyr::mutate(
+      out <- rv$data |> dplyr::mutate(
         warnings = purrr::map_int(warnings_details, function(wd) {
           # if (is.na(wd) || length(selected) == 0) return(0)
           wd_list <- strsplit(as.character(wd), ";")[[1]] |>
@@ -185,7 +195,25 @@ annotate_server <- function(id) {
           sum(wd_list %in% selected)
         })
       )
+      # Date-range filter on "Last Updated" (time_stamp is epoch seconds). Empty
+      # picker = no filter; end day is inclusive. Unlike the lock/state CSS
+      # filters this subsets the rows, so selection may reset when the range changes.
+      dr <- input$date_filter
+      if (!is.null(dr) && length(dr) == 2 && all(!is.na(dr))) {
+        lo <- as.numeric(as.POSIXct(as.Date(dr[1])))
+        hi <- as.numeric(as.POSIXct(as.Date(dr[2]) + 1))
+        out <- out |>
+          dplyr::filter(!is.na(time_stamp) & time_stamp >= lo & time_stamp < hi)
+      }
+      out
     })
+
+    # Refresh the table when the date-range filter changes (ignoreNULL = FALSE so
+    # clearing the range restores all rows).
+    observeEvent(input$date_filter, {
+      req(rv$data)
+      updateReactable("table", data = filtered_data())
+    }, ignoreNULL = FALSE, ignoreInit = TRUE)
 
     # Mirror the column-group picker so NULL (= user cleared all) is
     # distinguishable from the pre-init state. Default: all groups on.
@@ -257,7 +285,17 @@ annotate_server <- function(id) {
         height = "100%",
         wrap = FALSE,
         pageSizeOptions = c(25, 50, 100, 200, 500),
-        rowStyle = rt_highlight_row(),
+        # Selection takes precedence; otherwise tint rows for samples that have
+        # already been exported (export_time_stamp not null).
+        rowStyle = htmlwidgets::JS("
+          function(rowInfo) {
+            if (typeof rowInfo === 'undefined') return
+            if (rowInfo.selected) return { background: '#D3BEC2' }
+            var v = (rowInfo.values || {})['export_time_stamp']
+            if (v != null && v !== '') return { background: '#EAF5EA' }
+            return { background: '#FFFFFF' }
+          }
+        "),
         rowClass = JS("function(rowInfo) {
           if (!rowInfo || !rowInfo.values) return '';
           return 'mp-lock-' + rowInfo.values['annotate_lock'] +
@@ -434,6 +472,35 @@ annotate_server <- function(id) {
             align = "center",
             width = 100,
             cell = rt_bool_badge(invert = TRUE, hide_no = FALSE)
+          ),
+          export_group = colDef(
+            show = TRUE, class = .grp("export_group"), headerClass = .grp("export_group"),
+            name = "Export Group",
+            align = "left",
+            minWidth = 120,
+            cell = function(value) if (is.na(value) || !nzchar(value)) "" else value
+          ),
+          export_time_stamp = colDef(
+            show = TRUE, class = .grp("export_time_stamp"), headerClass = .grp("export_time_stamp"),
+            name = "Exported",
+            filterable = FALSE,
+            html = TRUE,
+            width = 170,
+            # JS cell so it re-renders on updateReactable(); shows a green check +
+            # export date + the group the sample was exported under.
+            cell = htmlwidgets::JS("
+              function(cellInfo) {
+                var v = cellInfo.value;
+                if (v == null || v === '') return '';
+                var opts = { year: 'numeric', month: 'numeric', day: 'numeric' };
+                var date = new Date(1000*v).toLocaleDateString('en-US', opts);
+                if (date === 'Invalid Date') return '';
+                var row = cellInfo.row || {};
+                var g = row.export_group;
+                var grp = (g == null || g === '' || g === 'NA') ? '' : ' (' + g + ')';
+                return '<span style=\"color:#3d9140;font-weight:bold;\">&#10003;</span> ' + date + grp;
+              }
+            ")
           ),
           time_stamp = colDef(
             show = TRUE, class = .grp("time_stamp"), headerClass = .grp("time_stamp"),

--- a/R/app_annotate.R
+++ b/R/app_annotate.R
@@ -29,6 +29,7 @@ ANNOTATE_STATE_CHOICES <- c(
   "Success"      = "2",
   "Failed"       = "3"
 )
+ANNOTATE_EXPORT_CHOICES <- c("Not Exported" = "0", "Exported" = "1")
 
 #' annotate UI Function
 #'
@@ -67,6 +68,21 @@ annotate_ui <- function(id) {
           label    = "State:",
           choices  = ANNOTATE_STATE_CHOICES,
           selected = ANNOTATE_STATE_CHOICES,
+          multiple = TRUE,
+          options  = list(
+            `actions-box`          = TRUE,
+            `select-all-text`      = "All",
+            `deselect-all-text`    = "None",
+            `selected-text-format` = "count > 0",
+            width                  = "140px"
+          )
+        ),
+        shinyWidgets::pickerInput(
+          inputId  = ns("export_filter"),
+          width    = "140px",
+          label    = "Exported:",
+          choices  = ANNOTATE_EXPORT_CHOICES,
+          selected = ANNOTATE_EXPORT_CHOICES,
           multiple = TRUE,
           options  = list(
             `actions-box`          = TRUE,
@@ -232,6 +248,10 @@ annotate_server <- function(id) {
     observeEvent(input$state_filter, {
       state_filter_rv(input$state_filter %||% character(0))
     }, ignoreNULL = FALSE, ignoreInit = TRUE)
+    export_filter_rv <- reactiveVal(unname(ANNOTATE_EXPORT_CHOICES))
+    observeEvent(input$export_filter, {
+      export_filter_rv(input$export_filter %||% character(0))
+    }, ignoreNULL = FALSE, ignoreInit = TRUE)
 
     # CSS class for a togglable column. Added to both body cells and the
     # header cell so the whole column collapses when the group is hidden.
@@ -251,13 +271,15 @@ annotate_server <- function(id) {
       hidden_grp   <- setdiff(names(ANNOTATE_COL_GROUPS), col_groups_rv())
       hidden_lock  <- setdiff(unname(ANNOTATE_LOCK_CHOICES), lock_filter_rv())
       hidden_state <- setdiff(unname(ANNOTATE_STATE_CHOICES), state_filter_rv())
+      hidden_exp   <- setdiff(unname(ANNOTATE_EXPORT_CHOICES), export_filter_rv())
       # Scope to THIS module's table so rules don't hit the shared mp-lock /
       # mp-state / mp-grp classes on the assemble, userAsmb, and export tables.
       sel <- paste0("#", ns("table"), " ")
       rules <- c(
         if (length(hidden_grp))   paste0(sel, ".mp-grp-",   hidden_grp,   " { display: none !important; }"),
         if (length(hidden_lock))  paste0(sel, ".mp-lock-",  hidden_lock,  " { display: none !important; }"),
-        if (length(hidden_state)) paste0(sel, ".mp-state-", hidden_state, " { display: none !important; }")
+        if (length(hidden_state)) paste0(sel, ".mp-state-", hidden_state, " { display: none !important; }"),
+        if (length(hidden_exp))   paste0(sel, ".mp-exp-",   hidden_exp,   " { display: none !important; }")
       )
       if (length(rules) == 0) return(NULL)
       tags$style(HTML(paste(rules, collapse = "\n")))
@@ -285,21 +307,14 @@ annotate_server <- function(id) {
         height = "100%",
         wrap = FALSE,
         pageSizeOptions = c(25, 50, 100, 200, 500),
-        # Selection takes precedence; otherwise tint rows for samples that have
-        # already been exported (export_time_stamp not null).
-        rowStyle = htmlwidgets::JS("
-          function(rowInfo) {
-            if (typeof rowInfo === 'undefined') return
-            if (rowInfo.selected) return { background: '#D3BEC2' }
-            var v = (rowInfo.values || {})['export_time_stamp']
-            if (v != null && v !== '') return { background: '#EAF5EA' }
-            return { background: '#FFFFFF' }
-          }
-        "),
+        rowStyle = rt_highlight_row(),
         rowClass = JS("function(rowInfo) {
           if (!rowInfo || !rowInfo.values) return '';
+          var ets = rowInfo.values['export_time_stamp'];
+          var exp = (ets != null && ets !== '') ? '1' : '0';
           return 'mp-lock-' + rowInfo.values['annotate_lock'] +
-                 ' mp-state-' + rowInfo.values['annotate_switch'];
+                 ' mp-state-' + rowInfo.values['annotate_switch'] +
+                 ' mp-exp-' + exp;
         }"),
         defaultColDef = colDef(align = "left", show = FALSE),
         columns = list(
@@ -408,7 +423,7 @@ annotate_server <- function(id) {
           ),
           blast_accession = colDef(
             show = TRUE, class = .grp("blast_accession"), headerClass = .grp("blast_accession"),
-            name = "BLAST Reference",
+            name = "BLAST Hit",
             html = TRUE,
             width = 120,
             cell = rt_ncbi_link(auto_col = "blast_accession_auto")
@@ -585,8 +600,10 @@ annotate_server <- function(id) {
     selected <- reactive({
       sel <- reactable::getReactableState("table", "selected")
       if (is.null(sel) || length(sel) == 0) return(sel)
+      exp_code <- ifelse(is.na(rv$data$export_time_stamp), "0", "1")
       visible <- as.character(rv$data$annotate_lock)   %in% lock_filter_rv() &
-                 as.character(rv$data$annotate_switch) %in% state_filter_rv()
+                 as.character(rv$data$annotate_switch) %in% state_filter_rv() &
+                 exp_code %in% export_filter_rv()
       intersect(sel, which(visible))
     })
 
@@ -605,11 +622,13 @@ annotate_server <- function(id) {
     # they never persist in reactable's state to reappear when later revealed.
     observeEvent(
       list(reactable::getReactableState("table", "selected"),
-           lock_filter_rv(), state_filter_rv()), {
+           lock_filter_rv(), state_filter_rv(), export_filter_rv()), {
       sel <- reactable::getReactableState("table", "selected")
       if (is.null(sel) || length(sel) == 0) return()
+      exp_code <- ifelse(is.na(rv$data$export_time_stamp), "0", "1")
       visible <- as.character(rv$data$annotate_lock)   %in% lock_filter_rv() &
-                 as.character(rv$data$annotate_switch) %in% state_filter_rv()
+                 as.character(rv$data$annotate_switch) %in% state_filter_rv() &
+                 exp_code %in% export_filter_rv()
       keep <- intersect(sel, which(visible))
       if (length(keep) != length(sel)) {
         reactable::updateReactable("table", selected = keep)

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -475,6 +475,29 @@ annotations_details_server <- function(id, rv) {
             pos2 = colDef(show = T),
             length = colDef(show = T),
             direction = colDef(show = T),
+            partial_start = colDef(
+              show = T,
+              name = "Partial",
+              html = T,
+              align = "center",
+              maxWidth = 90,
+              # JS cell (re-renders on updateReactable) reading the stored 5'/3'
+              # partial flags (partial_start/partial_stop are 5'/3' in the gene's
+              # orientation) so partiality is visible without entering edit mode.
+              cell = htmlwidgets::JS("
+                function(cellInfo) {
+                  var row = cellInfo.row || {};
+                  function pill(t) {
+                    return '<span style=\"background:#FAA34A30;color:#111111;border:1px solid #FAA34A;' +
+                      'border-radius:3px;padding:1px 4px;font-size:11px;white-space:nowrap;\">' + t + '</span>';
+                  }
+                  var out = [];
+                  if (row.partial_start == 1) out.push(pill(\"5'\"));
+                  if (row.partial_stop == 1) out.push(pill(\"3'\"));
+                  return out.join(' ');
+                }
+              ")
+            ),
             tool = colDef(
               show = T,
               name = "tool",

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -441,6 +441,7 @@ annotations_details_server <- function(id, rv) {
           columns = list(
             type = colDef(
               show = T,
+              name = "Type",
               align = "left",
               html = TRUE,
               # JS (not R) cell renderer so the badge re-renders client-side on
@@ -466,15 +467,16 @@ annotations_details_server <- function(id, rv) {
               ")
             ),
             gene = colDef(show = T,
+                          name = "Gene",
                           align = "left",
                           maxWidth = 300,
                           resizable = TRUE,
                           html = T,
                           cell = rt_longtext()),
-            pos1 = colDef(show = T),
-            pos2 = colDef(show = T),
-            length = colDef(show = T),
-            direction = colDef(show = T),
+            pos1 = colDef(show = T, name = "Start"),
+            pos2 = colDef(show = T, name = "End"),
+            length = colDef(show = T, name = "Length"),
+            direction = colDef(show = T, name = "Direction"),
             partial_start = colDef(
               show = T,
               name = "Partial",
@@ -500,12 +502,13 @@ annotations_details_server <- function(id, rv) {
             ),
             tool = colDef(
               show = T,
-              name = "tool",
+              name = "Tool",
               align = "left",
               maxWidth = 100
             ),
             notes = colDef(
               show = T,
+              name = "Notes",
               maxWidth = 1000,
               html = T,
               cell = rt_longtext(),
@@ -514,6 +517,7 @@ annotations_details_server <- function(id, rv) {
             ),
             warnings = colDef(
               show = T,
+              name = "Warnings",
               maxWidth = 1000,
               html = T,
               cell = rt_longtext(),
@@ -3385,6 +3389,9 @@ annotations_details_server <- function(id, rv) {
       if (!is.null(rv$alignment)) {
         rv$alignment$partial <- partial_label(selected())
       }
+      # Refresh the feature table so the "Partial" (5'/3') badge reflects the
+      # toggle immediately; keep the current selection so editing continues.
+      reactable::updateReactable("table", data = rv$annotations, selected = selected())
     })
     observeEvent(input$toggle_partial_stop, {
       req(rv$editing, length(selected()) == 1)
@@ -3393,6 +3400,7 @@ annotations_details_server <- function(id, rv) {
       if (!is.null(rv$alignment)) {
         rv$alignment$partial <- partial_label(selected())
       }
+      reactable::updateReactable("table", data = rv$annotations, selected = selected())
     })
 
     ## rRNA nucleotide-boundary editor ----

--- a/R/app_annotate_utils.R
+++ b/R/app_annotate_utils.R
@@ -15,7 +15,7 @@ fetch_annotate_data <- function(session = getDefaultReactiveDomain()) {
                   dplyr::any_of(c("blast_accession_auto", "poor_blast_ref")))
 
   taxa <- dplyr::tbl(db, "samples") |>
-    dplyr::select(ID, Taxon)
+    dplyr::select(ID, Taxon, export_group, export_time_stamp)
 
   annotations <- dplyr::tbl(db, "annotations") |>
     dplyr::select(ID, type, warnings) |>
@@ -78,6 +78,8 @@ fetch_annotate_data <- function(session = getDefaultReactiveDomain()) {
       problematic,
       partial,
       time_stamp,
+      export_group,
+      export_time_stamp,
       annotate_notes,
       warnings_details,
       use_orffinder,

--- a/R/app_assemble.R
+++ b/R/app_assemble.R
@@ -87,6 +87,15 @@ assemble_ui <- function(id) {
           `selected-text-format` = "count > 0",
           width                  = "150px"
         )
+      ),
+      shinyWidgets::airDatepickerInput(
+        inputId     = ns("date_filter"),
+        label       = "Updated between:",
+        range       = TRUE,
+        clearButton = TRUE,
+        value       = NULL,
+        width       = "220px",
+        placeholder = "any time"
       )
     ),
     div(class = "mp-table-resize", reactableOutput(ns("table"))),
@@ -129,13 +138,36 @@ assemble_server <- function(id) {
       updating = NULL
     )
 
+    # Date-range filter on "Last Updated" (time_stamp is epoch seconds). Empty
+    # picker = no filter; end day is inclusive. Unlike the lock/state CSS filters
+    # this subsets the rows, so selection may reset when the range changes.
+    filtered_data <- reactive({
+      req(rv$data)
+      out <- rv$data
+      dr <- input$date_filter
+      if (!is.null(dr) && length(dr) == 2 && all(!is.na(dr))) {
+        lo <- as.numeric(as.POSIXct(as.Date(dr[1])))
+        hi <- as.numeric(as.POSIXct(as.Date(dr[2]) + 1))
+        out <- out |>
+          dplyr::filter(!is.na(time_stamp) & time_stamp >= lo & time_stamp < hi)
+      }
+      out
+    })
+
+    # Refresh table when the date-range filter changes (ignoreNULL = FALSE so
+    # clearing the range restores all rows).
+    observeEvent(input$date_filter, {
+      req(rv$data)
+      trigger("update_assemble_table")
+    }, ignoreNULL = FALSE, ignoreInit = TRUE)
+
     # Refresh ----
     init("refresh_assemble")
     on("refresh_assemble", {
       rv$data <- fetch_assemble_data()
       updateReactable(
         "table",
-        data = rv$data
+        data = filtered_data()
       )
     })
 
@@ -190,7 +222,7 @@ assemble_server <- function(id) {
 
     # Render table ----
     output$table <- renderReactable({
-      isolate(req(rv$data)) |>
+      isolate(req(filtered_data())) |>
         reactable(
           resizable = TRUE,
           filterable = TRUE,
@@ -433,7 +465,7 @@ assemble_server <- function(id) {
     on("update_assemble_table", {
       reactable::updateReactable(
         "table",
-        data = rv$data |>
+        data = filtered_data() |>
           dplyr::mutate(
             output = dplyr::case_when(
               assemble_switch > 1 ~ "output",

--- a/R/app_assemble_coverage_details.R
+++ b/R/app_assemble_coverage_details.R
@@ -158,6 +158,7 @@ assembly_coverage_details_server <- function(id, rv) {
           defaultColDef = colDef(align = "center"),
           columns = list(
             ignore = colDef(
+              name = "Ignore",
               width = 60,
               html = TRUE, align = "center",
               cell = rt_bool_bttn(ns("ignore"), "fa fa-circle-xmark", "far fa-circle")
@@ -201,6 +202,9 @@ assembly_coverage_details_server <- function(id, rv) {
             ),
             blast_qcovs = colDef(
               name = "% Cov", width = 80, align = "center"
+            ),
+            blast_evalue = colDef(
+              name = "E-value", width = 90, align = "center"
             ),
             blast_lineage = colDef(
               name = "BLAST Lineage", minWidth = 200, resizable = TRUE, align = "left", html = TRUE,
@@ -1098,16 +1102,16 @@ assembly_coverage_details_server <- function(id, rv) {
         defaultColDef = colDef(align = "center"),
         columns = list(
           block_id  = colDef(name = "Block", width = 70),
-          label     = colDef(name = "Likely cause", minWidth = 180, align = "left",
+          label     = colDef(name = "Likely Cause", minWidth = 180, align = "left",
                              html = TRUE, cell = rt_longtext()),
           aln_start = colDef(name = "Start"),
           aln_end   = colDef(name = "End"),
           len       = colDef(name = "Length"),
           n_snps    = colDef(name = "SNPs"),
           n_indels  = colDef(name = "Indels"),
-          min_depth  = colDef(name = "Min depth"),
-          mean_depth = colDef(name = "Mean depth"),
-          max_error  = colDef(name = "Max error rate")
+          min_depth  = colDef(name = "Min Depth"),
+          mean_depth = colDef(name = "Mean Depth"),
+          max_error  = colDef(name = "Max Error Rate")
         )
       )
     })

--- a/R/app_assemble_userAsmb.R
+++ b/R/app_assemble_userAsmb.R
@@ -73,6 +73,15 @@ assemble_ui_userAsmb <- function(id) {
           `selected-text-format` = "count > 0",
           width                  = "150px"
         )
+      ),
+      shinyWidgets::airDatepickerInput(
+        inputId     = ns("date_filter"),
+        label       = "Updated between:",
+        range       = TRUE,
+        clearButton = TRUE,
+        value       = NULL,
+        width       = "220px",
+        placeholder = "any time"
       )
     ),
     div(class = "mp-table-resize", reactableOutput(ns("table"))),
@@ -103,13 +112,34 @@ assemble_server_userAsmb <- function(id) {
       updating = NULL
     )
 
+    # Date-range filter on "Last Updated" (time_stamp is epoch seconds). Empty
+    # picker = no filter; end day is inclusive. Unlike the lock/state CSS filters
+    # this subsets the rows, so selection may reset when the range changes.
+    filtered_data <- reactive({
+      req(rv$data)
+      out <- rv$data
+      dr <- input$date_filter
+      if (!is.null(dr) && length(dr) == 2 && all(!is.na(dr))) {
+        lo <- as.numeric(as.POSIXct(as.Date(dr[1])))
+        hi <- as.numeric(as.POSIXct(as.Date(dr[2]) + 1))
+        out <- out |>
+          dplyr::filter(!is.na(time_stamp) & time_stamp >= lo & time_stamp < hi)
+      }
+      out
+    })
+
+    observeEvent(input$date_filter, {
+      req(rv$data)
+      trigger("update_assemble_table")
+    }, ignoreNULL = FALSE, ignoreInit = TRUE)
+
     # Refresh ----
     init("refresh_assemble")
     on("refresh_assemble", {
       rv$data <- fetch_assemble_data_userAsmb()
       updateReactable(
         "table",
-        data = rv$data
+        data = filtered_data()
       )
     })
 
@@ -157,7 +187,7 @@ assemble_server_userAsmb <- function(id) {
 
     # Render table ----
     output$table <- renderReactable({
-      isolate(req(rv$data)) |>
+      isolate(req(filtered_data())) |>
         reactable(
           resizable = TRUE,
           filterable = TRUE,
@@ -387,7 +417,7 @@ assemble_server_userAsmb <- function(id) {
     on("update_assemble_table", {
       reactable::updateReactable(
         "table",
-        data = rv$data |>
+        data = filtered_data() |>
           dplyr::mutate(
             output = dplyr::case_when(
               assemble_switch > 1 ~ "output",

--- a/R/app_export.R
+++ b/R/app_export.R
@@ -42,19 +42,37 @@ export_ui <- function(id) {
   ns <- NS(id)
   tagList(
     uiOutput(ns("col_css")),
-    shinyWidgets::pickerInput(
-      inputId  = ns("col_groups"),
-      width    = "150px",
-      label    = "Show columns:",
-      choices  = names(EXPORT_COL_GROUPS),
-      selected = names(EXPORT_COL_GROUPS),
-      multiple = TRUE,
-      options  = list(
-        `actions-box`          = TRUE,
-        `select-all-text`      = "All",
-        `deselect-all-text`    = "None",
-        `selected-text-format` = "count > 0",
-        width                  = "150px"
+    div(
+      style = "display: flex; align-items: flex-end; gap: 20px; flex-wrap: wrap;",
+      shinyWidgets::pickerInput(
+        inputId  = ns("col_groups"),
+        width    = "150px",
+        label    = "Show columns:",
+        choices  = names(EXPORT_COL_GROUPS),
+        selected = names(EXPORT_COL_GROUPS),
+        multiple = TRUE,
+        options  = list(
+          `actions-box`          = TRUE,
+          `select-all-text`      = "All",
+          `deselect-all-text`    = "None",
+          `selected-text-format` = "count > 0",
+          width                  = "150px"
+        )
+      ),
+      shinyWidgets::pickerInput(
+        inputId  = ns("export_filter"),
+        width    = "140px",
+        label    = "Exported:",
+        choices  = ANNOTATE_EXPORT_CHOICES,
+        selected = ANNOTATE_EXPORT_CHOICES,
+        multiple = TRUE,
+        options  = list(
+          `actions-box`          = TRUE,
+          `select-all-text`      = "All",
+          `deselect-all-text`    = "None",
+          `selected-text-format` = "count > 0",
+          width                  = "140px"
+        )
       )
     ),
     div(class = "mp-table-resize", reactableOutput(ns("table"))),
@@ -113,24 +131,32 @@ export_server <- function(id) {
     observeEvent(input$col_groups, {
       col_groups_rv(input$col_groups %||% character(0))
     }, ignoreNULL = FALSE, ignoreInit = TRUE)
+    # Exported Yes/No filter. Rows are tagged with mp-exp-<0/1> (see rowClass)
+    # so unselected states hide via CSS, same mechanism as the column picker.
+    export_filter_rv <- reactiveVal(unname(ANNOTATE_EXPORT_CHOICES))
+    observeEvent(input$export_filter, {
+      export_filter_rv(input$export_filter %||% character(0))
+    }, ignoreNULL = FALSE, ignoreInit = TRUE)
 
     .grp <- function(col) {
       g <- EXPORT_COL_GROUP_LOOKUP[col]
       if (is.na(g)) NULL else paste0("mp-grp-", g)
     }
 
-    # CSS hide for unselected groups; keeps DOM intact so filter/sort/page
-    # state survives toggling.
+    # CSS hide for unselected groups / exported states; keeps DOM intact so
+    # filter/sort/page state survives toggling.
     output$col_css <- renderUI({
-      hidden <- setdiff(names(EXPORT_COL_GROUPS), col_groups_rv())
-      if (length(hidden) == 0) return(NULL)
-      # Scope to THIS module's table so rules don't hit the shared mp-grp
-      # classes on the assemble, userAsmb, and annotate tables.
+      hidden     <- setdiff(names(EXPORT_COL_GROUPS), col_groups_rv())
+      hidden_exp <- setdiff(unname(ANNOTATE_EXPORT_CHOICES), export_filter_rv())
+      # Scope to THIS module's table so rules don't hit the shared mp-grp /
+      # mp-exp classes on the assemble, userAsmb, and annotate tables.
       sel <- paste0("#", ns("table"), " ")
-      rules <- paste0(sel, ".mp-grp-", hidden,
-                      " { display: none !important; }",
-                      collapse = "\n")
-      tags$style(HTML(rules))
+      rules <- c(
+        if (length(hidden))     paste0(sel, ".mp-grp-", hidden, " { display: none !important; }"),
+        if (length(hidden_exp)) paste0(sel, ".mp-exp-", hidden_exp, " { display: none !important; }")
+      )
+      if (length(rules) == 0) return(NULL)
+      tags$style(HTML(paste(rules, collapse = "\n")))
     })
 
     # Render table ----
@@ -153,14 +179,26 @@ export_server <- function(id) {
         pageSizeOptions = c(25, 50, 100, 200, 500),
         striped = TRUE,
         rowStyle = rt_highlight_row(),
-        defaultColDef = colDef(align = "left"),
+        # Tag rows exported (mp-exp-1) vs not (mp-exp-0) so the Exported picker
+        # can hide unselected states via CSS.
+        rowClass = htmlwidgets::JS("function(rowInfo) {
+          if (!rowInfo || !rowInfo.values) return '';
+          var ets = rowInfo.values['export_time_stamp'];
+          return 'mp-exp-' + ((ets != null && ets !== '') ? '1' : '0');
+        }"),
+        # Hide by default so only the explicitly-named columns below show; the
+        # data carries extra internal columns (genetic_code, counts, etc.) that
+        # would otherwise render with raw names.
+        defaultColDef = colDef(align = "left", show = FALSE),
         columns = list(
           ID = colDef(show = T, minWidth = 120, sticky = "left"),
+          Taxon = colDef(show = T, name = "Taxon", minWidth = 140, html = TRUE, cell = rt_longtext()),
           curate_opts = colDef(
             show = TRUE, class = .grp("curate_opts"), headerClass = .grp("curate_opts"),
             name = "Curate Opts.",
             width = 110
           ),
+          genetic_code = colDef(show = T, name = "Genetic Code", align = "center", width = 110),
           poor_blast_ref = colDef(show = FALSE),
           partial = colDef(show = FALSE),
           completeness = colDef(show = FALSE),
@@ -177,7 +215,7 @@ export_server <- function(id) {
           ),
           blast_accession = colDef(
             show = TRUE, class = .grp("blast_accession"), headerClass = .grp("blast_accession"),
-            name = "BLAST Reference",
+            name = "BLAST Hit",
             html = TRUE,
             width = 120,
             cell = rt_ncbi_link(auto_col = "blast_accession_auto")
@@ -205,8 +243,18 @@ export_server <- function(id) {
             show = T, class = .grp("structure"), headerClass = .grp("structure"),
             name = "Structure"
           ),
-          ORFCount = colDef(name = "# ORFs", align = "center"),
-          export_group = colDef(name = "Group", sticky = "right")
+          PCGCount = colDef(show = T, name = "# PCGs", align = "center"),
+          tRNACount = colDef(show = T, name = "# tRNAs", align = "center"),
+          rRNACount = colDef(show = T, name = "# rRNAs", align = "center"),
+          ORFCount = colDef(show = T, name = "# ORFs", align = "center"),
+          missing = colDef(show = T, name = "Missing", align = "left", html = TRUE, cell = rt_longtext()),
+          extra = colDef(show = T, name = "Extra", align = "left", html = TRUE, cell = rt_longtext()),
+          warnings = colDef(show = T, name = "Warnings", align = "left", html = TRUE, cell = rt_longtext()),
+          export_time_stamp = colDef(
+            show = T, name = "Exported", html = TRUE, width = 150,
+            filterable = FALSE, cell = rt_ts_date()
+          ),
+          export_group = colDef(show = T, name = "Export Group", sticky = "right")
         )
       )
     })
@@ -223,7 +271,15 @@ export_server <- function(id) {
     })
 
     # table selection ----
-    selected <- reactive(reactable::getReactableState("table", "selected"))
+    # Rows hidden by the Exported filter stay mounted, so drop them from the
+    # selection so bulk export only touches visible samples.
+    selected <- reactive({
+      sel <- reactable::getReactableState("table", "selected")
+      if (is.null(sel) || length(sel) == 0) return(sel)
+      exp_code <- ifelse(is.na(rv$data$export_time_stamp), "0", "1")
+      visible <- exp_code %in% export_filter_rv()
+      intersect(sel, which(visible))
+    })
 
     output$n_selected <- renderText({
       paste0(length(selected()), " selected")
@@ -748,6 +804,8 @@ export_server <- function(id) {
         stop_aa = rv$review_stop,
         ident_pct = rv$review_ident
       )
+      # Refresh the table so the newly-written export_time_stamp shows up.
+      trigger("refresh_export")
     }
 
     # Finish a reviewed export: write files (now that all edits are committed to

--- a/R/backwards_compatibility.R
+++ b/R/backwards_compatibility.R
@@ -134,6 +134,7 @@ backwards_compatibility <- function(
       "problematic" %in% names(annotate_table) &&
       "partial" %in% names(annotate_table) &&
       "genetic_code" %in% names(samples_table) &&
+      "export_time_stamp" %in% names(samples_table) &&
       "poor_blast_ref" %in% names(assemble_table) &&
       "ID_verified" %in% names(annotate_table) &&
       "reviewed" %in% names(annotate_table) &&
@@ -277,6 +278,13 @@ backwards_compatibility <- function(
         copy = TRUE,
         by = "ID"
       )
+  }
+
+  # if export_time_stamp column doesn't exist, add it (marks when a sample was
+  # last exported; NULL = never exported)
+  if(!("export_time_stamp" %in% names(samples_table))){
+    message("added 'export_time_stamp' column to samples table")
+    DBI::dbExecute(con, "ALTER TABLE samples ADD COLUMN export_time_stamp INTEGER")
   }
 
   # normalize any legacy TEXT genetic_code to INTEGER (idempotent). Projects

--- a/R/export.R
+++ b/R/export.R
@@ -1060,6 +1060,16 @@ export_files <- function(
     utils::write.csv(summary_df, summary_fn, row.names = FALSE)
   }
 
+  # Mark the exported samples with the export time so the Annotate tab can flag /
+  # highlight samples that have already been exported (NULL = never exported).
+  if (length(group) == 1) {
+    DBI::dbExecute(
+      con,
+      "UPDATE samples SET export_time_stamp = ? WHERE export_group = ?",
+      params = list(as.integer(Sys.time()), group)
+    )
+  }
+
   db_path <- file.path(dirname(out_dir), ".sqlite")
 
   if (length(group) == 1 && length(IDs) > 1 && generateAAalignments) {

--- a/R/init_db.R
+++ b/R/init_db.R
@@ -180,7 +180,8 @@ new_db <- function(
       ID = .data[[mapping_id]],
       Taxon = .data[[mapping_taxon]],
       genetic_code = resolved_genetic_code,
-      export_group = NA_character_
+      export_group = NA_character_,
+      export_time_stamp = NA_integer_
     )
   glue::glue_sql(
     "CREATE TABLE samples (

--- a/R/init_db_userAsmb.R
+++ b/R/init_db_userAsmb.R
@@ -143,7 +143,8 @@ new_db_userAsmb <- function(
       genetic_code = resolved_genetic_code,
       topology = .data[["Topology"]],
       assembly = .data[["Assembly"]],
-      export_group = NA_character_
+      export_group = NA_character_,
+      export_time_stamp = NA_integer_
     ) |>
     dplyr::select(-Topology, -Assembly)
   glue::glue_sql(


### PR DESCRIPTION
Quality-of-life improvements to the Annotate, Assemble, and Export tabs, driven by user feedback for easier batch curation tracking.

## Annotate tab
- **Exported filter**: new Yes/No picker to show only exported / not-yet-exported samples.
- **Export status columns**: Export Group + a date-rendered "Exported" column (persisted per-sample `export_time_stamp`).
- **Date-range filter** on "Updated between" (last-update time).
- **5'/3' partial badges** visible in the details feature table without entering edit mode; badge refreshes live when partiality is toggled in the alignment editor.
- Renamed the BLAST column to "BLAST Hit".

## Assemble tab (+ user-assembly)
- **Date-range filter** on "Updated between", matching the Annotate tab.

## Export tab
- **Exported filter** (Yes/No) that actually filters; disabled the broken per-column date filter box; hidden rows are pruned from the selection so bulk export only touches visible samples.
- `export_time_stamp` renders as a date ("Exported" column); table auto-refreshes when an export finishes so it populates immediately.
- Cleaned up the table: hid raw internal columns (was leaking `genetic_code`, epoch timestamps, `linear_complete`, etc.) and gave readable names (Genetic Code, # PCGs/tRNAs/rRNAs, Missing, Extra, Warnings, Taxon).
- Renamed Group -> "Export Group" and the BLAST column -> "BLAST Hit".

## Column-name normalization
- Audited every reactable colDef; fixed remaining raw/snake_case and sentence-case headers to Title Case (details table type/gene/pos/length/direction/tool/notes/warnings; coverage Ignore/E-value/Min Depth/Mean Depth/Max Error Rate/Likely Cause).

## Schema / migration
- Adds one column: `samples.export_time_stamp` (INTEGER, NULL = never exported).
- `init_db` + `init_db_userAsmb` create it for new projects; `backwards_compatibility()` adds it via `ALTER TABLE` for existing projects and includes it in the currency guard so the migration fires on open.
- `export_files()` writes the timestamp for a group's samples on successful export.

Verification: driven against a fish test project; warning-flagging, filters, and migration confirmed. No automated tests exist for these Shiny modules.