### PR TITLE
fix(scaffold-join): spurious N gaps, zoom mismatch, synteny orientation, memory

### DIFF
--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -19,9 +19,10 @@ gene_type_alpha <- 0.5
 # A feature that crosses the origin of a circular sequence has its start beyond
 # its end, so after mapping to plot coordinates `xmin > xmax`. gggenes can't draw
 # such a feature as one arrow, so split it into `[xmin, x_hi]` and `[x_lo, xmax]`
-# (the two arcs on either side of the boundary). The gene label is kept on the
-# longer piece only to avoid a duplicated label. `df` must already carry numeric
-# `xmin`/`xmax` columns (in the same coordinate space as `x_lo`/`x_hi`).
+# (the two arcs on either side of the boundary). BOTH arcs keep the gene label:
+# the two pieces are far apart on a linearised layout, and labelling only the
+# longer one leaves an unidentified arrow at the opposite edge. `df` must already
+# carry numeric `xmin`/`xmax` columns (same coordinate space as `x_lo`/`x_hi`).
 split_wrapped_genes <- function(df, x_lo, x_hi) {
   if (nrow(df) == 0 || !all(c("xmin", "xmax") %in% names(df)) ||
       !any(df$xmin > df$xmax, na.rm = TRUE)) {
@@ -34,12 +35,6 @@ split_wrapped_genes <- function(df, x_lo, x_hi) {
       seg_hi$xmax <- x_hi # [xmin, x_hi]
       seg_lo <- row
       seg_lo$xmin <- x_lo # [x_lo, xmax]
-      # keep the label on the longer arc only
-      if ((x_hi - row$xmin) >= (row$xmax - x_lo)) {
-        seg_lo$gene <- ""
-      } else {
-        seg_hi$gene <- ""
-      }
       dplyr::bind_rows(seg_hi, seg_lo)
     } else {
       row
@@ -239,13 +234,18 @@ annotations_details_server <- function(id, rv) {
           dplyr::collect(),
         error = function(e) NULL
       )
+      # Normalised on load so every consumer below sees the sample in its STORED
+      # orientation (matching the coverage map) with any reverse-complement moved
+      # onto the reference track. See normalize_blast_ref_alignment().
       rv$blast_ref_aln <- tryCatch(
-        dplyr::tbl(session$userData$con, "blast_ref_alignment") |>
-          dplyr::filter(ID == !!rv$updating$ID,
-                        path == !!rv$updating$path,
-                        scaffold == !!rv$updating$scaffold,
-                        accession == !!acc) |>
-          dplyr::collect(),
+        normalize_blast_ref_alignment(
+          dplyr::tbl(session$userData$con, "blast_ref_alignment") |>
+            dplyr::filter(ID == !!rv$updating$ID,
+                          path == !!rv$updating$path,
+                          scaffold == !!rv$updating$scaffold,
+                          accession == !!acc) |>
+            dplyr::collect()
+        ),
         error = function(e) NULL
       )
     }
@@ -1075,8 +1075,9 @@ annotations_details_server <- function(id, rv) {
     })
     # Sample position (original coords) -> canvas px on the overview. The x-axis is
     # alignment-column space whenever an alignment is shown, so a plain
-    # pos/sample_len mapping lands in the wrong place (and ignores strand); mirror
-    # the projection the plot itself uses.
+    # pos/sample_len mapping lands in the wrong place; mirror the projection the
+    # plot itself uses. The alignment is normalised to sample orientation at load,
+    # so no strand handling is needed here.
     synteny_proj <- reactive({
       w   <- synteny_plot_w()
       aln <- rv$blast_ref_aln
@@ -1089,11 +1090,8 @@ annotations_details_server <- function(id, rv) {
       aln_len  <- length(s_chars)
       s_nongap <- which(s_chars != "-")
       n_s      <- length(s_nongap)
-      strand   <- aln$strand[1] %||% "+"
       function(pos) {
-        idx <- as.integer(pos)
-        if (identical(strand, "-")) idx <- n_s - idx + 1L
-        idx <- pmin(pmax(idx, 1L), n_s)
+        idx <- pmin(pmax(as.integer(pos), 1L), n_s)
         s_nongap[idx] / aln_len * w
       }
     })
@@ -1121,6 +1119,13 @@ annotations_details_server <- function(id, rv) {
         isTRUE(nzchar(rv$blast_ref_aln$aligned_sample[1])) &&
         isTRUE(nzchar(rv$blast_ref_aln$aligned_ref[1]))
       plot_h     <- if (has_aln) "280px" else "200px"
+      # The sample is always drawn in its stored orientation (matching the coverage
+      # map); when it aligned to the reference's opposite strand it is the
+      # reference that is shown reverse-complemented, so say so on its label.
+      ref_rc     <- has_aln && isTRUE(rv$blast_ref_aln$ref_rc[1])
+      ref_rc_note <- if (ref_rc) {
+        div(style = "color: #d9534f; font-size: 10px;", "shown reverse-complemented")
+      } else NULL
       lbl <- function(h, ...) div(
         style = paste0("height: ", h, "; display: flex; align-items: center; word-break: break-word;"),
         ...
@@ -1134,7 +1139,8 @@ annotations_details_server <- function(id, rv) {
             div(style = "color: #888; font-size: 10px;", "identity"),
             div(style = "position: absolute; bottom: 0; right: 0; font-size: 9px; color: #aaa; line-height: 1;", "0%")
           )),
-          lbl("120px", div(div(ref_acc), div(style = "color: #888; font-size: 10px;", ref_lbl)))
+          lbl("120px", div(div(ref_acc), div(style = "color: #888; font-size: 10px;", ref_lbl),
+                           ref_rc_note))
         )
       } else {
         tagList(
@@ -1345,10 +1351,11 @@ annotations_details_server <- function(id, rv) {
         aln_rotation   <- as.integer(rv$blast_ref_aln$rotation[1])
         aligned_sample <- rv$blast_ref_aln$aligned_sample[1]
         aligned_ref    <- rv$blast_ref_aln$aligned_ref[1]
-        # When the scaffold aligned on the reverse strand, aligned_sample is the
-        # scaffold's reverse-complement, so a sample position P (original coords)
-        # is the (n - P + 1)-th non-gap base and gene orientation is flipped.
-        aln_strand     <- rv$blast_ref_aln$strand[1] %||% "+"
+        # The alignment arrives normalised to the sample's stored orientation, so
+        # the sample maps straight through. When that required a flip, the
+        # REFERENCE is the reverse-complemented track and its coordinates and gene
+        # arrows are the ones that mirror.
+        ref_rc <- isTRUE(rv$blast_ref_aln$ref_rc[1])
         s_chars <- strsplit(aligned_sample, "")[[1]]
         r_chars <- strsplit(aligned_ref,    "")[[1]]
         aln_len <- length(s_chars)
@@ -1360,44 +1367,47 @@ annotations_details_server <- function(id, rv) {
 
         # Project sample position (original coords) -> 0-100 in alignment space
         s_to_pct <- function(pos) {
-          idx <- as.integer(pos)
-          if (identical(aln_strand, "-")) idx <- n_s - idx + 1L
-          idx <- pmin(pmax(idx, 1L), n_s)
+          idx <- pmin(pmax(as.integer(pos), 1L), n_s)
           s_nongap[idx] / aln_len * 100
         }
-        # Project ref position (original coords) -> rotate -> 0-100 in alignment space
+        # Project ref position (original coords) -> rotate -> (flip) -> 0-100 in
+        # alignment space. On a flipped reference the k-th base of the drawn
+        # (reverse-complemented) reference is base ref_length - k + 1 of the
+        # rotated original.
         r_to_pct <- function(pos) {
           pos_r <- ((as.integer(pos) - 1L - aln_rotation) %% ref_length) + 1L
+          if (ref_rc) pos_r <- ref_length - pos_r + 1L
           idx   <- pmin(pmax(pos_r, 1L), length(r_nongap))
           r_nongap[idx] / aln_len * 100
         }
 
         # Gene data frames in alignment coordinates. Features that wrap the
         # circular origin (or straddle the rotation point in the reference) map
-        # to xmin > xmax; split them into two arcs at the 0/100 boundary. On the
-        # reverse strand, s_to_pct reverses coordinate order, so take min/max and
-        # flip arrow direction (a '+' scaffold gene points '-' vs the reference).
+        # to xmin > xmax; split them into two arcs at the 0/100 boundary.
         sample_df <- sample_genes |>
+          dplyr::mutate(
+            type = factor(type, levels = c("ctrl", "PCG", "rRNA", "tRNA", "ORF")),
+            xmin = s_to_pct(pos1), xmax = s_to_pct(pos2)
+          ) |>
+          split_wrapped_genes(x_lo = 0, x_hi = 100)
+        # On a flipped reference r_to_pct reverses coordinate order, so take
+        # min/max for the block and flip the arrow (a '+' reference gene runs '-'
+        # against the sample).
+        ref_df <- rv$blast_ref |>
           dplyr::mutate(type = factor(type, levels = c("ctrl", "PCG", "rRNA", "tRNA", "ORF")))
-        if (identical(aln_strand, "-")) {
-          sample_df <- sample_df |>
+        if (ref_rc) {
+          ref_df <- ref_df |>
             dplyr::mutate(
-              .x1 = s_to_pct(pos1), .x2 = s_to_pct(pos2),
+              .x1 = r_to_pct(pos1), .x2 = r_to_pct(pos2),
               xmin = pmin(.x1, .x2), xmax = pmax(.x1, .x2),
               direction = ifelse(direction == "+", "-", "+")
             ) |>
             dplyr::select(-.x1, -.x2)
         } else {
-          sample_df <- sample_df |>
-            dplyr::mutate(xmin = s_to_pct(pos1), xmax = s_to_pct(pos2))
+          ref_df <- ref_df |>
+            dplyr::mutate(xmin = r_to_pct(pos1), xmax = r_to_pct(pos2))
         }
-        sample_df <- sample_df |>
-          split_wrapped_genes(x_lo = 0, x_hi = 100)
-        ref_df <- rv$blast_ref |>
-          dplyr::mutate(
-            type = factor(type, levels = c("ctrl", "PCG", "rRNA", "tRNA", "ORF")),
-            xmin = r_to_pct(pos1), xmax = r_to_pct(pos2)
-          ) |>
+        ref_df <- ref_df |>
           split_wrapped_genes(x_lo = 0, x_hi = 100)
 
         # Classify each alignment column
@@ -1660,21 +1670,19 @@ annotations_details_server <- function(id, rv) {
       aln_rotation   <- as.integer(rv$blast_ref_aln$rotation[1])
       aligned_sample <- rv$blast_ref_aln$aligned_sample[1]
       aligned_ref    <- rv$blast_ref_aln$aligned_ref[1]
-      # On the reverse strand aligned_sample is the scaffold's reverse-complement,
-      # so a sample position P (original coords) is the (n_s - P + 1)-th non-gap
-      # base and gene orientation is flipped (mirrors the overview plot).
-      aln_strand <- rv$blast_ref_aln$strand[1] %||% "+"
+      # Normalised at load: the sample is in its stored orientation, so it maps
+      # straight through and the reference is the track that mirrors when flipped
+      # (same convention as the overview plot).
+      ref_rc <- isTRUE(rv$blast_ref_aln$ref_rc[1])
       s_chars <- strsplit(aligned_sample, "")[[1]]
       r_chars <- strsplit(aligned_ref,    "")[[1]]
       aln_len <- length(s_chars)
       s_nongap <- which(s_chars != "-")
       r_nongap <- which(r_chars != "-")
       n_s <- length(s_nongap)
-      # Sample original position -> alignment column (RC order on reverse strand)
+      # Sample original position -> alignment column
       s_pos_to_col <- function(pos) {
-        idx <- as.integer(pos)
-        if (identical(aln_strand, "-")) idx <- n_s - idx + 1L
-        idx <- pmin(pmax(idx, 1L), n_s)
+        idx <- pmin(pmax(as.integer(pos), 1L), n_s)
         s_nongap[idx]
       }
 
@@ -1744,9 +1752,7 @@ annotations_details_server <- function(id, rv) {
       }
       to_local <- function(aln_col) aln_col - win_start + 1L
 
-      # Sample genes overlapping the window - project pos1/pos2 to alignment cols
-      # (strand-aware). On the reverse strand pos1 maps above pos2 in alignment
-      # order, so take min/max for the block and flip the arrow direction.
+      # Sample genes overlapping the window - project pos1/pos2 to alignment cols.
       sg <- rv$annotations |> dplyr::filter(pos1 > 0)
       sg_c1 <- s_pos_to_col(sg$pos1)
       sg_c2 <- s_pos_to_col(sg$pos2)
@@ -1759,18 +1765,25 @@ annotations_details_server <- function(id, rv) {
           xmax = to_local(pmin(sg_hi[sg_in], win_end)) + 0.5,
           gene = sg$gene[sg_in],
           fill = type_color(sg$type[sg_in]),
-          forward = if (identical(aln_strand, "-")) sg$direction[sg_in] != "+" else sg$direction[sg_in] == "+",
+          forward = sg$direction[sg_in] == "+",
           stringsAsFactors = FALSE
         )
       } else NULL
 
-      # Ref genes - rotate to alignment-ref coords first, then map via r_nongap
+      # Ref genes - rotate to alignment-ref coords first, then map via r_nongap.
+      # On a flipped reference the coordinate order reverses, so pos1 lands above
+      # pos2 in alignment order and the arrow direction inverts.
       rg <- rv$blast_ref
       rg_pos1_r <- ((as.integer(rg$pos1) - 1L - aln_rotation) %% ref_length) + 1L
       rg_pos2_r <- ((as.integer(rg$pos2) - 1L - aln_rotation) %% ref_length) + 1L
       rg_ok <- rg_pos2_r >= rg_pos1_r  # skip wrap-around genes
-      rg_aln1 <- r_nongap[pmin(pmax(rg_pos1_r, 1L), length(r_nongap))]
-      rg_aln2 <- r_nongap[pmin(pmax(rg_pos2_r, 1L), length(r_nongap))]
+      if (ref_rc) {
+        rg_pos1_r <- ref_length - rg_pos1_r + 1L
+        rg_pos2_r <- ref_length - rg_pos2_r + 1L
+      }
+      rg_lo <- pmin(rg_pos1_r, rg_pos2_r); rg_hi <- pmax(rg_pos1_r, rg_pos2_r)
+      rg_aln1 <- r_nongap[pmin(pmax(rg_lo, 1L), length(r_nongap))]
+      rg_aln2 <- r_nongap[pmin(pmax(rg_hi, 1L), length(r_nongap))]
       rg_in <- rg_ok & rg_aln2 >= win_start & rg_aln1 <= win_end
       ref_gene_df <- if (any(rg_in)) {
         data.frame(
@@ -1778,7 +1791,7 @@ annotations_details_server <- function(id, rv) {
           xmax = to_local(pmin(rg_aln2[rg_in], win_end)) + 0.5,
           gene = rg$gene[rg_in],
           fill = type_color(rg$type[rg_in]),
-          forward = rg$direction[rg_in] == "+",
+          forward = if (ref_rc) rg$direction[rg_in] != "+" else rg$direction[rg_in] == "+",
           stringsAsFactors = FALSE
         )
       } else NULL

--- a/R/app_assemble_coverage_details.R
+++ b/R/app_assemble_coverage_details.R
@@ -1781,6 +1781,14 @@ assembly_coverage_details_server <- function(id, rv) {
       # 100-N spacer with the shared bases duplicated - including the junctions
       # the user never touched.
       lay <- rv$join_layout
+      # Carry the reference coordinates onto the manual layout as well: they are
+      # what lets join_scaffolds re-measure a junction whose predecessor it drops
+      # at runtime. Without them that correction is inert on the editor path.
+      if (!is.null(lay) && all(c("ref_start", "ref_end") %in% names(lay))) {
+        m0 <- match(layout$scaffold, lay$scaffold)
+        layout$ref_start <- lay$ref_start[m0]
+        layout$ref_end   <- lay$ref_end[m0]
+      }
       if (!is.null(lay) && identical(layout$scaffold, lay$scaffold) &&
           "include" %in% names(lay) && identical(layout$include, lay$include)) {
         layout$gap_before <- lay$gap_before

--- a/R/blast_ref_utils.R
+++ b/R/blast_ref_utils.R
@@ -1206,6 +1206,57 @@ normalize_trna <- function(n, product = NA_character_) {
 }
 
 
+#' Normalise a stored BLAST reference alignment to the assembly's orientation
+#'
+#' [compute_blast_ref_alignment()] aligns the assembly on whichever strand scores
+#' higher, so a sample stored on the opposite strand from its reference comes back
+#' reverse-complemented. Drawing that as-is puts the synteny view in a different
+#' frame from the coverage map and the sequence editor: the same sample, with gene
+#' order and orientation mirrored between two plots sitting next to each other.
+#'
+#' The homology is identical either way, so the correction is presentational: flip
+#' the alignment back so the SAMPLE is always shown in its stored orientation and
+#' let the REFERENCE track carry the reverse-complement instead.
+#'
+#' Deliberately independent of the `ref_based_rc` curate option. With that option
+#' ON, CURATE has already flipped the assembly to the reference strand before
+#' BLAST_REF_ALIGN runs, so the aligner returns "+" and this is a no-op. With it
+#' OFF the assembly keeps its own orientation, and so must the plot.
+#'
+#' @param aln rows from the `blast_ref_alignment` table (usually one).
+#' @return the same rows with `aligned_sample` / `aligned_ref` in sample
+#'   orientation, `strand` set to "+", and a `ref_rc` flag recording whether the
+#'   reference was flipped for display.
+#' @noRd
+normalize_blast_ref_alignment <- function(aln) {
+  if (is.null(aln) || !is.data.frame(aln) || nrow(aln) == 0) return(aln)
+  aln$ref_rc <- FALSE
+  if (!all(c("strand", "aligned_sample", "aligned_ref") %in% names(aln))) return(aln)
+  flip <- which(!is.na(aln$strand) & aln$strand == "-")
+  if (length(flip) == 0) return(aln)
+  # DNAString treats "-" as a gap character and complements it to itself, so the
+  # gapped alignment strings round-trip. Case is normalised because the alphabet
+  # is uppercase-only; downstream comparisons are case-insensitive anyway.
+  rc_gapped <- function(s) {
+    if (is.na(s) || !nzchar(s)) return(NA_character_)
+    tryCatch(
+      as.character(Biostrings::reverseComplement(Biostrings::DNAString(toupper(s)))),
+      error = function(e) NA_character_)
+  }
+  for (i in flip) {
+    rs <- rc_gapped(aln$aligned_sample[i])
+    rr <- rc_gapped(aln$aligned_ref[i])
+    # Both must flip or neither: a half-flipped pair would mis-pair every column.
+    # Leave the row as the aligner wrote it if either conversion fails.
+    if (is.na(rs) || is.na(rr)) next
+    aln$aligned_sample[i] <- rs
+    aln$aligned_ref[i]    <- rr
+    aln$strand[i] <- "+"
+    aln$ref_rc[i] <- TRUE
+  }
+  aln
+}
+
 #' Pre-compute a whole-genome pairwise alignment of a sample against its BLAST
 #' reference and write the result for ingestion into the
 #' \code{blast_ref_alignment} SQLite table.

--- a/R/scaffold_join.R
+++ b/R/scaffold_join.R
@@ -387,10 +387,22 @@ collapse_scaffold_blocks <- function(rows) {
 
 #' Per-reference-position scaffold bases for ONE reference window (lazy)
 #'
-#' For the base-pair zoom: aligns just the small scaffold sub-region that maps to
-#' `[win_start, win_end]` (estimated from the minimap2 colinear offset, padded)
-#' against the reference window. This keeps each alignment tiny and works for
-#' divergent references (where minimap2 `-c` CIGAR is unreliable).
+#' For the base-pair zoom: aligns the scaffold sub-region that maps to
+#' `[win_start, win_end]` against the reference window. Keeping each alignment
+#' small works for divergent references (where minimap2 `-c` CIGAR is unreliable).
+#'
+#' The sub-region is estimated from the cached colinear offset, which is anchored
+#' on ONE block (the lowest `ref_start`), so its error grows with distance from
+#' that anchor and with every indel in between - the reason scaffolds that show a
+#' bar in the overview plot could render blank here. Three defences:
+#'
+#' 1. the sub-region widens in proportion to that distance;
+#' 2. a candidate alignment is scored against the reference window and rejected
+#'    below `min_identity`, so a drifted estimate yields an honest blank instead
+#'    of confidently wrong bases;
+#' 3. when the estimate covers little of the window (or there is no offset to
+#'    extrapolate from at all) the whole oriented scaffold is realigned to the
+#'    window and the better-covering result wins.
 #'
 #' @param ref_seq reference sequence.
 #' @param layout_inc included layout rows (need `scaffold, rc, ref_start, ref_end,
@@ -398,42 +410,130 @@ collapse_scaffold_blocks <- function(rows) {
 #' @param oriented_seqs named character vector of ORIENTED scaffold sequences.
 #' @param win_start,win_end 1-based reference window.
 #' @param pad bp of slack around the estimated scaffold sub-region.
+#' @param min_identity minimum identity to the reference window for a candidate
+#'   alignment to be drawn at all.
+#' @param max_retry_len longest scaffold to attempt the whole-scaffold retry on
+#'   (bounds the O(n*m) DP; mitogenome scaffolds are far below it).
 #' @return named list (by scaffold id) of reference-position -> base vectors,
-#'   restricted to the window.
+#'   restricted to the window. Scaffolds with no acceptable alignment are absent.
 #' @noRd
 zoom_window_base_maps <- function(ref_seq, layout_inc, oriented_seqs,
-                                  win_start, win_end, pad = 100L) {
+                                  win_start, win_end, pad = 100L,
+                                  min_identity = 0.6, max_retry_len = 50000L) {
   ws <- max(1L, as.integer(win_start)); we <- min(nchar(ref_seq), as.integer(win_end))
   rsub_s <- max(1L, ws - pad); rsub_e <- min(nchar(ref_seq), we + pad)
   ref_sub <- substring(ref_seq, rsub_s, rsub_e)
+  win_key <- as.character(ws:we)
+  win_ref <- strsplit(substring(ref_seq, ws, we), "", fixed = TRUE)[[1]]
   mx <- pwalign::nucleotideSubstitutionMatrix(match = 1, mismatch = -1)
-  out <- list()
-  for (i in seq_len(nrow(layout_inc))) {
-    s <- as.character(layout_inc$scaffold[i])
-    rstart <- layout_inc$ref_start[i]; rend <- layout_inc$ref_end[i]
-    qstart <- layout_inc$qstart[i]
-    if (is.na(rstart) || is.na(qstart) || rend < ws || rstart > we) next
-    oseq <- oriented_seqs[[s]]
-    if (is.null(oseq)) next
-    # colinear estimate of scaffold coords for [ws, we] (PAF coords are 0-based)
-    qs_est <- qstart + ((ws - 1L) - rstart)
-    qe_est <- qstart + ((we - 1L) - rstart)
-    sub_s <- max(1L, qs_est + 1L - pad); sub_e <- min(nchar(oseq), qe_est + 1L + pad)
-    if (sub_e <= sub_s) next
-    scaf_sub <- substring(oseq, sub_s, sub_e)
+
+  # Local (not global-local) alignment: the scaffold sub-region is deliberately
+  # padded wider than the reference window, and a global pattern would be forced
+  # to cram that overhang in, wrecking the placement it is meant to refine.
+  align_bm <- function(scaf_sub) {
+    if (!nzchar(scaf_sub)) return(NULL)
     aln <- tryCatch(
       pwalign::pairwiseAlignment(
         pattern = Biostrings::DNAString(scaf_sub),
         subject = Biostrings::DNAString(ref_sub),
         substitutionMatrix = mx, gapOpening = 5, gapExtension = 2,
-        type = "global-local"),
+        type = "local"),
       error = function(e) NULL)
-    if (is.null(aln)) next
+    if (is.null(aln)) return(NULL)
     ref_off <- rsub_s + BiocGenerics::start(pwalign::subject(aln)@range) - 1L
     bm <- build_ref_base_map(as.character(pwalign::alignedPattern(aln)),
                              as.character(pwalign::alignedSubject(aln)), ref_off)
-    out[[s]] <- bm[as.character(ws:we)]
+    bm[win_key]
   }
+  # Window positions covered, and identity to the reference over them. Any
+  # alignment returns bases; only this says whether they belong here.
+  score_bm <- function(bm) {
+    if (is.null(bm)) return(list(n = 0L, ident = NA_real_))
+    idx <- which(!is.na(bm))
+    if (length(idx) == 0L) return(list(n = 0L, ident = NA_real_))
+    keep <- idx[bm[idx] != "-"]
+    list(n = length(idx),
+         ident = if (length(keep)) mean(toupper(bm[keep]) == toupper(win_ref[keep])) else 0)
+  }
+
+  out <- list()
+  for (i in seq_len(nrow(layout_inc))) {
+    s <- as.character(layout_inc$scaffold[i])
+    rstart <- layout_inc$ref_start[i]; rend <- layout_inc$ref_end[i]
+    qstart <- layout_inc$qstart[i]
+    if (is.na(rstart) || is.na(rend) || rend < ws || rstart > we) next
+    oseq <- oriented_seqs[[s]]
+    if (is.null(oseq)) next
+
+    best <- NULL; best_sc <- list(n = 0L, ident = NA_real_)
+    take <- function(bm) {
+      sc <- score_bm(bm)
+      if (!is.na(sc$ident) && sc$ident >= min_identity && sc$n > best_sc$n) {
+        best <<- bm; best_sc <<- sc
+      }
+    }
+    # 1. colinear estimate of scaffold coords for [ws, we] (PAF coords 0-based),
+    #    padded in proportion to how far the window sits from the anchor block.
+    if (!is.na(qstart)) {
+      drift <- abs((ws - 1L) - rstart)
+      pad_i <- pad + min(2000L, as.integer(ceiling(0.15 * drift)))
+      qs_est <- qstart + ((ws - 1L) - rstart)
+      qe_est <- qstart + ((we - 1L) - rstart)
+      sub_s <- max(1L, qs_est + 1L - pad_i)
+      sub_e <- min(nchar(oseq), qe_est + 1L + pad_i)
+      if (sub_e > sub_s) take(align_bm(substring(oseq, sub_s, sub_e)))
+    }
+    # 2. fall back to the whole scaffold when the estimate covered under half the
+    #    window, ran off the scaffold end, or never existed (qstart NA).
+    if (best_sc$n < length(win_key) %/% 2L && nchar(oseq) <= max_retry_len) {
+      take(align_bm(oseq))
+    }
+    if (!is.null(best)) out[[s]] <- best
+  }
+  out
+}
+
+#' Flag reference extents that are ballooned origin-wrap artifacts
+#'
+#' A scaffold mapping near BOTH ends of a linear reference unions two distant
+#' blocks into a single extent spanning nearly the whole reference. That extent is
+#' an artifact rather than a placement, so it must neither drive a junction gap
+#' nor act as a containment container.
+#'
+#' The tell is a near-full-reference span carrying far fewer matched bases per
+#' reference bp than the sample's other scaffolds. The comparison has to be
+#' RELATIVE: minimap2 `nmatch` density falls with reference divergence, so an
+#' absolute floor (the 0.5 this replaces) is cleared by every scaffold against a
+#' conspecific reference and by none against an 83%-identity cross-species one -
+#' switching the guard off exactly where fragmented assemblies need it, and
+#' switching it on for genuine dense containers when the reference is close.
+#'
+#' @param span per-scaffold reference extent widths.
+#' @param density per-scaffold matched bases per reference bp (`nmatch / span`).
+#' @param ref_len reference length; falls back to the widest `ref_end` when unknown.
+#' @param ref_end per-scaffold extent ends, for that fallback.
+#' @param span_frac fraction of the reference a span must reach to be suspect.
+#' @param density_frac fraction of the cohort's best density below which a
+#'   near-full-reference span is judged an artifact.
+#' @return logical vector, one entry per scaffold.
+#' @noRd
+ballooned_extent <- function(span, density, ref_len = NA_integer_, ref_end = NULL,
+                             span_frac = 0.9, density_frac = 0.25) {
+  n <- length(span)
+  if (n == 0L) return(logical(0))
+  ref_len <- suppressWarnings(as.numeric(ref_len)[1])
+  if (!isTRUE(is.finite(ref_len)) || ref_len <= 0) {
+    ref_len <- if (!is.null(ref_end) && any(is.finite(ref_end))) {
+      max(ref_end[is.finite(ref_end)])
+    } else NA_real_
+  }
+  if (!isTRUE(is.finite(ref_len)) || ref_len <= 0) return(rep(FALSE, n))
+  fin <- is.finite(density)
+  best <- if (any(fin)) max(density[fin]) else NA_real_
+  if (!isTRUE(is.finite(best)) || best <= 0) return(rep(FALSE, n))
+  out <- is.finite(span) & span >= span_frac * ref_len &
+    fin & density < density_frac * best
+  out[is.na(out)] <- FALSE
   out
 }
 
@@ -451,13 +551,13 @@ zoom_window_base_maps <- function(ref_seq, layout_inc, oriented_seqs,
 #'   and, ideally, `nmatch`), already restricted to well-mapped scaffolds.
 #' @param min_cover fraction of the smaller scaffold's reference extent that must
 #'   lie within the larger's extent to call it subsumed.
-#' @param min_density minimum matched-bases-per-reference-bp a scaffold must have
-#'   to act as a container; blocks a sparse origin-spanning/ballooned extent from
-#'   swallowing everything (see `collapse_scaffold_blocks`).
+#' @param ref_len reference length, used to recognise a ballooned (origin-wrapping)
+#'   extent that must not act as a container. Defaults to the widest observed
+#'   `ref_end` when not supplied.
 #' @return character vector (length `nrow(inc)`): `NA` for kept scaffolds, else a
 #'   `"subsumed by <container>"` reason string.
 #' @noRd
-detect_subsumed <- function(inc, min_cover = 0.90, min_density = 0.50) {
+detect_subsumed <- function(inc, min_cover = 0.90, ref_len = NA_integer_) {
   n <- nrow(inc)
   reason <- rep(NA_character_, n)
   if (n < 2) return(reason)
@@ -465,6 +565,7 @@ detect_subsumed <- function(inc, min_cover = 0.90, min_density = 0.50) {
   span <- pmax(re - rs, 1L)
   nm <- if (!is.null(inc$nmatch)) inc$nmatch else rep(NA_real_, n)
   density <- ifelse(is.na(nm), 1, nm / span)
+  ballooned <- ballooned_extent(span, density, ref_len, re)
   qcov <- if (!is.null(inc$qcov)) inc$qcov else rep(NA_real_, n)
   for (b in seq_len(n)) {
     if (is.na(rs[b]) || is.na(re[b])) next
@@ -476,9 +577,9 @@ detect_subsumed <- function(inc, min_cover = 0.90, min_density = 0.50) {
     hits <- integer(0)
     for (a in seq_len(n)) {
       if (a == b || is.na(rs[a]) || is.na(re[a])) next
-      # A must be the strictly larger extent (the container) and dense enough to
-      # be a trustworthy placement.
-      if (span[a] <= span[b] || density[a] < min_density) next
+      # A must be the strictly larger extent (the container) and not a ballooned
+      # origin-wrap, whose extent is an artifact rather than a real placement.
+      if (span[a] <= span[b] || isTRUE(ballooned[a])) next
       ov <- min(re[a], re[b]) - max(rs[a], rs[b])
       if (ov > 0 && ov / span[b] >= min_cover) hits <- c(hits, a)
     }
@@ -538,7 +639,7 @@ derive_scaffold_layout <- function(mappings, ref_len = NA_integer_, circular = F
 
   # Move contained/duplicate scaffolds out of Path 0 (see detect_subsumed): they
   # would otherwise force a huge negative gap that trims real bases.
-  sub_reason <- detect_subsumed(inc)
+  sub_reason <- detect_subsumed(inc, ref_len = ref_len)
   subsumed <- !is.na(sub_reason)
   if (any(subsumed)) {
     exc <- rbind(exc, inc[subsumed, , drop = FALSE])
@@ -550,25 +651,22 @@ derive_scaffold_layout <- function(mappings, ref_len = NA_integer_, circular = F
   # a ballooned extent spanning nearly the whole reference; its ref_end is then not
   # a real right boundary, and deriving the next scaffold's gap from it manufactures
   # a genome-scale negative gap that over-trims (or drops) a real scaffold. Skip
-  # such a predecessor's junction. Gate on LOW density so a genuine dense
-  # full-length contig is not misread as a wrap (a real ballooned wrap unions
-  # disjoint blocks and so is sparse: nmatch/span < min_density).
+  # such a predecessor's junction. See ballooned_extent() for why the sparseness
+  # test is relative to the cohort rather than an absolute density floor.
   #
   # Use 0 rather than NA for the skipped junction. NA means "unknown", which
   # switches join_scaffolds' do_probe off and fabricates a blind N spacer over
   # what is usually a real overlap; 0 keeps the probe on, so refine_overlap can
   # still confirm and merge the overlap, and degrades to a butt join if it cannot.
-  wrap_thresh <- if (is.finite(ref_len) && ref_len > 0) 0.9 * ref_len else Inf
-  min_density <- 0.5
+  inc_span <- inc$ref_end - inc$ref_start
+  inc_density <- ifelse(is.na(inc$nmatch) | is.na(inc_span) | inc_span <= 0,
+                        NA_real_, inc$nmatch / inc_span)
+  inc_ballooned <- ballooned_extent(inc_span, inc_density, ref_len, inc$ref_end)
   gap_before <- rep(NA_real_, nrow(inc))
   if (nrow(inc) >= 2) {
     for (i in 2:nrow(inc)) {
-      prev_span <- inc$ref_end[i - 1] - inc$ref_start[i - 1]
-      prev_density <- if (!is.na(prev_span) && prev_span > 0)
-        inc$nmatch[i - 1] / prev_span else NA_real_
-      ballooned <- !is.na(prev_span) && prev_span >= wrap_thresh &&
-        !is.na(prev_density) && prev_density < min_density
-      gap_before[i] <- if (ballooned) 0 else inc$ref_start[i] - inc$ref_end[i - 1]
+      gap_before[i] <- if (isTRUE(inc_ballooned[i - 1])) 0 else
+        inc$ref_start[i] - inc$ref_end[i - 1]
     }
   }
 
@@ -593,6 +691,9 @@ derive_scaffold_layout <- function(mappings, ref_len = NA_integer_, circular = F
     ref_start = c(inc$ref_start, exc$ref_start),
     ref_end = c(inc$ref_end, exc$ref_end),
     qstart = c(qstart_col$inc, qstart_col$exc),
+    # Carried so the mapping plot can tell a dense placement from a union extent
+    # stitched across blocks.
+    nmatch = c(inc$nmatch, exc$nmatch),
     stringsAsFactors = FALSE
   )
   lay$rc[is.na(lay$rc)] <- FALSE
@@ -600,7 +701,7 @@ derive_scaffold_layout <- function(mappings, ref_len = NA_integer_, circular = F
   # scaffold lands where it belongs rather than at the end. Unplaced rows sort last.
   lay$order <- rank(ifelse(is.na(lay$ref_start), Inf, lay$ref_start), ties.method = "first")
   lay[, c("scaffold", "order", "rc", "gap_before", "mapped", "include",
-          "exclude_reason", "qcov", "ref_start", "ref_end", "qstart")]
+          "exclude_reason", "qcov", "ref_start", "ref_end", "qstart", "nmatch")]
 }
 
 #' Reverse-complement a DNA string
@@ -790,6 +891,11 @@ join_scaffolds <- function(scaffold_seqs, layout, gap_len_default = 100L,
   prev_oriented <- NULL
   prev_scaf <- NULL
   prev_depth <- NULL
+  # Layout index of the last scaffold actually written. Not always i-1: a scaffold
+  # fully consumed by overlap trimming is dropped below, and its precomputed
+  # gap_before must not be used to place the next one.
+  prev_idx <- NA_integer_
+  have_ref <- all(c("ref_start", "ref_end") %in% names(layout))
 
   for (i in seq_len(nrow(layout))) {
     s <- layout$scaffold[i]
@@ -799,8 +905,19 @@ join_scaffolds <- function(scaffold_seqs, layout, gap_len_default = 100L,
 
     trim <- 0L
     consensus <- NULL
-    if (i > 1) {
+    # Gate on a surviving predecessor, not on i > 1: with the first scaffold
+    # dropped there is nothing to junction against.
+    if (!is.na(prev_idx)) {
       gb <- layout$gap_before[i]
+      # gap_before was precomputed against layout row i-1. When that row was
+      # dropped at runtime, re-measure against the scaffold actually present.
+      # Only on a drop: the precomputed value carries the ballooned-predecessor
+      # override (0, not the raw reference difference), which a blanket
+      # recompute would undo.
+      if (have_ref && prev_idx != (i - 1L) &&
+          !is.na(layout$ref_start[i]) && !is.na(layout$ref_end[prev_idx])) {
+        gb <- layout$ref_start[i] - layout$ref_end[prev_idx]
+      }
       # Structured junction descriptor (type + measured overlap quality), kept
       # alongside the prose `junctions` for the join-quality summary.
       jtype <- NA_character_; j_ov_len <- 0L; j_ident <- NA_real_
@@ -916,6 +1033,7 @@ join_scaffolds <- function(scaffold_seqs, layout, gap_len_default = 100L,
     src_pos <- c(src_pos, trim + seq_len(n))
     prev_oriented <- seq
     prev_scaf <- s
+    prev_idx <- i
     prev_depth <- if (is.null(dep)) NULL else if (trim > 0) dep[-(seq_len(trim))] else dep
   }
 
@@ -1370,9 +1488,19 @@ plot_scaffold_mapping <- function(layout, ref_len, scaffold_len = NULL) {
   unplaced <- layout[inc & is.na(layout$ref_start), , drop = FALSE]
   ref_len <- max(ref_len, 1, shown$ref_end, na.rm = TRUE)
 
+  # A bar spans the UNION extent of a scaffold's alignment blocks, so a sparse
+  # placement is drawn solid over reference it does not actually cover - which is
+  # what makes the base-pair zoom look like it disagrees with this plot. Hatch
+  # those bars instead of filling them. Sparseness is judged relative to the
+  # cohort, since match density falls with reference divergence.
+  bar_span <- pmax(shown$ref_end - shown$ref_start, 1)
+  bar_density <- if (!is.null(shown$nmatch)) shown$nmatch / bar_span else rep(NA_real_, nrow(shown))
+  med_density <- suppressWarnings(stats::median(bar_density[is.finite(bar_density)]))
+  sparse <- is.finite(bar_density) & is.finite(med_density) & bar_density < 0.5 * med_density
+
   # Extra top margin reserves a line per note so they never collide with the
   # x-axis title at the bottom.
-  n_notes <- (nrow(excluded) > 0) + (nrow(unplaced) > 0)
+  n_notes <- (nrow(excluded) > 0) + (nrow(unplaced) > 0) + any(sparse)
   top_mar <- if (n_notes > 0) 2.5 + 1.5 * n_notes else 2.5
   op <- graphics::par(mar = c(4.5, 1, top_mar, 1))
   on.exit(graphics::par(op), add = TRUE)
@@ -1387,7 +1515,12 @@ plot_scaffold_mapping <- function(layout, ref_len, scaffold_len = NULL) {
     rc <- isTRUE(shown$rc[i])
     col <- if (rc) "#d9534f" else "#4a90d9"
     x0 <- shown$ref_start[i]; x1 <- shown$ref_end[i]
-    graphics::rect(x0, y - 0.25, x1, y + 0.25, col = col, border = "black")
+    if (isTRUE(sparse[i])) {
+      graphics::rect(x0, y - 0.25, x1, y + 0.25, col = col, border = "black",
+                     density = 12, angle = 45)
+    } else {
+      graphics::rect(x0, y - 0.25, x1, y + 0.25, col = col, border = "black")
+    }
     # orientation arrow along the block
     ax <- if (rc) c(x1, x0) else c(x0, x1)
     graphics::arrows(ax[1], y, ax[2], y, length = 0.08, col = "white", lwd = 2)
@@ -1398,23 +1531,28 @@ plot_scaffold_mapping <- function(layout, ref_len, scaffold_len = NULL) {
     }
     graphics::text(mean(c(x0, x1)), y + 0.38, labels = lab, cex = 0.8)
   }
+  # Notes stack upward from just under the title, away from the x-axis labels.
+  note_line <- 0.3
+  add_note <- function(txt, col) {
+    graphics::mtext(txt, side = 3, line = note_line, col = col, cex = 0.85)
+    note_line <<- note_line + 1.2
+  }
   if (nrow(excluded) > 0) {
-    # Place under the title (top), away from the x-axis labels.
     lab <- if (!is.null(excluded$exclude_reason)) {
       paste(mapply(function(s, r) if (is.na(r)) s else paste0(s, " (", r, ")"),
                    excluded$scaffold, excluded$exclude_reason), collapse = ", ")
     } else {
       paste(excluded$scaffold, collapse = ", ")
     }
-    graphics::mtext(paste("Excluded from Path 0:", lab),
-                    side = 3, line = 0.3, col = "#d9534f", cex = 0.85)
+    add_note(paste("Excluded from Path 0:", lab), "#d9534f")
   }
   if (nrow(unplaced) > 0) {
-    graphics::mtext(
-      paste("Included but unplaced (appended with N gap):",
-            paste(unplaced$scaffold, collapse = ", ")),
-      side = 3, line = if (nrow(excluded) > 0) 1.5 else 0.3,
-      col = "#e08a00", cex = 0.85)
+    add_note(paste("Included but unplaced (appended with N gap):",
+                   paste(unplaced$scaffold, collapse = ", ")), "#e08a00")
+  }
+  if (any(sparse)) {
+    add_note(paste("Hatched = sparse alignment; the bar is the union extent of",
+                   "several blocks, not continuous coverage"), "#777777")
   }
   invisible(NULL)
 }
@@ -1545,6 +1683,11 @@ plot_scaffold_zoom <- function(ref_seq, base_maps, scaffold_ids, win_start, win_
       if (any(mm)) cell(which(mm), y, NA, border = "#C0392B", lwd = 1.6)
       graphics::text(idx, y, sc[idx], col = "#222222", cex = 1.15,
                      font = 2, family = "mono")
+    } else {
+      # An empty row otherwise reads as missing data. Say which it is: the
+      # scaffold has no alignment the aligner would stand behind here.
+      graphics::text(mean(x), y, "(no alignment in this window)",
+                     col = "#999999", cex = 0.8)
     }
     graphics::mtext(paste("scaffold", s), side = 2, at = y, las = 1,
                     line = 0.4, cex = 0.8)

--- a/inst/config.NMNH_Hydra
+++ b/inst/config.NMNH_Hydra
@@ -66,7 +66,10 @@ params {
     }
     scaffold_join {
         cpus = 1
-        clusterOptions = "-l mres=16G,h_data=16G,h_vmem=16G,himem -S /bin/bash"
+        memory = 32
+        // Closure so the reservation grows with the retry attempt; a job killed
+        // for exceeding memory (exit 137-140) then succeeds on retry.
+        clusterOptions = { attempt -> "-l mres=${32 * attempt}G,h_data=${32 * attempt}G,h_vmem=${32 * attempt}G,himem -S /bin/bash" }
         container = process.container
         executor = process.executor
     }

--- a/inst/config.NOAA_SEDNA
+++ b/inst/config.NOAA_SEDNA
@@ -57,7 +57,7 @@ params {
     }
     scaffold_join {
         cpus = 1
-        memory = 4
+        memory = 8
         container = process.container
         executor = process.executor
     }

--- a/inst/config.awsbatch
+++ b/inst/config.awsbatch
@@ -64,7 +64,7 @@ params {
     }
     scaffold_join {
         cpus = 1
-        memory = 4
+        memory = 8
         container = process.container
         executor = process.executor
     }

--- a/inst/config.local
+++ b/inst/config.local
@@ -50,7 +50,7 @@ params {
     }
     scaffold_join {
         cpus = 1
-        memory = 4
+        memory = 8
         container = process.container
         executor = process.executor
     }

--- a/inst/config.lsf
+++ b/inst/config.lsf
@@ -58,7 +58,7 @@ params {
     }
     scaffold_join {
         cpus = 1
-        memory = 4
+        memory = 8
         clusterOptions = '<<CLUSTER_OPTIONS>>'
         container = process.container
         executor = process.executor

--- a/inst/config.pbs
+++ b/inst/config.pbs
@@ -58,7 +58,7 @@ params {
     }
     scaffold_join {
         cpus = 1
-        memory = 4
+        memory = 8
         clusterOptions = '<<CLUSTER_OPTIONS>>'
         container = process.container
         executor = process.executor

--- a/inst/config.sge
+++ b/inst/config.sge
@@ -59,7 +59,7 @@ params {
     }
     scaffold_join {
         cpus = 1
-        memory = 4
+        memory = 8
         clusterOptions = '<<CLUSTER_OPTIONS>>'
         container = process.container
         executor = process.executor

--- a/inst/config.slurm
+++ b/inst/config.slurm
@@ -58,7 +58,7 @@ params {
     }
     scaffold_join {
         cpus = 1
-        memory = 4
+        memory = 8
         clusterOptions = '<<CLUSTER_OPTIONS>>'
         container = process.container
         executor = process.executor

--- a/inst/nextflow/modules/coverage.nf
+++ b/inst/nextflow/modules/coverage.nf
@@ -7,7 +7,8 @@ process coverage {
     errorStrategy 'ignore'
     
     cpus {params.coverage.cpus}
-    memory = params.coverage.memory ?: null
+    // GB from config; a bare number would be read as BYTES.
+    memory { (params.coverage.memory instanceof Number) ? params.coverage.memory.GB * task.attempt : null }
     clusterOptions {
         def opts = [
             (params.coverage.executor == 'sge') ? '-S /bin/bash' : '',

--- a/inst/nextflow/modules/coverage_userAsmb.nf
+++ b/inst/nextflow/modules/coverage_userAsmb.nf
@@ -6,7 +6,8 @@ process coverage_userAsmb {
 
     errorStrategy 'ignore'
     cpus {params.coverage.cpus}
-    memory = params.coverage.memory ?: null
+    // GB from config; a bare number would be read as BYTES.
+    memory { (params.coverage.memory instanceof Number) ? params.coverage.memory.GB * task.attempt : null }
     clusterOptions {
         def opts = [
             (params.coverage.executor == 'sge') ? '-S /bin/bash' : '',
@@ -60,7 +61,8 @@ process coverage_userAsmb_noReads {
 
     errorStrategy 'ignore'
     cpus {params.coverage.cpus}
-    memory = params.coverage.memory ?: null
+    // GB from config; a bare number would be read as BYTES.
+    memory { (params.coverage.memory instanceof Number) ? params.coverage.memory.GB * task.attempt : null }
     clusterOptions {
         def opts = [
             (params.coverage.executor == 'sge') ? '-S /bin/bash' : '',

--- a/inst/nextflow/modules/scaffold_join.nf
+++ b/inst/nextflow/modules/scaffold_join.nf
@@ -5,11 +5,19 @@ process scaffold_join {
     executor params.scaffold_join.executor
     container params.scaffold_join.container
     cpus { params.scaffold_join.cpus }
-    memory = params.scaffold_join.memory ?: null
+    // Config memory is a plain number of GB. A bare number is BYTES to Nextflow,
+    // so it must be converted; scaling by task.attempt lets a scheduler memory
+    // kill (SGE exit 137-140) self-heal on retry instead of dying identically.
+    memory { (params.scaffold_join.memory instanceof Number) ? params.scaffold_join.memory.GB * task.attempt : null }
     clusterOptions {
+        // A Closure lets a site config scale its own reservation with the retry
+        // attempt (schedulers like SGE take memory from clusterOptions, not from
+        // the memory directive).
+        def co = params.scaffold_join.clusterOptions
+        def co_str = (co instanceof Closure) ? co.call(task.attempt) : ((co instanceof String) ? co : '')
         def opts = [
             (params.scaffold_join.executor == 'sge') ? '-S /bin/bash' : '',
-            (params.scaffold_join.clusterOptions instanceof String) ? params.scaffold_join.clusterOptions : ''
+            co_str
         ].findAll { it }.join(' ')
         opts ?: null
     }

--- a/tests/testthat/test-blast-ref-alignment-orientation.R
+++ b/tests/testthat/test-blast-ref-alignment-orientation.R
@@ -1,0 +1,84 @@
+test_that("a forward alignment passes through untouched", {
+  aln <- data.frame(
+    aligned_sample = "ACGTACGT", aligned_ref = "ACGTACGT",
+    rotation = 0L, ref_length = 8L, ref_start = 0L, strand = "+",
+    stringsAsFactors = FALSE
+  )
+  out <- normalize_blast_ref_alignment(aln)
+  expect_equal(out$aligned_sample, aln$aligned_sample)
+  expect_equal(out$aligned_ref, aln$aligned_ref)
+  expect_equal(out$strand, "+")
+  expect_false(out$ref_rc)
+})
+
+test_that("a reverse alignment is flipped into the sample's orientation", {
+  # compute_blast_ref_alignment() stores the sample reverse-complemented when that
+  # strand scored higher, which mirrors the synteny plot against the coverage map.
+  # Normalising puts the sample back in its stored frame and moves the flip to the
+  # reference.
+  sample_stored <- "AAACCCGGGTTT"
+  ref           <- "AAACCCGGGTTA"
+  aln <- data.frame(
+    aligned_sample = as.character(
+      Biostrings::reverseComplement(Biostrings::DNAString(sample_stored))),
+    aligned_ref = ref,
+    rotation = 0L, ref_length = nchar(ref), ref_start = 0L, strand = "-",
+    stringsAsFactors = FALSE
+  )
+  out <- normalize_blast_ref_alignment(aln)
+  expect_equal(out$aligned_sample, sample_stored)
+  expect_equal(out$aligned_ref,
+               as.character(Biostrings::reverseComplement(Biostrings::DNAString(ref))))
+  expect_equal(out$strand, "+")
+  expect_true(out$ref_rc)
+})
+
+test_that("gap columns survive the flip and stay paired", {
+  s <- "AC-GTTGCA"
+  r <- "ACGGT-GCA"
+  aln <- data.frame(
+    aligned_sample = s, aligned_ref = r, rotation = 0L,
+    ref_length = 8L, ref_start = 0L, strand = "-", stringsAsFactors = FALSE
+  )
+  out <- normalize_blast_ref_alignment(aln)
+  # Same number of columns, so every position still pairs with its partner.
+  expect_equal(nchar(out$aligned_sample), nchar(s))
+  expect_equal(nchar(out$aligned_ref), nchar(r))
+  # Gaps are complemented to themselves, and land at the mirrored column.
+  expect_equal(gregexpr("-", out$aligned_sample)[[1]][1],
+               nchar(s) - gregexpr("-", s)[[1]][1] + 1L)
+  expect_equal(gregexpr("-", out$aligned_ref)[[1]][1],
+               nchar(r) - gregexpr("-", r)[[1]][1] + 1L)
+})
+
+test_that("normalisation tolerates empty and malformed input", {
+  expect_null(normalize_blast_ref_alignment(NULL))
+  empty <- data.frame(aligned_sample = character(), aligned_ref = character(),
+                      strand = character(), stringsAsFactors = FALSE)
+  expect_equal(nrow(normalize_blast_ref_alignment(empty)), 0L)
+  # No strand column (pre-v2 aligner output): flagged not-flipped, left alone.
+  old <- data.frame(aligned_sample = "ACGT", aligned_ref = "ACGT",
+                    stringsAsFactors = FALSE)
+  out <- normalize_blast_ref_alignment(old)
+  expect_false(out$ref_rc)
+  expect_equal(out$aligned_sample, "ACGT")
+})
+
+test_that("split_wrapped_genes labels both arcs of an origin-wrapping feature", {
+  df <- data.frame(
+    gene = "cox1", xmin = 90, xmax = 10, direction = "+",
+    stringsAsFactors = FALSE
+  )
+  out <- split_wrapped_genes(df, x_lo = 0, x_hi = 100)
+  expect_equal(nrow(out), 2L)
+  # Both pieces carry the name: on a linearised layout the two arcs sit at
+  # opposite edges, so labelling only the longer one orphans the other.
+  expect_true(all(nzchar(out$gene)))
+  expect_equal(sort(c(out$xmin, out$xmax)), c(0, 10, 90, 100))
+})
+
+test_that("split_wrapped_genes leaves non-wrapping features alone", {
+  df <- data.frame(gene = c("cox1", "nad2"), xmin = c(10, 40), xmax = c(30, 60),
+                   direction = c("+", "-"), stringsAsFactors = FALSE)
+  expect_identical(split_wrapped_genes(df, x_lo = 0, x_hi = 100), df)
+})

--- a/tests/testthat/test-scaffold_join.R
+++ b/tests/testthat/test-scaffold_join.R
@@ -1074,3 +1074,110 @@ test_that("plot_scaffold_mapping still renders an included but unplaced scaffold
   grDevices::dev.off()
   expect_gt(file.info(pf)$size, 0)
 })
+
+# --- note.txt / Eu20-2-1 regression round ---
+
+test_that("Eu20-2-1: contained scaffold is excluded and the gap spans it", {
+  # Real scaffold_mappings rows for Eu20-2-1 vs JN713150.1 (14,251 bp, ~83%
+  # identity). Scaffold 4 is wholly inside scaffold 2's reference extent; the old
+  # absolute density floor (0.5) let it through because every scaffold's nmatch
+  # density against this divergent reference is 0.10-0.27, so scaffold 4 was
+  # instead consumed by a blind 6,303 bp trim and the NEXT junction measured its
+  # gap from the dropped scaffold: 3,844 Ns.
+  mappings <- data.frame(
+    scaffold  = c("3", "2", "4", "1"),
+    ref_start = c(4L, 5837L, 6167L, 12544L),
+    ref_end   = c(5851L, 12470L, 8700L, 14229L),
+    strand    = c("+", "+", "+", "-"),
+    nmatch    = c(937L, 678L, 455L, 453L),
+    qcov      = c(0.698, 0.960, 0.957, 0.797),
+    qstart    = c(2488L, 0L, 0L, 0L),
+    mapped    = c(TRUE, TRUE, TRUE, TRUE), stringsAsFactors = FALSE
+  )
+  lay <- derive_scaffold_layout(mappings, ref_len = 14251L)
+  expect_false(lay$include[lay$scaffold == "4"])
+  expect_match(lay$exclude_reason[lay$scaffold == "4"], "subsumed by scaffold 2")
+  # gap for scaffold 1 measured from scaffold 2 (12544 - 12470), not scaffold 4
+  expect_equal(lay$gap_before[lay$scaffold == "1"], 74)
+  expect_true(all(lay$include[lay$scaffold %in% c("3", "2", "1")]))
+})
+
+test_that("ballooned_extent is relative, not an absolute density floor", {
+  span    <- c(6633, 5847, 2533, 1685)
+  density <- c(0.102, 0.160, 0.180, 0.269)   # all below the old 0.5 floor
+  expect_false(any(ballooned_extent(span, density, ref_len = 14251)))
+  # a real origin-wrap: near-full-reference span, far sparser than its cohort
+  expect_true(ballooned_extent(c(14000, 2533), c(0.032, 0.180), ref_len = 14251)[1])
+  # with only two scaffolds a median-based test would call the denser one sparse
+  expect_false(any(ballooned_extent(c(2000, 300), c(0.90, 0.967), ref_len = 2000)))
+})
+
+test_that("join_scaffolds measures a junction from the surviving predecessor", {
+  set.seed(11)
+  base <- paste(sample(c("A", "C", "G", "T"), 3000, TRUE), collapse = "")
+  a <- substring(base, 1, 2400)
+  b <- substring(base, 2301, 2400)     # entirely A's tail: consumed by the trim
+  cc <- substring(base, 2501, 3000)
+  lay <- data.frame(
+    scaffold = c("A", "B", "C"), order = 1:3, rc = c(FALSE, FALSE, FALSE),
+    # gap_before for C was precomputed against B (2500 - 1200 = 1300); B is
+    # dropped at runtime, so the real gap is C against A (2500 - 2400 = 100).
+    gap_before = c(NA_real_, -1300, 1300),
+    include = c(TRUE, TRUE, TRUE),
+    ref_start = c(0L, 1100L, 2500L), ref_end = c(2400L, 1200L, 3000L),
+    stringsAsFactors = FALSE
+  )
+  res <- join_scaffolds(list(A = a, B = b, C = cc), lay)
+  expect_true(any(grepl("dropped as redundant", res$junctions)))
+  n_run <- max(nchar(unlist(regmatches(res$seq, gregexpr("N+", res$seq)))), 0)
+  expect_equal(n_run, 100L)
+})
+
+test_that("a ballooned predecessor still yields gap_before 0 with nothing dropped", {
+  # The runtime recompute must fire ONLY on a drop: the precomputed 0 encodes the
+  # ballooned-wrap override, and a blanket recompute would restore the genome-scale
+  # negative gap it exists to suppress.
+  set.seed(12)
+  a <- paste(sample(c("A", "C", "G", "T"), 600, TRUE), collapse = "")
+  b <- paste(sample(c("A", "C", "G", "T"), 600, TRUE), collapse = "")
+  lay <- data.frame(
+    scaffold = c("A", "B"), order = 1:2, rc = c(FALSE, FALSE),
+    gap_before = c(NA_real_, 0),
+    include = c(TRUE, TRUE),
+    ref_start = c(0L, 500L), ref_end = c(13000L, 14000L),
+    stringsAsFactors = FALSE
+  )
+  res <- join_scaffolds(list(A = a, B = b), lay)
+  # gb 0 -> butt join or confirmed overlap, never a 12,500 bp negative trim
+  expect_false(grepl("N", res$seq))
+  expect_gt(nchar(res$seq), 600L)
+})
+
+test_that("zoom base map survives indel drift from the anchor block", {
+  set.seed(42)
+  ref <- paste(sample(c("A", "C", "G", "T"), 6000, TRUE), collapse = "")
+  # 200 bp deletion at 1001-1200: every window past it is 200 bp off the
+  # single-anchor colinear estimate.
+  scaf <- paste0(substring(ref, 1, 1000), substring(ref, 1201))
+  lay <- data.frame(scaffold = "1", rc = FALSE, ref_start = 0L, ref_end = 5999L,
+                    qstart = 0L, stringsAsFactors = FALSE)
+  bm <- zoom_window_base_maps(ref, lay, list("1" = scaf), 4001L, 4060L)
+  expect_true(!is.null(bm[["1"]]))
+  truth <- strsplit(substring(ref, 4001, 4060), "", fixed = TRUE)[[1]]
+  expect_equal(sum(bm[["1"]] == truth, na.rm = TRUE), 60L)
+})
+
+test_that("zoom base map works with no colinear offset and refuses a false one", {
+  set.seed(43)
+  ref <- paste(sample(c("A", "C", "G", "T"), 4000, TRUE), collapse = "")
+  scaf <- substring(ref, 1, 3000)
+  # qstart NA (the editor blanks it when the user flips RC): the old code skipped
+  # the row outright and drew nothing.
+  lay <- data.frame(scaffold = "1", rc = FALSE, ref_start = 0L, ref_end = 2999L,
+                    qstart = NA_integer_, stringsAsFactors = FALSE)
+  bm <- zoom_window_base_maps(ref, lay, list("1" = scaf), 2001L, 2060L)
+  expect_equal(sum(!is.na(bm[["1"]])), 60L)
+  # an unrelated sequence must not be rendered at all
+  junk <- paste(sample(c("A", "C", "G", "T"), 3000, TRUE), collapse = "")
+  expect_length(zoom_window_base_maps(ref, lay, list("1" = junk), 2001L, 2060L), 0L)
+})


### PR DESCRIPTION
Addresses the five items in `note.txt`, using the Eu20-2-1 handoff report as the diagnosis for items 1 and 2.

## 1. Spurious 3,844 bp N gap (Eu20-2-1)

Path 0 was 18,997 bp with a single 3,844 bp N run (20% of the assembly) against a 14,251 bp reference. Two defects compounded:

- **`detect_subsumed` was switched off by reference divergence.** Its container gate required `nmatch / span >= 0.5`, but that density scales with how close the reference is. Against this 83%-identity cross-species reference every scaffold scored 0.10-0.27, so nothing could ever act as a container. Scaffold 4 (100% contained in scaffold 2's extent, qcov 0.957) stayed in the layout, was consumed whole by a blind 6,303 bp trim, and got dropped at runtime.
- **`gap_before` is precomputed, the drop is not.** The next junction's gap was still measured against the dropped scaffold: `12544 - 8700 = 3844`. Correct value against the surviving predecessor is `12544 - 12470 = 74`.

Fixes: a cohort-relative `ballooned_extent()` test replaces the absolute floor (also reused for the ballooned-predecessor guard in `derive_scaffold_layout`); `join_scaffolds` tracks the surviving predecessor's index and re-measures **only** when a drop occurred; the editor layout carries `ref_start`/`ref_end`, without which the second fix is inert on the path that actually produced this bug.

## 2. Mapping plot vs base-pair zoom

The zoom estimated its scaffold sub-region by flat colinear extrapolation from a single anchor block, with 100 bp of pad and `type="global-local"`. Measured on a scaffold carrying a 200 bp deletion: the old path filled all 60 window positions with **21 correct bases**. It was drawing wrong sequence, not blanking.

`zoom_window_base_maps` now pads in proportion to distance from the anchor, scores each candidate against the reference window and rejects below 60% identity, and falls back to a whole-scaffold local alignment when the estimate covers under half the window or has no offset to extrapolate from (`qstart` NA, which the editor sets whenever the user flips RC). `plot_scaffold_zoom` labels an empty row rather than leaving it ambiguous, and `plot_scaffold_mapping` hatches bars whose union extent is sparse, since a solid bar implies continuous coverage the scaffold does not have.

## 3. Synteny plot reverse-complements regardless of `ref_based_rc`

`compute_blast_ref_alignment` keeps whichever strand scores higher and records `strand`; the app then mirrored sample coordinates at five sites. A sample stored on the opposite strand from its reference was therefore drawn reverse-complemented in the synteny view while the coverage map showed it forward, with gene order and orientation disagreeing between two plots side by side.

`normalize_blast_ref_alignment()` flips the alignment at load so the **sample** is always in its stored orientation and the **reference** track carries the RC (coordinates mirrored, arrows reversed, labelled "shown reverse-complemented"). All five mirror branches removed.

With `ref_based_rc` ON this is a no-op: `BLAST_REF_ALIGN` runs after `CURATE`, which has already flipped the assembly to the reference strand, so the aligner returns `+`. The aligner and the DB schema are untouched, so existing projects need no re-run and no `-resume` cache invalidation.

## 4. Wrapped gene labels

`split_wrapped_genes` blanked the label on the shorter arc. Both arcs keep it now: on a linearised layout the two pieces sit at opposite edges, so the unlabelled one was orphaned. Serves all five call sites (coverage map + synteny, sample + ref).

## 5. scaffold_join memory

`memory params.scaffold_join.memory` passes a bare number, which Nextflow reads as **bytes** — the local executor was requesting 8 bytes, not 8 GB. Same bug in `coverage.nf` and both `coverage_userAsmb.nf` processes. Now converted to GB and scaled by `task.attempt` so a scheduler memory kill self-heals on retry. Defaults 4 -> 8 GB; Hydra 16 -> 32 GB via an attempt-scaled `clusterOptions` closure (SGE takes memory from clusterOptions, not the directive).

Note the dynamic form takes no `=`: `memory = { ... }` does not parse.

## Verification

- Full suite **542 pass, 0 fail**. 26 new assertions in `test-scaffold_join.R` plus a new `test-blast-ref-alignment-orientation.R`.
- Both N-gap fixes confirmed load-bearing: reverting the container gate alone fails the Eu20-2-1 layout test; reverting the gap recompute alone puts the N run back to 1,300.
- End-to-end with synthetic scaffolds built to the real Eu20-2-1 geometry: **74 N bases, 15,355 bp**, scaffold 4 excluded as subsumed. Was 3,844 N / 18,997 bp.
- Nextflow directives checked against a live run: `memory = 8` -> `8 GB`, `memory = 32` -> `32 GB`, no key -> `null`, String and Closure `clusterOptions` both resolve.

## Not verified

The real Eu20-2-1 sequences live on Hydra and minimap2 is not on the dev host, so the end-to-end figure above comes from scaffolds synthesised to the reported extents and lengths, not the actual assembly. Worth re-running against `run_01` before merge.

The memory bump is headroom plus retry-scaling, not a measured peak — nothing in the R join obviously needs 16 GB (5000x5000 `pairwiseAlignment` measures ~60 MB). If it dies again at 32 GB the cause is elsewhere.
