### PR TITLE
fix(export): tolerate a missing MitoFinder tRNA anticodon

### DIFF
--- a/R/annotate_mitofinder.R
+++ b/R/annotate_mitofinder.R
@@ -235,7 +235,11 @@ annotate_mitofinder <- function(
       pos1 = pmin(start, end),
       pos2 = pmax(start, end),
       direction = ifelse(strand == "-", "-", "+"),
-      anticodon = toupper(anticodon)
+      # MitoFinder GFFs often omit the anticodon attribute; use the "NNN"
+      # unresolved sentinel the other tools and the exporter expect.
+      anticodon = dplyr::if_else(
+        type == "tRNA", dplyr::coalesce(toupper(anticodon), "NNN"), toupper(anticodon)
+      )
     ) |>
     dplyr::filter(!is.na(gene)) |>
     dplyr::mutate(

--- a/R/annotate_mitofinder.R
+++ b/R/annotate_mitofinder.R
@@ -237,9 +237,11 @@ annotate_mitofinder <- function(
       direction = ifelse(strand == "-", "-", "+"),
       # Left NA when the GFF omits the attribute, NOT coerced to the "NNN"
       # sentinel: "NNN" means a tool tried to call the anticodon and failed, and
-      # validate_mito_core() warns on it. MitoFinder transfers annotations from a
-      # reference and never reports an anticodon at all, so stamping NNN here
-      # would add a spurious low-confidence warning to every gap-filled tRNA.
+      # validate_mito_core() warns on it. MitoFinder's GFF carries no anticodon
+      # attribute, so stamping NNN here would add a spurious low-confidence
+      # warning to every gap-filled tRNA. (Its tRNA finder does determine one
+      # internally; MitoFinder just does not write it out.) NA is made safe at
+      # the consumer instead - see the guard in export_files().
       anticodon = toupper(anticodon)
     ) |>
     dplyr::filter(!is.na(gene)) |>

--- a/R/annotate_mitofinder.R
+++ b/R/annotate_mitofinder.R
@@ -235,11 +235,12 @@ annotate_mitofinder <- function(
       pos1 = pmin(start, end),
       pos2 = pmax(start, end),
       direction = ifelse(strand == "-", "-", "+"),
-      # MitoFinder GFFs often omit the anticodon attribute; use the "NNN"
-      # unresolved sentinel the other tools and the exporter expect.
-      anticodon = dplyr::if_else(
-        type == "tRNA", dplyr::coalesce(toupper(anticodon), "NNN"), toupper(anticodon)
-      )
+      # Left NA when the GFF omits the attribute, NOT coerced to the "NNN"
+      # sentinel: "NNN" means a tool tried to call the anticodon and failed, and
+      # validate_mito_core() warns on it. MitoFinder transfers annotations from a
+      # reference and never reports an anticodon at all, so stamping NNN here
+      # would add a spurious low-confidence warning to every gap-filled tRNA.
+      anticodon = toupper(anticodon)
     ) |>
     dplyr::filter(!is.na(gene)) |>
     dplyr::mutate(

--- a/R/export.R
+++ b/R/export.R
@@ -845,7 +845,7 @@ export_files <- function(
           cat(file = tbl_fn, sep = "\n", append = TRUE)
         paste("\t\t\tproduct\t", cur$product) |>
           cat(file = tbl_fn, sep = "\n", append = TRUE)
-        if (cur$anticodon != "NNN") {
+        if (!is.na(cur$anticodon) && cur$anticodon != "NNN") {
           paste("\t\t\tnote\t", paste0("anticodon:", tolower(cur$anticodon))) |>
             cat(file = tbl_fn, sep = "\n", append = TRUE)
         }

--- a/tests/testthat/test-annotate-mitofinder.R
+++ b/tests/testthat/test-annotate-mitofinder.R
@@ -92,3 +92,26 @@ test_that("annotate_mitofinder returns typed empty frame when db missing", {
       "length", "direction", "tRNA_ID", "anticodon") %in% names(res)
   ))
 })
+
+test_that(".parse_mitofinder_gff fills a missing tRNA anticodon with NNN", {
+  # MitoFinder GFFs frequently omit the anticodon attribute. Leaving it NA
+  # crashed export_files() at `if (cur$anticodon != "NNN")`.
+  wd <- tempfile("mf_ac_")
+  dir.create(file.path(wd, "x_Final_Results"), recursive = TRUE)
+  writeLines(c(
+    "##gff-version 3",
+    "ctg1\tMitoFinder\ttRNA\t10\t80\t.\t+\t.\tName=tRNA-Pro",
+    "ctg1\tMitoFinder\ttRNA\t100\t170\t.\t+\t.\tName=tRNA-Phe;anticodon=gaa",
+    "ctg1\tMitoFinder\trRNA\t200\t400\t.\t+\t.\tName=16S"
+  ), file.path(wd, "x_Final_Results", "x.gff"))
+  asm <- Biostrings::DNAStringSet(paste(rep("A", 500), collapse = ""))
+  names(asm) <- "ctg1"
+
+  res <- .parse_mitofinder_gff(wd, asm, "2")
+
+  expect_equal(res$anticodon[res$gene == "trnP"], "NNN")
+  expect_equal(res$anticodon[res$gene == "trnF"], "GAA")
+  expect_false(any(is.na(res$anticodon[res$type == "tRNA"])))
+  # non-tRNA features keep NA rather than a bogus sentinel
+  expect_true(is.na(res$anticodon[res$type == "rRNA"]))
+})

--- a/tests/testthat/test-annotate-mitofinder.R
+++ b/tests/testthat/test-annotate-mitofinder.R
@@ -93,9 +93,11 @@ test_that("annotate_mitofinder returns typed empty frame when db missing", {
   ))
 })
 
-test_that(".parse_mitofinder_gff fills a missing tRNA anticodon with NNN", {
-  # MitoFinder GFFs frequently omit the anticodon attribute. Leaving it NA
-  # crashed export_files() at `if (cur$anticodon != "NNN")`.
+test_that(".parse_mitofinder_gff leaves a missing tRNA anticodon as NA, not NNN", {
+  # MitoFinder GFFs frequently omit the anticodon attribute. It must stay NA:
+  # "NNN" is the sentinel for a tool that tried to call the anticodon and failed,
+  # and validate_mito_core() raises a low-confidence warning on it. The NA is made
+  # safe at the consumer instead (see the export_files() guard).
   wd <- tempfile("mf_ac_")
   dir.create(file.path(wd, "x_Final_Results"), recursive = TRUE)
   writeLines(c(
@@ -109,9 +111,24 @@ test_that(".parse_mitofinder_gff fills a missing tRNA anticodon with NNN", {
 
   res <- .parse_mitofinder_gff(wd, asm, "2")
 
-  expect_equal(res$anticodon[res$gene == "trnP"], "NNN")
-  expect_equal(res$anticodon[res$gene == "trnF"], "GAA")
-  expect_false(any(is.na(res$anticodon[res$type == "tRNA"])))
-  # non-tRNA features keep NA rather than a bogus sentinel
+  expect_true(is.na(res$anticodon[res$gene == "trnP"]))   # absent attribute -> NA
+  expect_equal(res$anticodon[res$gene == "trnF"], "GAA")  # present attribute -> parsed
+  # ...and specifically NOT the low-confidence sentinel, which would make
+  # validate_mito_core() warn on every MitoFinder gap-filled tRNA.
+  expect_false(any(res$anticodon[res$type == "tRNA"] %in% "NNN"))
   expect_true(is.na(res$anticodon[res$type == "rRNA"]))
+})
+
+test_that("export_files tolerates an NA anticodon on a tRNA row", {
+  # The half of the fix that actually rescues an existing project: rows already in
+  # the DB carry NA regardless of what annotate_mitofinder() does from now on.
+  # `if (cur$anticodon != "NNN")` on NA aborted the export mid-sample.
+  guard <- function(anticodon) {
+    if (!is.na(anticodon) && anticodon != "NNN") "note written" else "note skipped"
+  }
+  expect_equal(guard(NA_character_), "note skipped")
+  expect_equal(guard("NNN"), "note skipped")
+  expect_equal(guard("GAA"), "note written")
+  # The pre-fix condition is what crashed; keep a live record of that.
+  expect_error(if (NA_character_ != "NNN") TRUE, "missing value where TRUE/FALSE needed")
 })


### PR DESCRIPTION
## Problem

Exporting a MitoFinder-annotated sample aborted after printing a single SeqID to the console, with no error surfaced in the app.

`export_files()` evaluates:

```r
if (cur$anticodon != "NNN") {
```

on an `NA` anticodon, which raises `missing value where TRUE/FALSE needed` inside `purrr::pwalk`, immediately after the `message(paste0(.seqid, ":"))` progress line.

## Root cause

`annotate_mitofinder()` stores `anticodon = toupper(anticodon)`, which is `NA` whenever the MitoFinder GFF carries no `anticodon=` attribute. That is normal MitoFinder output, not a malformed file: both example GFFs shipped in this repo contain zero anticodon attributes. MitoFinder transfers annotations from a reference and does not call anticodons at all.

## Why it looked multi-scaffold specific

MitoFinder is the lowest-priority annotator and only fills gaps: its calls are dropped where they overlap an existing annotation. So its rows survive mainly on the secondary scaffolds of a fragmented assembly, which the higher-priority tools left bare. Single-scaffold samples rarely retain any MitoFinder row at all.

## Fix

One line, at the consumer:

```r
if (!is.na(cur$anticodon) && cur$anticodon != "NNN") {
```

`NA` is the correct stored value here, so it is made safe where it is read rather than overwritten at the source. This also covers ARWEN and ARAGORN rows, which build the anticodon from a regex capture group and yield `NA` on a non-match.

Fixing it at the consumer is also what actually helps the reporting user: their annotations are already in the database with `NA`, so a change to `annotate_mitofinder()` would only affect future annotate runs.

### Rejected alternative

The first version of this PR also stamped `"NNN"` onto MitoFinder tRNAs at the source. That was reverted in 211bd1b after review. `"NNN"` is not a neutral placeholder in this codebase - it means a tool tried to call the anticodon and failed, and `validate_mito_core.R:218` raises `low-confidence tRNA (NNN anticodon)` on it, inside a `type == "tRNA"` branch with no tool filter. Stamping it added one un-suppressible warning per gap-filled tRNA, persisted to `annotate.warnings` and surfaced in the Warnings column, the warnings filter, and the exported per-sample CSV.

Retention is unaffected either way: both NNN filters in `annotate.R` whitelist `is.na(anticodon)`, and MitoFinder rows are bound in after them regardless, so `main` and this branch keep the identical rows.

## Verification

Reproduced against a real project database by inserting one MitoFinder-shaped tRNA row (`anticodon` NULL, `tool = 'MitoFinder'`) on the second scaffold of a real two-scaffold sample:

```
ERROR: Caused by error in `if (cur$anticodon != "NNN") ...`:
! missing value where TRUE/FALSE needed
```

After the fix the export completes and the tRNA is written to the `.tbl` with no anticodon note, which is the correct rendering for an unresolved anticodon. Re-verified after the revert, confirming the guard alone is sufficient.

Tests assert the anticodon stays `NA` and is specifically not `"NNN"`, plus the guard condition itself. Full `testthat` suite green.

## Not covered

No real MitoFinder execution (synthetic GFFs plus the two shipped example GFFs). No `table2asn` validation of the resulting `.tbl`. Other NA-sensitive `if()` conditions in `export_files()` were not audited; the sibling `if (stringr::str_detect(cur$translation, "\*"))` in the PCG branch has the same shape but no known producer of an NA translation.
