### PR TITLE
PCG outlier review: MSA refresh fix, edit-any-sample/cancel, recompute perf

### DIFF
--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -376,6 +376,9 @@ annotations_details_server <- function(id, rv) {
           identical(goto$ID, rv$updating$ID)) {
         # Remember the flag so the banner can remind the user what to edit
         outlier_flag(goto)
+        # Snapshot the focal gene's edit-relevant fields so the reopen handler can
+        # tell whether anything changed and skip the recompute if not.
+        session$userData$review_entry_sig <- focal_sig(rv$annotations, goto$gene)
         gidx <- which(rv$annotations$gene == goto$gene)
         if (length(gidx) > 0) {
           gidx <- gidx[[1]]
@@ -392,6 +395,7 @@ annotations_details_server <- function(id, rv) {
         session$userData$goto_annotate_target <- NULL
       } else {
         outlier_flag(NULL)
+        session$userData$review_entry_sig <- NULL
       }
     })
 
@@ -760,6 +764,20 @@ annotations_details_server <- function(id, rv) {
     # poly-A stop trim change partial_start/partial_stop/stop_codon/positions
     # without altering the translation, so a translation-only test would let the
     # user close/lock and silently drop those edits.
+    # Order-independent signature of a gene's annotation rows over the fields that
+    # drive the outlier recompute (translation for single-exon genes; pos/direction
+    # for multi-exon). Lets "Back to Review" skip the recompute when nothing changed.
+    focal_sig <- function(ann, gene) {
+      if (is.null(ann) || is.null(gene)) return(NULL)
+      rows <- ann[!is.na(ann$gene) & ann$gene == gene, , drop = FALSE]
+      if (nrow(rows) == 0) return("")
+      flds <- c("translation", "pos1", "pos2", "direction")
+      cols <- lapply(flds, function(f) {
+        if (f %in% names(rows)) as.character(rows[[f]]) else rep(NA_character_, nrow(rows))
+      })
+      paste(sort(do.call(paste, c(cols, sep = "|"))), collapse = ";")
+    }
+
     editing_unsaved <- function(idx = selected()) {
       if (is.null(rv$editing) || is.null(rv$editing$backup)) return(FALSE)
       bak <- rv$editing$backup
@@ -841,6 +859,10 @@ annotations_details_server <- function(id, rv) {
       info <- outlier_flag()
       if (!is.null(info) && !is.null(info$ID) && !is.null(info$gene)) {
         session$userData$resolve_on_return <- list(ID = info$ID, gene = info$gene)
+        # If the focal gene's annotation is unchanged vs the entry snapshot, the
+        # reopen handler can skip the alignment recompute entirely.
+        session$userData$review_annotation_changed <-
+          !identical(session$userData$review_entry_sig, focal_sig(rv$annotations, info$gene))
       }
       shinyjs::click("close")
     })

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -188,6 +188,9 @@ annotations_details_server <- function(id, rv) {
     output$outlier_flag_banner <- renderUI({
       info <- outlier_flag()
       if (is.null(info)) return(NULL)
+      # A sample picked from the review's "edit any sample" list has no flag, so
+      # skip the issue/offset text and show a plain editing reminder.
+      flagged <- !is.null(info$issue) && !is.na(info$issue)
       div(
         style = paste(
           "background:#fff3cd; border:1px solid #ffe69c; color:#664d03;",
@@ -197,8 +200,8 @@ annotations_details_server <- function(id, rv) {
         icon("triangle-exclamation"),
         span(
           tags$b(stringr::str_glue("Outlier review - {toupper(info$gene)}: ")),
-          info$issue,
-          tags$span(
+          if (flagged) info$issue,
+          if (flagged) tags$span(
             style = "color:#8a6d3b; margin-left:6px;",
             stringr::str_glue(
               "(start {sprintf('%+d', info$start_offset)} aa, ",

--- a/R/app_export.R
+++ b/R/app_export.R
@@ -105,6 +105,8 @@ export_server <- function(id) {
       updating = NULL,
       outliers = NULL,    # flags tibble from flag_PCG_outliers()
       alns = NULL,        # named list of aligned AAStringSet (by gene)
+      review_samples = NULL, # named list (by gene) of every unit in the alignment,
+                             # so any sample can be picked for editing (not just flagged)
       review_genes = NULL, # genes still pending review (drives navigation)
       review_idx = 1L,     # cursor into review_genes
       resolved = character(0), # "ID|gene" keys the user marked resolved;
@@ -957,6 +959,7 @@ export_server <- function(id) {
     present_review <- function(res, focus_gene = NULL) {
       rv$outliers <- res$flags
       rv$alns <- res$alignments
+      rv$review_samples <- res$samples
       flagged_genes <- unique(res$flags$gene)
       if (length(flagged_genes) > 0) {
         rv$review_genes <- flagged_genes
@@ -982,8 +985,12 @@ export_server <- function(id) {
         rv$outliers[rv$outliers$gene != gene, , drop = FALSE],
         res$flags
       )
-      # res$alignments has the gene only when it still has a flagged sample
+      # res$alignments/res$samples keep the recomputed gene even when the edit
+      # cleared its last flag (flag_PCG_outliers retains explicitly-requested
+      # genes), so the corrected alignment replaces the stale one instead of the
+      # panel freezing on the pre-edit view.
       rv$alns[[gene]] <- res$alignments[[gene]]
+      rv$review_samples[[gene]] <- res$samples[[gene]]
       # review_genes intentionally unchanged: genes stay in the list and are
       # marked resolved rather than removed.
       if (gene %in% rv$review_genes) {
@@ -1169,6 +1176,12 @@ export_server <- function(id) {
       g <- current_gene()
       rv$outliers[rv$outliers$gene == g, , drop = FALSE]
     })
+    # Every unit in the current gene's alignment (flagged or not), for the
+    # "edit any sample" picker.
+    current_samples <- reactive({
+      g <- current_gene()
+      rv$review_samples[[g]]
+    })
     # Sample (by label) to highlight in the MSA; cleared when the gene changes
     highlight_label <- reactiveVal(NULL)
 
@@ -1223,10 +1236,14 @@ export_server <- function(id) {
         uiOutput(ns("review_aln_ui")),
         tags$hr(),
         reactableOutput(ns("review_table")),
+        # Edit any sample of this gene, flagged or not (only this gene stays
+        # editable in the details modal, same as clicking a flagged sample's 'edit').
+        uiOutput(ns("review_sample_picker")),
         footer = tagList(
           actionButton(ns("review_prev"), "Prev"),
           actionButton(ns("review_next"), "Next"),
           actionButton(ns("skip_gene"), "Mark gene resolved", class = "btn-success"),
+          actionButton(ns("cancel_review"), "Cancel export", class = "btn-danger"),
           actionButton(ns("review_done"), "Done", class = "btn-primary")
         )
       ) |> showModal()
@@ -1245,7 +1262,10 @@ export_server <- function(id) {
     review_aln_height <- reactive({
       g <- current_gene()
       aln <- rv$alns[[g]]
-      req(aln)
+      # Do NOT req(aln) here: review_aln_ui depends on this, and a req-stop would
+      # skip emitting the fresh msaROutput div, leaving the previous (stale) widget
+      # on screen. Fall back to a default height so the div is always rebuilt.
+      if (is.null(aln)) return(120L)
       min(400L, max(120L, as.integer(length(aln) * 18 + 40)))
     })
 
@@ -1260,7 +1280,10 @@ export_server <- function(id) {
 
     output$review_table <- renderReactable({
       df <- current_flags()
-      req(nrow(df) > 0)
+      # Render even with 0 rows (reactable shows an empty table) rather than
+      # req(nrow>0)-stopping: after an edit clears a gene's last flag the table
+      # must refresh to empty, not freeze on the stale pre-edit rows.
+      req(!is.null(df))
       keys <- paste(df$ID, df$gene, sep = "|")
       df <- df |>
         dplyr::transmute(
@@ -1330,6 +1353,29 @@ export_server <- function(id) {
       )
     })
 
+    # Picker to edit ANY sample of the current gene, flagged or not. The table
+    # above only lists flagged samples; this offers the rest of the alignment.
+    output$review_sample_picker <- renderUI({
+      samp <- current_samples()
+      req(!is.null(samp), nrow(samp) > 0)
+      div(
+        style = "margin-top: 0.75em; display: flex; align-items: flex-end; gap: 0.5em;",
+        div(
+          style = "flex: 1;",
+          selectInput(
+            ns("edit_sample_label"),
+            label = sprintf("Edit any %s sample", toupper(current_gene())),
+            choices = sort(samp$label),
+            width = "100%"
+          )
+        ),
+        actionButton(
+          ns("edit_sample"), "edit",
+          class = "btn-primary", style = "margin-bottom: 15px;"
+        )
+      )
+    })
+
     # Toggle a (sample, gene) as resolved; kept in rv$resolved so it survives
     # alignment/flag recomputes (Back to Review).
     observeEvent(input$toggle_resolved, {
@@ -1389,6 +1435,38 @@ export_server <- function(id) {
       )
       removeModal()
       trigger("goto_annotate")
+    })
+
+    # Jump to the annotate details modal for any chosen sample of the current
+    # gene, flagged or not. Mirrors goto_annot; the unit comes from the sample
+    # roster and there are no outlier offsets (NA -> the editor shows a plain
+    # "editing <gene>" banner instead of offset values).
+    observeEvent(input$edit_sample, {
+      samp <- current_samples()
+      req(!is.null(samp))
+      row <- samp[samp$label == input$edit_sample_label, , drop = FALSE]
+      req(nrow(row) == 1)
+      session$userData$goto_annotate_target <- list(
+        ID = row$ID, path = row$path, scaffold = row$scaffold,
+        gene = current_gene(), issue = NA_character_,
+        start_offset = NA_integer_, stop_offset = NA_integer_,
+        pct_identity = NA_real_
+      )
+      removeModal()
+      trigger("goto_annotate")
+    })
+
+    # Abort the export: close the review modal and clear review state so no files
+    # are written and the modal does not reopen.
+    observeEvent(input$cancel_review, {
+      removeModal()
+      highlight_label(NULL)
+      rv$outliers <- NULL
+      rv$alns <- NULL
+      rv$review_samples <- NULL
+      rv$review_genes <- NULL
+      rv$review_idx <- 1L
+      rv$resolved <- character(0)
     })
   })
 }

--- a/R/app_export.R
+++ b/R/app_export.R
@@ -1036,6 +1036,14 @@ export_server <- function(id) {
           ),
           finally = waiter::waiter_hide()
         )
+        # TEMP diagnostic: ungapped AA length per sequence straight from the fresh
+        # recompute (compare against "REVIEW RENDER" to localize any staleness).
+        if (!is.null(focal) && !is.null(res$alignments[[focal]])) {
+          message(
+            "RECOMPUTE gene=", focal,
+            " lens=", paste(nchar(gsub("-", "", as.character(res$alignments[[focal]]))), collapse = ",")
+          )
+        }
         # Scoped merge when we know the single edited gene and have cached state;
         # otherwise fall back to a full reload.
         if (!is.null(focal) && !is.null(rv$outliers)) {
@@ -1196,30 +1204,8 @@ export_server <- function(id) {
     on("outlier_modal", {
       req(length(rv$review_genes) > 0)
       highlight_label(NULL)
-      # Fresh output id for this open -> the shown gene's MSA rebuilds from scratch
-      # (no stale htmlwidget binding reuse). Register the renderer for that id here.
+      # Bump so review_aln_ui rebuilds the widget from scratch on every (re)open.
       aln_nonce(isolate(aln_nonce()) + 1L)
-      output[[paste0("review_aln_", isolate(aln_nonce()))]] <- msaR::renderMsaR({
-        g <- current_gene()
-        aln <- rv$alns[[g]]
-        req(aln)
-        # Move the picked sample to the top and mark it so it stands out
-        hl <- highlight_label()
-        if (!is.null(hl) && hl %in% names(aln)) {
-          aln <- aln[c(which(names(aln) == hl), which(names(aln) != hl))]
-          names(aln)[1] <- paste0(">> ", names(aln)[1])
-        }
-        msaR::msaR(
-          aln,
-          overviewbox = FALSE,
-          seqlogo = FALSE,
-          menu = FALSE,
-          conservation = TRUE,
-          labelNameLength = 150,
-          colorscheme = "zappo",
-          alignmentHeight = review_aln_height()
-        )
-      })
       modalDialog(
         title = "PCG Annotation Outlier Review",
         size = "l",
@@ -1262,19 +1248,45 @@ export_server <- function(id) {
     review_aln_height <- reactive({
       g <- current_gene()
       aln <- rv$alns[[g]]
-      # Do NOT req(aln) here: review_aln_ui depends on this, and a req-stop would
-      # skip emitting the fresh msaROutput div, leaving the previous (stale) widget
-      # on screen. Fall back to a default height so the div is always rebuilt.
       if (is.null(aln)) return(120L)
       min(400L, max(120L, as.integer(length(aln) * 18 + 40)))
     })
 
-    # Dynamic id (tracks aln_nonce) so each modal open binds a fresh msaR widget;
-    # the renderer for this id is registered in on("outlier_modal").
+    # Render the MSA as the uiOutput content itself (not a msaROutput placeholder
+    # filled by a separate renderMsaR). Returning the widget from renderUI makes
+    # Shiny REPLACE the container's innerHTML on every (re)open, so the old widget
+    # DOM is torn down and a fresh one built from the current rv$alns - the
+    # msaROutput+dynamic-renderMsaR pattern instead let htmlwidgets reuse a stale
+    # binding (and msaR::renderValue appends rather than clearing), which showed the
+    # pre-edit alignment after "Back to Review". aln_nonce() forces a rebuild even
+    # if the gene is unchanged.
     output$review_aln_ui <- renderUI({
-      msaR::msaROutput(
-        ns(paste0("review_aln_", aln_nonce())),
-        height = paste0(review_aln_height() + 10, "px")
+      aln_nonce()
+      g <- current_gene()
+      aln <- rv$alns[[g]]
+      if (is.null(aln)) {
+        return(div(style = "color:#666; padding:1em;", "No alignment for this gene."))
+      }
+      # Move the picked sample to the top and mark it so it stands out
+      hl <- highlight_label()
+      if (!is.null(hl) && hl %in% names(aln)) {
+        aln <- aln[c(which(names(aln) == hl), which(names(aln) != hl))]
+        names(aln)[1] <- paste0(">> ", names(aln)[1])
+      }
+      # TEMP diagnostic: ungapped AA length per sequence in the rendered alignment.
+      message(
+        "REVIEW RENDER gene=", g, " nonce=", isolate(aln_nonce()),
+        " lens=", paste(nchar(gsub("-", "", as.character(aln))), collapse = ",")
+      )
+      msaR::msaR(
+        aln,
+        overviewbox = FALSE,
+        seqlogo = FALSE,
+        menu = FALSE,
+        conservation = TRUE,
+        labelNameLength = 150,
+        colorscheme = "zappo",
+        alignmentHeight = review_aln_height()
       )
     })
 

--- a/R/app_export.R
+++ b/R/app_export.R
@@ -1011,8 +1011,23 @@ export_server <- function(id) {
       # navigate back to it.
       rr <- session$userData$resolve_on_return
       session$userData$resolve_on_return <- NULL
+      focal <- if (!is.null(rr)) rr$gene else NULL
+      # Only skip the recompute when the details modal reported NO change (explicit
+      # FALSE); an unset flag means recompute to be safe.
+      unchanged <- identical(session$userData$review_annotation_changed, FALSE)
+      session$userData$review_annotation_changed <- NULL
       if (!is.null(rr)) {
         rv$resolved <- union(rv$resolved, paste(rr$ID, rr$gene, sep = "|"))
+      }
+      # Nothing was edited: the cached flags/alignments are still valid, so just
+      # reopen at the focal gene and skip the (expensive) alignment recompute.
+      if (unchanged && !is.null(rv$outliers) && length(rv$review_genes) > 0) {
+        if (!is.null(focal) && focal %in% rv$review_genes) {
+          rv$review_idx <- which(rv$review_genes == focal)[1]
+        }
+        removeModal()
+        trigger("outlier_modal")
+        return()
       }
       # Show the overlay first, then defer the (blocking) recompute one tick so
       # the "hold tight" message actually paints before alignment starts.
@@ -1024,7 +1039,6 @@ export_server <- function(id) {
         color = "rgba(40,40,40,0.85)"
       )
       shinyjs::delay(100, {
-        focal <- if (!is.null(rr)) rr$gene else NULL
         res <- tryCatch(
           flag_PCG_outliers(
             group = rv$review_group,

--- a/R/export.R
+++ b/R/export.R
@@ -1375,7 +1375,11 @@ get_export_PCG_annotations <- function(con, group) {
 #'       `start_offset`, `stop_offset`, `start_flag`, `stop_flag`,
 #'       `identity_flag`, `issue`.}
 #'     \item{alignments}{A named list (by gene) of clustering-ordered aligned
-#'       `AAStringSet` objects, for every gene that has a flagged sample.}
+#'       `AAStringSet` objects, for every gene that has a flagged sample (plus any
+#'       explicitly requested via `genes`, even if their last flag was cleared).}
+#'     \item{samples}{A named list (by gene) of tibbles listing every unit in the
+#'       gene's alignment (`ID`, `label`, `path`, `scaffold`), flagged or not, so
+#'       the review UI can edit any sample of the gene.}
 #'   }
 #'
 #' @export
@@ -1395,6 +1399,9 @@ flag_PCG_outliers <- function(group, db, start_aa = 10, stop_aa = 10, ident_pct 
   loop_genes <- if (!is.null(genes)) intersect(all_genes, genes) else all_genes
   flag_rows <- list()
   alignments <- list()
+  # Per-gene roster of every unit in the alignment (flagged or not), so the review
+  # UI can offer to edit any sample of the gene, not only the flagged ones.
+  samples <- list()
 
   for (g in loop_genes) {
     sub <- annotations[annotations$gene == g, , drop = FALSE]
@@ -1413,6 +1420,9 @@ flag_PCG_outliers <- function(group, db, start_aa = 10, stop_aa = 10, ident_pct 
     clust <- stats::hclust(dst, "complete")
     aln <- aln[clust$order]
     alignments[[g]] <- aln
+    samples[[g]] <- dplyr::tibble(
+      ID = sub$ID, label = sub$seqid, path = sub$path, scaffold = sub$scaffold
+    )
 
     # Mean pairwise identity of each sample to the rest of the group
     dmat <- as.matrix(DECIPHER::DistanceMatrix(
@@ -1482,10 +1492,16 @@ flag_PCG_outliers <- function(group, db, start_aa = 10, stop_aa = 10, ident_pct 
   }
 
   flags <- if (length(flag_rows) > 0) dplyr::bind_rows(flag_rows) else .empty_outlier_flags()
-  # Keep alignments only for genes that actually have a flagged sample
-  alignments <- alignments[names(alignments) %in% unique(flags$gene)]
+  # Keep alignments/rosters for genes that have a flagged sample. When a specific
+  # gene set was requested (a "Back to Review" recompute of an edited gene), also
+  # keep those genes even if the edit cleared their last flag, so the review can
+  # still show the corrected alignment instead of a stale one.
+  keep_genes <- unique(flags$gene)
+  if (!is.null(genes)) keep_genes <- union(keep_genes, intersect(names(alignments), genes))
+  alignments <- alignments[names(alignments) %in% keep_genes]
+  samples <- samples[names(samples) %in% keep_genes]
 
-  list(flags = flags, alignments = alignments)
+  list(flags = flags, alignments = alignments, samples = samples)
 }
 
 # Empty flags tibble with the canonical column types

--- a/R/export.R
+++ b/R/export.R
@@ -1261,8 +1261,20 @@ get_export_PCG_annotations <- function(con, group) {
   # Row indices of exons removed after being merged into their first exon
   rows_to_remove <- integer(0)
 
-  for (.i in seq_len(nrow(units))) {
-    u <- units[.i, ]
+  # The per-unit loop below only does anything for units carrying a multi-exon
+  # (intron) gene: the curate/sample reads and the full-scaffold get_assembly read
+  # feed only the intron-merge branch, and every single-exon gene hits the
+  # length<=1 skip. Reading each unit's whole assembly regardless is the dominant
+  # cost of a "Back to Review" recompute, so visit only units that can merge.
+  # Output is unchanged: skipped units overwrite no translation and remove no rows.
+  merge_units <- annotations |>
+    dplyr::count(ID, path, scaffold, gene) |>
+    dplyr::filter(n > 1) |>
+    dplyr::distinct(ID, path, scaffold)
+  loop_units <- dplyr::semi_join(units, merge_units, by = c("ID", "path", "scaffold"))
+
+  for (.i in seq_len(nrow(loop_units))) {
+    u <- loop_units[.i, ]
     # Curation rules for the current unit
     curation_opts <- dplyr::tbl(con, "annotate") |>
       dplyr::filter(ID == !!u$ID & path == !!u$path & scaffold == !!u$scaffold) |>


### PR DESCRIPTION
## Summary

Fixes and speeds up the PCG outlier review flow (export module), and adds
edit-any-sample / cancel controls.

### Correctness
- **Stale MSA after edit:** the outlier review modal kept showing the pre-edit
  alignment after "Back to Review". Retain the requested gene's alignment in
  `flag_PCG_outliers` even when an edit clears its last flag, and rebuild the
  MSA as the `renderUI` content itself (returning the widget replaces the
  container each reopen) so the edited alignment is shown instead of the stale
  widget DOM.

### Features
- **Edit any sample:** a sample picker to edit any unit of the current gene
  (flagged or not); `flag_PCG_outliers` now returns a per-gene roster of all
  units.
- **Cancel export:** button that closes the review modal and clears review
  state without writing files.

## Commits
- `7bd6e25` refresh outlier-review MSA after edit; add edit-any-sample and cancel
- `1b78bd1` rebuild outlier-review MSA via renderUI to clear stale widget
- `a2b0227` skip single-exon-only units in get_export_PCG_annotations
- `2fbe965` skip outlier alignment recompute when focal annotation unchanged
