### PR TITLE
Fix native-pipe crash in sample fns; sync preprocess reads in update_sample_seqdata

### DIFF
--- a/R/add_samples.R
+++ b/R/add_samples.R
@@ -97,14 +97,14 @@ add_samples <- function(
   }
 
   # convert everything to characters
-  mapping <- mapping %>%
-    dplyr::mutate(across(everything(), as.character))
+  mapping <- mapping |>
+    dplyr::mutate(dplyr::across(dplyr::everything(), as.character))
 
   # read existing sample table
   sample_table <- DBI::dbReadTable(con, "samples")
   # convert everything to characters
-  sample_table <- sample_table %>%
-    dplyr::mutate(across(everything(), as.character))
+  sample_table <- sample_table |>
+    dplyr::mutate(dplyr::across(dplyr::everything(), as.character))
 
   # check to make sure there are no existing samples in the update database
   new_samples <- mapping$ID[which(mapping$ID %in% sample_table$ID)]

--- a/R/export_db_to_csv.R
+++ b/R/export_db_to_csv.R
@@ -36,9 +36,9 @@ export_db_to_csv <- function(
   names(annot_table)[names(annot_table) == 'time_stamp'] <- 'time_stamp.annot'
 
   # join tables on ID
-  tbl <- sample_table %>%
-    dplyr::left_join(pre_table, by='ID') %>%
-    dplyr::left_join(asmb_table, by='ID') %>%
+  tbl <- sample_table |>
+    dplyr::left_join(pre_table, by='ID') |>
+    dplyr::left_join(asmb_table, by='ID') |>
     dplyr::left_join(annot_table, by='ID')
 
   # make new directory

--- a/R/update_sample_metadata.R
+++ b/R/update_sample_metadata.R
@@ -53,8 +53,8 @@ update_sample_metadata <- function(
       Taxon = .data[[mapping_taxon]]
     )
   # convert everything to characters
-  mapping <- mapping %>%
-    dplyr::mutate(across(everything(), as.character))
+  mapping <- mapping |>
+    dplyr::mutate(dplyr::across(dplyr::everything(), as.character))
 
   # remove R1 and R2 columns from updated mapping
   if("R1" %in% colnames(mapping) | "R2" %in% colnames(mapping)){
@@ -73,8 +73,8 @@ update_sample_metadata <- function(
   # read existing sample table
   sample_table <- DBI::dbReadTable(con, "samples")
   # convert everything to characters
-  sample_table <- sample_table %>%
-    dplyr::mutate(across(everything(), as.character))
+  sample_table <- sample_table |>
+    dplyr::mutate(dplyr::across(dplyr::everything(), as.character))
 
   # check to make sure there are no new samples in the update database
   new_samples <- mapping$ID[which(!(mapping$ID %in% sample_table$ID))]

--- a/R/update_sample_seqdata.R
+++ b/R/update_sample_seqdata.R
@@ -51,8 +51,8 @@ update_sample_seqdata <- function(
     )
 
   # convert everything to characters
-  mapping <- mapping %>%
-    dplyr::mutate(across(everything(), as.character))
+  mapping <- mapping |>
+    dplyr::mutate(dplyr::across(dplyr::everything(), as.character))
 
   # check that mapping file contains sequence data columns
   if(!("R1" %in% colnames(mapping)) | !("R2" %in% colnames(mapping))){
@@ -69,8 +69,8 @@ update_sample_seqdata <- function(
   # read existing sample table
   sample_table <- DBI::dbReadTable(con, "samples")
   # convert everything to characters
-  sample_table <- sample_table %>%
-    dplyr::mutate(across(everything(), as.character))
+  sample_table <- sample_table |>
+    dplyr::mutate(dplyr::across(dplyr::everything(), as.character))
 
   # check to make sure there are no new samples in the update database
   new_samples <- mapping$ID[which(!(mapping$ID %in% sample_table$ID))]
@@ -112,5 +112,17 @@ update_sample_seqdata <- function(
       in_place = TRUE,
       copy = TRUE,
       by = "ID"
+    )
+
+  # also update the preprocess table: R1/R2 there are the copy the PREPROCESS
+  # module actually reads (samples.R1/R2 is not consumed by the pipeline).
+  # Targeted update so pipeline-computed columns (reads, etc.) are untouched.
+  dplyr::tbl(con, "preprocess") |>
+    dplyr::rows_update(
+      dplyr::select(mapping, "ID", "R1", "R2"),
+      by = "ID",
+      in_place = TRUE,
+      copy = TRUE,
+      unmatched = "ignore"
     )
 }


### PR DESCRIPTION
## Summary

Two fixes to the sample-management functions.

### 1. `could not find function "%>%"` crash

`add_samples`, `update_sample_metadata`, `update_sample_seqdata`, and `export_db_to_csv` used the magrittr pipe `%>%`, but magrittr was **never** a dependency: it has never appeared in `DESCRIPTION` Imports or been imported in `NAMESPACE` in any commit. Inside a package namespace `%>%` only resolves if some attached package happens to re-export it onto the search path, so these functions crashed for users who ran them with only MitoPilot attached (e.g. `MitoPilot::add_samples()`).

Swapped `%>%` to the native `|>` pipe, consistent with the rest of the codebase (no new dependency). Also qualified `across(everything(), ...)` to `dplyr::across(dplyr::everything(), ...)` so nothing rides on unqualified lookup.

### 2. `update_sample_seqdata` updated the wrong table

The function wrote new `R1`/`R2` paths only to the `samples` table. The pipeline reads raw reads from the `preprocess` table (`preprocess_workflow.nf`: `SELECT p.ID, p.R1, p.R2 FROM preprocess p ...`); `samples.R1/R2` is vestigial and consumed by nothing. So updated read paths silently never took effect, while the function still reported success and told the user to re-run.

`update_sample_seqdata` now also updates `preprocess.R1/R2`. The update is targeted to `R1`/`R2` only, so pipeline-computed columns (`reads`, `trimmed_reads`, `mean_length`, `time_stamp`) are left untouched.

## Testing

Exercised all four functions end-to-end against a throwaway `new_db()` project with `%>%` confirmed absent from the search path (reproducing the crash environment):

- `add_samples`: 2 to 4 samples across samples/preprocess/assemble/annotate
- `update_sample_metadata`: Taxon updated
- `update_sample_seqdata`: **both** `samples.R1/R2` and `preprocess.R1/R2` updated; numeric preprocess columns preserved; untouched samples unchanged
- `export_db_to_csv`: CSV written

All pass.