### PR TITLE
Scaffold join: placement, junction and orientation fixes; live join editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ CLAUDE.md
 .codex
 .positai
 data-raw
+dev
 .serena
 ~$*

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -19,9 +19,10 @@ gene_type_alpha <- 0.5
 # A feature that crosses the origin of a circular sequence has its start beyond
 # its end, so after mapping to plot coordinates `xmin > xmax`. gggenes can't draw
 # such a feature as one arrow, so split it into `[xmin, x_hi]` and `[x_lo, xmax]`
-# (the two arcs on either side of the boundary). The gene label is kept on the
-# longer piece only to avoid a duplicated label. `df` must already carry numeric
-# `xmin`/`xmax` columns (in the same coordinate space as `x_lo`/`x_hi`).
+# (the two arcs on either side of the boundary). BOTH arcs keep the gene label:
+# the two pieces are far apart on a linearised layout, and labelling only the
+# longer one leaves an unidentified arrow at the opposite edge. `df` must already
+# carry numeric `xmin`/`xmax` columns (same coordinate space as `x_lo`/`x_hi`).
 split_wrapped_genes <- function(df, x_lo, x_hi) {
   if (nrow(df) == 0 || !all(c("xmin", "xmax") %in% names(df)) ||
       !any(df$xmin > df$xmax, na.rm = TRUE)) {
@@ -34,12 +35,6 @@ split_wrapped_genes <- function(df, x_lo, x_hi) {
       seg_hi$xmax <- x_hi # [xmin, x_hi]
       seg_lo <- row
       seg_lo$xmin <- x_lo # [x_lo, xmax]
-      # keep the label on the longer arc only
-      if ((x_hi - row$xmin) >= (row$xmax - x_lo)) {
-        seg_lo$gene <- ""
-      } else {
-        seg_hi$gene <- ""
-      }
       dplyr::bind_rows(seg_hi, seg_lo)
     } else {
       row
@@ -239,13 +234,18 @@ annotations_details_server <- function(id, rv) {
           dplyr::collect(),
         error = function(e) NULL
       )
+      # Normalised on load so every consumer below sees the sample in its STORED
+      # orientation (matching the coverage map) with any reverse-complement moved
+      # onto the reference track. See normalize_blast_ref_alignment().
       rv$blast_ref_aln <- tryCatch(
-        dplyr::tbl(session$userData$con, "blast_ref_alignment") |>
-          dplyr::filter(ID == !!rv$updating$ID,
-                        path == !!rv$updating$path,
-                        scaffold == !!rv$updating$scaffold,
-                        accession == !!acc) |>
-          dplyr::collect(),
+        normalize_blast_ref_alignment(
+          dplyr::tbl(session$userData$con, "blast_ref_alignment") |>
+            dplyr::filter(ID == !!rv$updating$ID,
+                          path == !!rv$updating$path,
+                          scaffold == !!rv$updating$scaffold,
+                          accession == !!acc) |>
+            dplyr::collect()
+        ),
         error = function(e) NULL
       )
     }
@@ -1075,8 +1075,9 @@ annotations_details_server <- function(id, rv) {
     })
     # Sample position (original coords) -> canvas px on the overview. The x-axis is
     # alignment-column space whenever an alignment is shown, so a plain
-    # pos/sample_len mapping lands in the wrong place (and ignores strand); mirror
-    # the projection the plot itself uses.
+    # pos/sample_len mapping lands in the wrong place; mirror the projection the
+    # plot itself uses. The alignment is normalised to sample orientation at load,
+    # so no strand handling is needed here.
     synteny_proj <- reactive({
       w   <- synteny_plot_w()
       aln <- rv$blast_ref_aln
@@ -1089,11 +1090,8 @@ annotations_details_server <- function(id, rv) {
       aln_len  <- length(s_chars)
       s_nongap <- which(s_chars != "-")
       n_s      <- length(s_nongap)
-      strand   <- aln$strand[1] %||% "+"
       function(pos) {
-        idx <- as.integer(pos)
-        if (identical(strand, "-")) idx <- n_s - idx + 1L
-        idx <- pmin(pmax(idx, 1L), n_s)
+        idx <- pmin(pmax(as.integer(pos), 1L), n_s)
         s_nongap[idx] / aln_len * w
       }
     })
@@ -1121,6 +1119,13 @@ annotations_details_server <- function(id, rv) {
         isTRUE(nzchar(rv$blast_ref_aln$aligned_sample[1])) &&
         isTRUE(nzchar(rv$blast_ref_aln$aligned_ref[1]))
       plot_h     <- if (has_aln) "280px" else "200px"
+      # The sample is always drawn in its stored orientation (matching the coverage
+      # map); when it aligned to the reference's opposite strand it is the
+      # reference that is shown reverse-complemented, so say so on its label.
+      ref_rc     <- has_aln && isTRUE(rv$blast_ref_aln$ref_rc[1])
+      ref_rc_note <- if (ref_rc) {
+        div(style = "color: #d9534f; font-size: 10px;", "shown reverse-complemented")
+      } else NULL
       lbl <- function(h, ...) div(
         style = paste0("height: ", h, "; display: flex; align-items: center; word-break: break-word;"),
         ...
@@ -1134,7 +1139,8 @@ annotations_details_server <- function(id, rv) {
             div(style = "color: #888; font-size: 10px;", "identity"),
             div(style = "position: absolute; bottom: 0; right: 0; font-size: 9px; color: #aaa; line-height: 1;", "0%")
           )),
-          lbl("120px", div(div(ref_acc), div(style = "color: #888; font-size: 10px;", ref_lbl)))
+          lbl("120px", div(div(ref_acc), div(style = "color: #888; font-size: 10px;", ref_lbl),
+                           ref_rc_note))
         )
       } else {
         tagList(
@@ -1345,10 +1351,11 @@ annotations_details_server <- function(id, rv) {
         aln_rotation   <- as.integer(rv$blast_ref_aln$rotation[1])
         aligned_sample <- rv$blast_ref_aln$aligned_sample[1]
         aligned_ref    <- rv$blast_ref_aln$aligned_ref[1]
-        # When the scaffold aligned on the reverse strand, aligned_sample is the
-        # scaffold's reverse-complement, so a sample position P (original coords)
-        # is the (n - P + 1)-th non-gap base and gene orientation is flipped.
-        aln_strand     <- rv$blast_ref_aln$strand[1] %||% "+"
+        # The alignment arrives normalised to the sample's stored orientation, so
+        # the sample maps straight through. When that required a flip, the
+        # REFERENCE is the reverse-complemented track and its coordinates and gene
+        # arrows are the ones that mirror.
+        ref_rc <- isTRUE(rv$blast_ref_aln$ref_rc[1])
         s_chars <- strsplit(aligned_sample, "")[[1]]
         r_chars <- strsplit(aligned_ref,    "")[[1]]
         aln_len <- length(s_chars)
@@ -1360,44 +1367,47 @@ annotations_details_server <- function(id, rv) {
 
         # Project sample position (original coords) -> 0-100 in alignment space
         s_to_pct <- function(pos) {
-          idx <- as.integer(pos)
-          if (identical(aln_strand, "-")) idx <- n_s - idx + 1L
-          idx <- pmin(pmax(idx, 1L), n_s)
+          idx <- pmin(pmax(as.integer(pos), 1L), n_s)
           s_nongap[idx] / aln_len * 100
         }
-        # Project ref position (original coords) -> rotate -> 0-100 in alignment space
+        # Project ref position (original coords) -> rotate -> (flip) -> 0-100 in
+        # alignment space. On a flipped reference the k-th base of the drawn
+        # (reverse-complemented) reference is base ref_length - k + 1 of the
+        # rotated original.
         r_to_pct <- function(pos) {
           pos_r <- ((as.integer(pos) - 1L - aln_rotation) %% ref_length) + 1L
+          if (ref_rc) pos_r <- ref_length - pos_r + 1L
           idx   <- pmin(pmax(pos_r, 1L), length(r_nongap))
           r_nongap[idx] / aln_len * 100
         }
 
         # Gene data frames in alignment coordinates. Features that wrap the
         # circular origin (or straddle the rotation point in the reference) map
-        # to xmin > xmax; split them into two arcs at the 0/100 boundary. On the
-        # reverse strand, s_to_pct reverses coordinate order, so take min/max and
-        # flip arrow direction (a '+' scaffold gene points '-' vs the reference).
+        # to xmin > xmax; split them into two arcs at the 0/100 boundary.
         sample_df <- sample_genes |>
+          dplyr::mutate(
+            type = factor(type, levels = c("ctrl", "PCG", "rRNA", "tRNA", "ORF")),
+            xmin = s_to_pct(pos1), xmax = s_to_pct(pos2)
+          ) |>
+          split_wrapped_genes(x_lo = 0, x_hi = 100)
+        # On a flipped reference r_to_pct reverses coordinate order, so take
+        # min/max for the block and flip the arrow (a '+' reference gene runs '-'
+        # against the sample).
+        ref_df <- rv$blast_ref |>
           dplyr::mutate(type = factor(type, levels = c("ctrl", "PCG", "rRNA", "tRNA", "ORF")))
-        if (identical(aln_strand, "-")) {
-          sample_df <- sample_df |>
+        if (ref_rc) {
+          ref_df <- ref_df |>
             dplyr::mutate(
-              .x1 = s_to_pct(pos1), .x2 = s_to_pct(pos2),
+              .x1 = r_to_pct(pos1), .x2 = r_to_pct(pos2),
               xmin = pmin(.x1, .x2), xmax = pmax(.x1, .x2),
               direction = ifelse(direction == "+", "-", "+")
             ) |>
             dplyr::select(-.x1, -.x2)
         } else {
-          sample_df <- sample_df |>
-            dplyr::mutate(xmin = s_to_pct(pos1), xmax = s_to_pct(pos2))
+          ref_df <- ref_df |>
+            dplyr::mutate(xmin = r_to_pct(pos1), xmax = r_to_pct(pos2))
         }
-        sample_df <- sample_df |>
-          split_wrapped_genes(x_lo = 0, x_hi = 100)
-        ref_df <- rv$blast_ref |>
-          dplyr::mutate(
-            type = factor(type, levels = c("ctrl", "PCG", "rRNA", "tRNA", "ORF")),
-            xmin = r_to_pct(pos1), xmax = r_to_pct(pos2)
-          ) |>
+        ref_df <- ref_df |>
           split_wrapped_genes(x_lo = 0, x_hi = 100)
 
         # Classify each alignment column
@@ -1660,21 +1670,19 @@ annotations_details_server <- function(id, rv) {
       aln_rotation   <- as.integer(rv$blast_ref_aln$rotation[1])
       aligned_sample <- rv$blast_ref_aln$aligned_sample[1]
       aligned_ref    <- rv$blast_ref_aln$aligned_ref[1]
-      # On the reverse strand aligned_sample is the scaffold's reverse-complement,
-      # so a sample position P (original coords) is the (n_s - P + 1)-th non-gap
-      # base and gene orientation is flipped (mirrors the overview plot).
-      aln_strand <- rv$blast_ref_aln$strand[1] %||% "+"
+      # Normalised at load: the sample is in its stored orientation, so it maps
+      # straight through and the reference is the track that mirrors when flipped
+      # (same convention as the overview plot).
+      ref_rc <- isTRUE(rv$blast_ref_aln$ref_rc[1])
       s_chars <- strsplit(aligned_sample, "")[[1]]
       r_chars <- strsplit(aligned_ref,    "")[[1]]
       aln_len <- length(s_chars)
       s_nongap <- which(s_chars != "-")
       r_nongap <- which(r_chars != "-")
       n_s <- length(s_nongap)
-      # Sample original position -> alignment column (RC order on reverse strand)
+      # Sample original position -> alignment column
       s_pos_to_col <- function(pos) {
-        idx <- as.integer(pos)
-        if (identical(aln_strand, "-")) idx <- n_s - idx + 1L
-        idx <- pmin(pmax(idx, 1L), n_s)
+        idx <- pmin(pmax(as.integer(pos), 1L), n_s)
         s_nongap[idx]
       }
 
@@ -1744,9 +1752,7 @@ annotations_details_server <- function(id, rv) {
       }
       to_local <- function(aln_col) aln_col - win_start + 1L
 
-      # Sample genes overlapping the window - project pos1/pos2 to alignment cols
-      # (strand-aware). On the reverse strand pos1 maps above pos2 in alignment
-      # order, so take min/max for the block and flip the arrow direction.
+      # Sample genes overlapping the window - project pos1/pos2 to alignment cols.
       sg <- rv$annotations |> dplyr::filter(pos1 > 0)
       sg_c1 <- s_pos_to_col(sg$pos1)
       sg_c2 <- s_pos_to_col(sg$pos2)
@@ -1759,18 +1765,25 @@ annotations_details_server <- function(id, rv) {
           xmax = to_local(pmin(sg_hi[sg_in], win_end)) + 0.5,
           gene = sg$gene[sg_in],
           fill = type_color(sg$type[sg_in]),
-          forward = if (identical(aln_strand, "-")) sg$direction[sg_in] != "+" else sg$direction[sg_in] == "+",
+          forward = sg$direction[sg_in] == "+",
           stringsAsFactors = FALSE
         )
       } else NULL
 
-      # Ref genes - rotate to alignment-ref coords first, then map via r_nongap
+      # Ref genes - rotate to alignment-ref coords first, then map via r_nongap.
+      # On a flipped reference the coordinate order reverses, so pos1 lands above
+      # pos2 in alignment order and the arrow direction inverts.
       rg <- rv$blast_ref
       rg_pos1_r <- ((as.integer(rg$pos1) - 1L - aln_rotation) %% ref_length) + 1L
       rg_pos2_r <- ((as.integer(rg$pos2) - 1L - aln_rotation) %% ref_length) + 1L
       rg_ok <- rg_pos2_r >= rg_pos1_r  # skip wrap-around genes
-      rg_aln1 <- r_nongap[pmin(pmax(rg_pos1_r, 1L), length(r_nongap))]
-      rg_aln2 <- r_nongap[pmin(pmax(rg_pos2_r, 1L), length(r_nongap))]
+      if (ref_rc) {
+        rg_pos1_r <- ref_length - rg_pos1_r + 1L
+        rg_pos2_r <- ref_length - rg_pos2_r + 1L
+      }
+      rg_lo <- pmin(rg_pos1_r, rg_pos2_r); rg_hi <- pmax(rg_pos1_r, rg_pos2_r)
+      rg_aln1 <- r_nongap[pmin(pmax(rg_lo, 1L), length(r_nongap))]
+      rg_aln2 <- r_nongap[pmin(pmax(rg_hi, 1L), length(r_nongap))]
       rg_in <- rg_ok & rg_aln2 >= win_start & rg_aln1 <= win_end
       ref_gene_df <- if (any(rg_in)) {
         data.frame(
@@ -1778,7 +1791,7 @@ annotations_details_server <- function(id, rv) {
           xmax = to_local(pmin(rg_aln2[rg_in], win_end)) + 0.5,
           gene = rg$gene[rg_in],
           fill = type_color(rg$type[rg_in]),
-          forward = rg$direction[rg_in] == "+",
+          forward = if (ref_rc) rg$direction[rg_in] != "+" else rg$direction[rg_in] == "+",
           stringsAsFactors = FALSE
         )
       } else NULL

--- a/R/app_assemble_coverage_details.R
+++ b/R/app_assemble_coverage_details.R
@@ -1630,12 +1630,15 @@ assembly_coverage_details_server <- function(id, rv) {
       rc_seed <- if (!is.null(lay)) lay$rc else rep(FALSE, length(scaffolds))
       inc_seed <- if (!is.null(lay) && "include" %in% names(lay)) lay$include else rep(TRUE, length(scaffolds))
       qcov <- if (!is.null(lay) && "qcov" %in% names(lay)) lay$qcov else rep(NA_real_, length(scaffolds))
+      reason_seed <- if (!is.null(lay) && "exclude_reason" %in% names(lay)) lay$exclude_reason else rep(NA_character_, length(scaffolds))
       tagList(
         div(style = "margin-top: 8px; font-weight: bold; color: #555;",
             "Scaffold layout (only included scaffolds go into Path 0)"),
         lapply(seq_along(scaffolds), function(i) {
           s <- scaffolds[i]
           qc <- if (!is.na(qcov[i])) sprintf(" (%.0f%% mapped)", 100 * qcov[i]) else ""
+          why <- if (!isTRUE(inc_seed[i]) && !is.na(reason_seed[i]))
+            span(style = "font-size: 11px; color: #d9534f;", reason_seed[i]) else NULL
           div(style = "display: flex; gap: 12px; align-items: center; margin-top: 4px;",
               checkboxInput(ns(paste0("join_inc_", s)), NULL, value = isTRUE(inc_seed[i]),
                             width = "30px"),
@@ -1643,7 +1646,8 @@ assembly_coverage_details_server <- function(id, rv) {
               numericInput(ns(paste0("join_order_", s)), NULL,
                            value = order_seed[i], min = 1, width = "80px"),
               checkboxInput(ns(paste0("join_rc_", s)), "reverse-comp",
-                            value = isTRUE(rc_seed[i])))
+                            value = isTRUE(rc_seed[i])),
+              why)
         })
       )
     })
@@ -1686,9 +1690,11 @@ assembly_coverage_details_server <- function(id, rv) {
       layout <- data.frame(
         scaffold = scaffolds[o], order = seq_along(o), rc = rc[o],
         gap_before = NA_real_, mapped = TRUE, include = inc[o], stringsAsFactors = FALSE)
-      # Reuse reference-derived gaps only when the manual order matches auto.
+      # Reuse reference-derived gaps only when the manual order AND include set
+      # both match auto; any include change invalidates the neighbor gaps.
       lay <- rv$join_layout
-      if (!is.null(lay) && identical(layout$scaffold, lay$scaffold)) {
+      if (!is.null(lay) && identical(layout$scaffold, lay$scaffold) &&
+          "include" %in% names(lay) && identical(layout$include, lay$include)) {
         layout$gap_before <- lay$gap_before
       }
       scaffolds_df <- data.frame(

--- a/R/app_assemble_coverage_details.R
+++ b/R/app_assemble_coverage_details.R
@@ -1496,6 +1496,9 @@ assembly_coverage_details_server <- function(id, rv) {
           if (isTRUE(inc$rc[i])) rc_seq(sq) else sq
         }), as.character(inc$scaffold))
       rv$join_zoom_anchor <- NULL
+      # Record which accession the stored layout was actually built from so the
+      # build step inherits that reference's BLAST hit, not a stale dropdown value.
+      rv$join_ref_accession <- accession
       invisible(TRUE)
     }
 
@@ -1565,11 +1568,41 @@ assembly_coverage_details_server <- function(id, rv) {
         uiOutput(ns("join_zoom_ui"))
       )
     })
+    # Live layout for the verification views: auto geometry (ref_start/ref_end/
+    # qcov/qstart) overlaid with the user's current RC/include widget choices, so
+    # the mapping plot and bp zoom reflect manual edits without re-running minimap.
+    # Order is intentionally NOT applied (plot x = fixed reference coordinates).
+    live_layout <- reactive({
+      lay <- rv$join_layout
+      if (is.null(lay)) return(NULL)
+      for (i in seq_len(nrow(lay))) {
+        s <- lay$scaffold[i]
+        rcv <- input[[paste0("join_rc_", s)]]
+        incv <- input[[paste0("join_inc_", s)]]
+        if (!is.null(rcv)) lay$rc[i] <- isTRUE(rcv)
+        if (!is.null(incv)) lay$include[i] <- isTRUE(incv)
+      }
+      lay
+    })
+    live_oriented <- reactive({
+      lay <- live_layout()
+      if (is.null(lay)) return(NULL)
+      rows <- join_scaffold_rows()
+      if (is.null(rows)) return(NULL)
+      seqs <- stats::setNames(rows$sequence, as.character(rows$scaffold))
+      inc <- lay[lay$include, , drop = FALSE]
+      stats::setNames(
+        lapply(seq_len(nrow(inc)), function(i) {
+          sq <- seqs[[as.character(inc$scaffold[i])]]
+          if (isTRUE(inc$rc[i])) rc_seq(sq) else sq
+        }), as.character(inc$scaffold))
+    })
     output$join_map_plot <- renderPlot({
-      req(!is.null(rv$join_layout), !is.null(rv$join_ref_len))
+      lay <- live_layout()
+      req(!is.null(lay), !is.null(rv$join_ref_len))
       rows <- join_scaffold_rows()
       slen <- if (!is.null(rows)) stats::setNames(rows$length, as.character(rows$scaffold)) else NULL
-      plot_scaffold_mapping(rv$join_layout, rv$join_ref_len, slen)
+      plot_scaffold_mapping(lay, rv$join_ref_len, slen)
     })
 
     # Click the overview -> anchor the base-pair zoom at that reference position.
@@ -1607,15 +1640,16 @@ assembly_coverage_details_server <- function(id, rv) {
     })
 
     output$join_zoom_plot <- renderPlot({
-      req(!is.null(rv$join_zoom_anchor), !is.null(rv$join_ref_seq),
-          !is.null(rv$join_oriented), !is.null(rv$join_layout))
+      req(!is.null(rv$join_zoom_anchor), !is.null(rv$join_ref_seq))
+      lay <- live_layout()
+      oriented <- live_oriented()
+      req(!is.null(lay), !is.null(oriented))
       win <- zoom_win_rv()
       anchor <- rv$join_zoom_anchor
       ws <- max(1L, anchor - win %/% 2L)
       we <- min(nchar(rv$join_ref_seq), ws + win - 1L)
-      lay <- rv$join_layout
       inc <- lay[lay$include, , drop = FALSE]
-      bm <- zoom_window_base_maps(rv$join_ref_seq, inc, rv$join_oriented, ws, we)
+      bm <- zoom_window_base_maps(rv$join_ref_seq, inc, oriented, ws, we)
       plot_scaffold_zoom(rv$join_ref_seq, bm, inc$scaffold, ws, we)
     })
 
@@ -1656,6 +1690,21 @@ assembly_coverage_details_server <- function(id, rv) {
       compute_join_layout(input$join_reference, notify = TRUE)
     })
 
+    # Switching the reference must recompute the layout so the geometry, widgets
+    # and the blast_row attributed at build time all come from one accession.
+    # ignoreInit: the modal-open compute (choose_reference) already covers the
+    # dropdown's initial value, so only user changes recompute here. If the new
+    # reference has no cached seq/mapping the recompute fails; notify and snap the
+    # dropdown back to the last good accession so it never disagrees with the layout.
+    observeEvent(input$join_reference, ignoreInit = TRUE, {
+      ok <- compute_join_layout(input$join_reference, notify = TRUE)
+      if (!isTRUE(ok) && !is.null(rv$join_ref_accession) &&
+          !identical(input$join_reference, rv$join_ref_accession)) {
+        shiny::updateSelectInput(session, "join_reference",
+                                 selected = rv$join_ref_accession)
+      }
+    })
+
     observeEvent(input$join_build, {
       rows <- join_scaffold_rows()
       req(!is.null(rows), nrow(rows) > 1)
@@ -1668,7 +1717,10 @@ assembly_coverage_details_server <- function(id, rv) {
           type = "warning")
         req(FALSE)
       }
-      scaffolds <- as.character(rows$scaffold)
+      # Iterate in the on-screen layout order so equal manual order values
+      # tie-break by the visible list, not invisible DB row order.
+      lay0 <- rv$join_layout
+      scaffolds <- if (!is.null(lay0)) as.character(lay0$scaffold) else as.character(rows$scaffold)
       ord <- vapply(scaffolds, function(s) {
         v <- input[[paste0("join_order_", s)]]
         if (is.null(v) || is.na(v)) NA_real_ else as.numeric(v)
@@ -1687,6 +1739,11 @@ assembly_coverage_details_server <- function(id, rv) {
       }
       ord[is.na(ord)] <- seq_along(ord)[is.na(ord)]
       o <- order(ord)
+      if (anyDuplicated(ord)) {
+        shiny::showNotification(
+          "Duplicate scaffold order values; ties broken by the on-screen order.",
+          type = "warning", duration = 6)
+      }
       layout <- data.frame(
         scaffold = scaffolds[o], order = seq_along(o), rc = rc[o],
         gap_before = NA_real_, mapped = TRUE, include = inc[o], stringsAsFactors = FALSE)
@@ -1697,13 +1754,14 @@ assembly_coverage_details_server <- function(id, rv) {
           "include" %in% names(lay) && identical(layout$include, lay$include)) {
         layout$gap_before <- lay$gap_before
       }
+      idx <- match(scaffolds, as.character(rows$scaffold))
       scaffolds_df <- data.frame(
-        scaffold = scaffolds, sequence = rows$sequence,
-        depth = rows$depth, gc = rows$gc, errors = rows$errors,
+        scaffold = scaffolds, sequence = rows$sequence[idx],
+        depth = rows$depth[idx], gc = rows$gc[idx], errors = rows$errors[idx],
         stringsAsFactors = FALSE)
       # 100 N is the standard "gap of unknown length" convention; not user-tunable.
-      # ref_seq omitted so circular rotation (minimap-based) is skipped in the app;
-      # the molecule still circularizes (end-overlap trim) when applicable.
+      # ref_seq omitted so minimap-based origin rotation is skipped in the app; the
+      # molecule circularizes (end-overlap trim) only when the user checks Circular.
       res <- assemble_from_layout(scaffolds_df, layout, gap_len = 100L,
                                   circular = isTRUE(input$join_circular),
                                   ref_seq = NULL)
@@ -1712,10 +1770,14 @@ assembly_coverage_details_server <- function(id, rv) {
                            " WARNING: contains ambiguous bases (IUPAC/N) - may cause ",
                            "problems in annotation; MITOS does not handle them well.")
       }
-      # Inherit the BLAST hit from the reference used for the join (accession +
-      # species + lineage), but blank %ident / %cov / evalue: those described a
-      # single scaffold's hit and are meaningless for the joined assembly.
-      blast_row <- join_reference_blast_row(input$join_reference, rows)
+      # Inherit the BLAST hit from the reference the layout was actually built from
+      # (accession + species + lineage), but blank %ident / %cov / evalue: those
+      # described a single scaffold's hit and are meaningless for the joined
+      # assembly. Use the stored accession, not the raw dropdown, so a reference
+      # whose recompute failed cannot mislabel Path 0.
+      join_acc <- rv$join_ref_accession
+      if (is.null(join_acc)) join_acc <- input$join_reference
+      blast_row <- join_reference_blast_row(join_acc, rows)
       persist_path0(res$seq, res$depth, res$gc, res$errors, res$note,
                     blast_row, res$topology)
     })

--- a/R/app_assemble_coverage_details.R
+++ b/R/app_assemble_coverage_details.R
@@ -1781,6 +1781,14 @@ assembly_coverage_details_server <- function(id, rv) {
       # 100-N spacer with the shared bases duplicated - including the junctions
       # the user never touched.
       lay <- rv$join_layout
+      # Carry the reference coordinates onto the manual layout as well: they are
+      # what lets join_scaffolds re-measure a junction whose predecessor it drops
+      # at runtime. Without them that correction is inert on the editor path.
+      if (!is.null(lay) && all(c("ref_start", "ref_end") %in% names(lay))) {
+        m0 <- match(layout$scaffold, lay$scaffold)
+        layout$ref_start <- lay$ref_start[m0]
+        layout$ref_end   <- lay$ref_end[m0]
+      }
       if (!is.null(lay) && identical(layout$scaffold, lay$scaffold) &&
           "include" %in% names(lay) && identical(layout$include, lay$include)) {
         layout$gap_before <- lay$gap_before

--- a/R/app_assemble_coverage_details.R
+++ b/R/app_assemble_coverage_details.R
@@ -39,6 +39,12 @@ assembly_coverage_details_server <- function(id, rv) {
       rv$join_layout <- NULL
       rv$join_ref_len <- NULL
       rv$join_zoom_anchor <- NULL
+      # Session-scoped, so they must be cleared per sample: if compute_join_layout
+      # early-returns for this sample, a stale accession would be stamped onto its
+      # Path 0 and a stale reference/orientation drawn under its scaffolds.
+      rv$join_ref_accession <- NULL
+      rv$join_ref_seq <- NULL
+      rv$join_oriented <- NULL
       # Auto-run reference-guided mapping on open so the layout + mapping plot show
       # without an extra click; the Auto-layout button re-runs after edits.
       if (isTRUE(rv$asmb_join_eligible)) {
@@ -1579,6 +1585,14 @@ assembly_coverage_details_server <- function(id, rv) {
         s <- lay$scaffold[i]
         rcv <- input[[paste0("join_rc_", s)]]
         incv <- input[[paste0("join_inc_", s)]]
+        # qstart is a FORWARD-query coordinate from the auto mapping. Once the user
+        # flips RC, live_oriented() hands the zoom a reverse-complemented sequence
+        # that this coordinate no longer indexes, so drop it rather than pairing
+        # the two: zoom_window_base_maps already skips rows with qstart NA, which
+        # is far better than a confidently drawn wrong base map.
+        if (!is.null(rcv) && !identical(isTRUE(rcv), isTRUE(lay$rc[i]))) {
+          lay$qstart[i] <- NA_integer_
+        }
         if (!is.null(rcv)) lay$rc[i] <- isTRUE(rcv)
         if (!is.null(incv)) lay$include[i] <- isTRUE(incv)
       }
@@ -1697,9 +1711,21 @@ assembly_coverage_details_server <- function(id, rv) {
     # reference has no cached seq/mapping the recompute fails; notify and snap the
     # dropdown back to the last good accession so it never disagrees with the layout.
     observeEvent(input$join_reference, ignoreInit = TRUE, {
+      # ignoreInit only covers the very first value. This input is re-rendered
+      # whenever scaffold_join_div redraws for a different sample, which fires the
+      # observer again and would pop the alert the modal-open path deliberately
+      # suppressed with notify = FALSE. If the dropdown already agrees with the
+      # accession the layout was built from, there is nothing to recompute.
+      if (identical(input$join_reference, rv$join_ref_accession)) return()
       ok <- compute_join_layout(input$join_reference, notify = TRUE)
+      # Only snap back to a target the new sample actually offers; reverting to a
+      # previous sample's accession would blank the control.
+      rws <- join_scaffold_rows()
+      accs <- if (is.null(rws)) character(0) else
+        unique(rws$blast_accession[!is.na(rws$blast_accession) & nzchar(rws$blast_accession)])
       if (!isTRUE(ok) && !is.null(rv$join_ref_accession) &&
-          !identical(input$join_reference, rv$join_ref_accession)) {
+          !identical(input$join_reference, rv$join_ref_accession) &&
+          rv$join_ref_accession %in% accs) {
         shiny::updateSelectInput(session, "join_reference",
                                  selected = rv$join_ref_accession)
       }
@@ -1747,12 +1773,27 @@ assembly_coverage_details_server <- function(id, rv) {
       layout <- data.frame(
         scaffold = scaffolds[o], order = seq_along(o), rc = rc[o],
         gap_before = NA_real_, mapped = TRUE, include = inc[o], stringsAsFactors = FALSE)
-      # Reuse reference-derived gaps only when the manual order AND include set
-      # both match auto; any include change invalidates the neighbor gaps.
+      # Reference-derived gaps. Reuse them verbatim when the order and include set
+      # both match auto; otherwise RECOMPUTE them from the stored reference
+      # coordinates rather than discarding the vector. Leaving gap_before all-NA
+      # would switch off join_scaffolds' overlap probe at every junction
+      # (do_probe requires !is.na(gap_before)), turning each one into a blind
+      # 100-N spacer with the shared bases duplicated - including the junctions
+      # the user never touched.
       lay <- rv$join_layout
       if (!is.null(lay) && identical(layout$scaffold, lay$scaffold) &&
           "include" %in% names(lay) && identical(layout$include, lay$include)) {
         layout$gap_before <- lay$gap_before
+      } else if (!is.null(lay) &&
+                 all(c("ref_start", "ref_end") %in% names(lay))) {
+        m <- match(layout$scaffold, lay$scaffold)
+        rs <- lay$ref_start[m]; re <- lay$ref_end[m]
+        g <- rep(NA_real_, nrow(layout))
+        ii <- which(layout$include)
+        if (length(ii) >= 2) for (k in 2:length(ii)) {
+          g[ii[k]] <- rs[ii[k]] - re[ii[k - 1]]
+        }
+        layout$gap_before <- g
       }
       idx <- match(scaffolds, as.character(rows$scaffold))
       scaffolds_df <- data.frame(

--- a/R/blast_ref_utils.R
+++ b/R/blast_ref_utils.R
@@ -1206,6 +1206,57 @@ normalize_trna <- function(n, product = NA_character_) {
 }
 
 
+#' Normalise a stored BLAST reference alignment to the assembly's orientation
+#'
+#' [compute_blast_ref_alignment()] aligns the assembly on whichever strand scores
+#' higher, so a sample stored on the opposite strand from its reference comes back
+#' reverse-complemented. Drawing that as-is puts the synteny view in a different
+#' frame from the coverage map and the sequence editor: the same sample, with gene
+#' order and orientation mirrored between two plots sitting next to each other.
+#'
+#' The homology is identical either way, so the correction is presentational: flip
+#' the alignment back so the SAMPLE is always shown in its stored orientation and
+#' let the REFERENCE track carry the reverse-complement instead.
+#'
+#' Deliberately independent of the `ref_based_rc` curate option. With that option
+#' ON, CURATE has already flipped the assembly to the reference strand before
+#' BLAST_REF_ALIGN runs, so the aligner returns "+" and this is a no-op. With it
+#' OFF the assembly keeps its own orientation, and so must the plot.
+#'
+#' @param aln rows from the `blast_ref_alignment` table (usually one).
+#' @return the same rows with `aligned_sample` / `aligned_ref` in sample
+#'   orientation, `strand` set to "+", and a `ref_rc` flag recording whether the
+#'   reference was flipped for display.
+#' @noRd
+normalize_blast_ref_alignment <- function(aln) {
+  if (is.null(aln) || !is.data.frame(aln) || nrow(aln) == 0) return(aln)
+  aln$ref_rc <- FALSE
+  if (!all(c("strand", "aligned_sample", "aligned_ref") %in% names(aln))) return(aln)
+  flip <- which(!is.na(aln$strand) & aln$strand == "-")
+  if (length(flip) == 0) return(aln)
+  # DNAString treats "-" as a gap character and complements it to itself, so the
+  # gapped alignment strings round-trip. Case is normalised because the alphabet
+  # is uppercase-only; downstream comparisons are case-insensitive anyway.
+  rc_gapped <- function(s) {
+    if (is.na(s) || !nzchar(s)) return(NA_character_)
+    tryCatch(
+      as.character(Biostrings::reverseComplement(Biostrings::DNAString(toupper(s)))),
+      error = function(e) NA_character_)
+  }
+  for (i in flip) {
+    rs <- rc_gapped(aln$aligned_sample[i])
+    rr <- rc_gapped(aln$aligned_ref[i])
+    # Both must flip or neither: a half-flipped pair would mis-pair every column.
+    # Leave the row as the aligner wrote it if either conversion fails.
+    if (is.na(rs) || is.na(rr)) next
+    aln$aligned_sample[i] <- rs
+    aln$aligned_ref[i]    <- rr
+    aln$strand[i] <- "+"
+    aln$ref_rc[i] <- TRUE
+  }
+  aln
+}
+
 #' Pre-compute a whole-genome pairwise alignment of a sample against its BLAST
 #' reference and write the result for ingestion into the
 #' \code{blast_ref_alignment} SQLite table.

--- a/R/scaffold_join.R
+++ b/R/scaffold_join.R
@@ -195,15 +195,25 @@ compute_scaffold_mappings <- function(scaffold_seqs, ref_seqs,
 #' @noRd
 load_scaffold_mappings <- function(con, ID, accession) {
   if (is.null(accession) || is.na(accession) || !nzchar(accession)) return(NULL)
+  # suppressWarnings: unmapped rows store empty strings in numeric columns, so
+  # SQLite fetches those columns as character and warns about mixed types; we
+  # coerce them back below.
   rows <- tryCatch(
-    DBI::dbGetQuery(con, paste0(
+    suppressWarnings(DBI::dbGetQuery(con, paste0(
       "SELECT scaffold, ref_start, ref_end, strand, nmatch, qcov, qstart, mapped ",
       "FROM scaffold_mappings WHERE ID = ? AND ref_accession = ?"),
-      params = list(ID, accession)),
+      params = list(ID, accession))),
     error = function(e) NULL)
   if (is.null(rows) || nrow(rows) == 0) return(NULL)
   rows$scaffold <- as.character(rows$scaffold)
   rows$mapped <- as.logical(rows$mapped)
+  # Unmapped scaffolds are stored as empty strings in these numeric columns, which
+  # makes SQLite return the whole column as character; coerce back so downstream
+  # ordering and gap arithmetic do not break.
+  for (col in c("ref_start", "ref_end", "qstart", "nmatch")) {
+    if (col %in% names(rows)) rows[[col]] <- suppressWarnings(as.integer(rows[[col]]))
+  }
+  rows$qcov <- suppressWarnings(as.numeric(rows$qcov))
   rows$qcov[is.na(rows$qcov)] <- 0
   rows
 }
@@ -285,6 +295,28 @@ parse_paf <- function(paf_lines) {
   )
 }
 
+#' Reduce one scaffold's same-strand blocks to a single colinear chain
+#'
+#' Blocks on one colinear alignment share a query-vs-reference diagonal
+#' (`ref_start - qstart` on the '+' strand, `ref_start + qend` on '-'). Anchoring
+#' on the largest-nmatch block and keeping only blocks within `tol` of its
+#' diagonal drops origin-wrap and distant repeat/secondary blocks that would
+#' otherwise balloon the reference extent in [collapse_scaffold_blocks()].
+#'
+#' @param gs single-strand PAF rows for one scaffold (columns `strand`,
+#'   `ref_start`, `qstart`, `qend`, `nmatch`, `qlen`).
+#' @param tol max diagonal deviation from the anchor; defaults to a scaffold-
+#'   relative slack that tolerates indels but not an origin wrap / distant repeat.
+#' @return the subset of `gs` on the anchor block's colinear diagonal.
+#' @noRd
+colinear_chain <- function(gs, tol = NULL) {
+  if (nrow(gs) <= 1L) return(gs)
+  dg <- ifelse(gs$strand == "-", gs$ref_start + gs$qend, gs$ref_start - gs$qstart)
+  anchor <- which.max(gs$nmatch)
+  if (is.null(tol)) tol <- max(1000L, as.integer(round(0.2 * gs$qlen[1])))
+  gs[abs(dg - dg[anchor]) <= tol, , drop = FALSE]
+}
+
 #' Collapse a scaffold's PAF alignment blocks to one placement row
 #'
 #' A scaffold crossing a duplication/rearrangement maps to the reference in
@@ -293,7 +325,8 @@ parse_paf <- function(paf_lines) {
 #' placement = the UNION extent (`min(ref_start)`..`max(ref_end)`) of that
 #' strand's blocks. `qstart`/`ref_start` are kept as a colinear pair (the block
 #' at min `ref_start`) so the zoom view can still map reference positions back to
-#' scaffold bases. `qcov` is the union of query intervals across ALL blocks.
+#' scaffold bases. `qcov` is the union of query intervals across the dominant
+#' strand's colinear chain (the same blocks used for the placement extent).
 #'
 #' @param rows parsed PAF rows (see [parse_paf()]) for one or more scaffolds.
 #' @return one row per scaffold: `scaffold, ref_start, ref_end, strand, nmatch,
@@ -304,6 +337,9 @@ collapse_scaffold_blocks <- function(rows) {
     by_strand <- tapply(g$nmatch, g$strand, sum)
     dom <- names(by_strand)[which.max(by_strand)]
     gs <- g[g$strand == dom, , drop = FALSE]
+    # Keep only the dominant strand's colinear chain so an origin-wrap or a
+    # distant repeat/secondary block cannot balloon the reference extent.
+    gs <- colinear_chain(gs)
     anchor <- gs[which.min(gs$ref_start), , drop = FALSE]
     data.frame(
       scaffold  = g$scaffold[1],
@@ -311,7 +347,7 @@ collapse_scaffold_blocks <- function(rows) {
       ref_end   = max(gs$ref_end),
       strand    = dom,
       nmatch    = sum(gs$nmatch),
-      qcov      = union_len(g$qstart, g$qend) / g$qlen[1],
+      qcov      = union_len(gs$qstart, gs$qend) / gs$qlen[1],
       qstart    = anchor$qstart,
       stringsAsFactors = FALSE
     )
@@ -462,9 +498,24 @@ derive_scaffold_layout <- function(mappings, ref_len = NA_integer_, circular = F
     inc <- inc[!subsumed, , drop = FALSE]
   }
 
+  # An origin-wrapping scaffold (maps near ref 0 AND near ref_len) can collapse to
+  # a ballooned extent spanning nearly the whole reference; its ref_end is then not
+  # a real right boundary, and deriving the next scaffold's gap from it manufactures
+  # a genome-scale negative gap that over-trims (or drops) a real scaffold. Skip
+  # such a predecessor's junction (NA -> N-gap). Gate on LOW density so a genuine
+  # dense full-length contig is not misread as a wrap (a real ballooned wrap unions
+  # disjoint blocks and so is sparse: nmatch/span < min_density).
+  wrap_thresh <- if (is.finite(ref_len) && ref_len > 0) 0.9 * ref_len else Inf
+  min_density <- 0.5
   gap_before <- rep(NA_real_, nrow(inc))
   if (nrow(inc) >= 2) {
     for (i in 2:nrow(inc)) {
+      prev_span <- inc$ref_end[i - 1] - inc$ref_start[i - 1]
+      prev_density <- if (!is.na(prev_span) && prev_span > 0)
+        inc$nmatch[i - 1] / prev_span else NA_real_
+      ballooned <- !is.na(prev_span) && prev_span >= wrap_thresh &&
+        !is.na(prev_density) && prev_density < min_density
+      if (ballooned) next
       gap_before[i] <- inc$ref_start[i] - inc$ref_end[i - 1]
     }
   }
@@ -499,6 +550,21 @@ rc_seq <- function(seq) {
   as.character(Biostrings::reverseComplement(Biostrings::DNAString(seq)))
 }
 
+#' Is an aligned overlap region low-complexity (homopolymer / short motif)?
+#'
+#' Counts distinct k-mers in the overlap; a homopolymer or short tandem repeat
+#' has very few, so it can clear the identity/length bar by chance and trim real
+#' bases. Used to reject such confirmations in [refine_overlap()].
+#' @noRd
+low_complexity_overlap <- function(s, k = 3L, min_distinct = 4L) {
+  s <- toupper(s)
+  n <- nchar(s)
+  if (n < k) return(TRUE)
+  starts <- seq_len(n - k + 1L)
+  kmers <- substring(s, starts, starts + k - 1L)
+  length(unique(kmers)) < min_distinct
+}
+
 #' Verify a scaffold-junction overlap by aligning the actual scaffold ends
 #'
 #' The reference coordinates only *suggest* an overlap of `est_overlap` bp; the
@@ -521,7 +587,11 @@ refine_overlap <- function(a_seq, b_seq, est_overlap, min_identity = 0.7,
                            min_overlap = 10L) {
   est <- max(as.integer(round(est_overlap)), 1L)
   slack <- max(50L, as.integer(round(est)))
-  L <- min(nchar(a_seq), nchar(b_seq), est + slack)
+  # Size the probe window from the scaffold lengths (capped) so large true
+  # overlaps are not missed when the reference under-predicts them; keep the
+  # wider window when the reference itself predicts a big overlap.
+  maxwin <- as.integer(getOption("MitoPilot.scaffold_overlap_maxwin", 5000L))
+  L <- min(nchar(a_seq), nchar(b_seq), max(est + slack, maxwin))
   out <- list(reliable = FALSE, trim_b = 0L, identity = NA_real_, overlap_len = 0L)
   if (L < 10L) return(out)
   a_tail <- substring(a_seq, nchar(a_seq) - L + 1L)
@@ -543,7 +613,17 @@ refine_overlap <- function(a_seq, b_seq, est_overlap, min_identity = 0.7,
   sub_rng <- pwalign::subject(aln)@range
   sub_start <- BiocGenerics::start(sub_rng)
   sub_end <- BiocGenerics::end(sub_rng)
-  if (ident >= min_identity && sub_start <= 2L) {
+  # The aligned pattern (a_tail) must also reach a's 3' terminus: a genuine
+  # junction overlap sits at BOTH a's suffix end and b's prefix start. Without
+  # this, a copy of b's prefix buried inside a's tail (an internal repeat, made
+  # reachable by the widened window) would falsely confirm and trim real bases.
+  pat_rng <- pwalign::pattern(aln)@range
+  pat_at_end <- (nchar(a_tail) - BiocGenerics::end(pat_rng)) <= 2L
+  # Reject low-complexity confirmations (homopolymer / short tandem motif at
+  # AT-rich termini) that clear identity/length by chance and would trim real
+  # bases from B.
+  ov_lc <- low_complexity_overlap(substring(b_head, 1L, sub_end))
+  if (ident >= min_identity && sub_start <= 2L && pat_at_end && !ov_lc) {
     out$reliable <- TRUE
     out$trim_b <- as.integer(sub_end)
     out$identity <- ident
@@ -793,9 +873,20 @@ stitch_coverage <- function(scaffold_cov, layout, joined) {
 
 #' Parse a space-separated numeric coverage string to a vector
 #' @noRd
-parse_cov_string <- function(x) {
-  if (is.null(x) || length(x) == 0 || is.na(x) || !nzchar(x)) return(numeric(0))
-  suppressWarnings(as.numeric(strsplit(trimws(x), "\\s+")[[1]]))
+parse_cov_string <- function(x, n = NULL) {
+  if (is.null(x) || length(x) == 0 || is.na(x) || !nzchar(x)) {
+    return(if (is.null(n)) numeric(0) else rep(NA_real_, n))
+  }
+  # Split on single spaces (do NOT trim/collapse) so empty cells stay as empty
+  # tokens -> NA and the position count is preserved. Strip any '#' outlier-mask
+  # prefix before numeric use, matching the auto (cov_string) path.
+  tok <- strsplit(x, " ", fixed = TRUE)[[1]]
+  v <- suppressWarnings(as.numeric(sub("^#", "", tok)))
+  if (!is.null(n)) {
+    if (length(v) < n) v <- c(v, rep(NA_real_, n - length(v)))
+    else if (length(v) > n) v <- v[seq_len(n)]
+  }
+  v
 }
 
 #' Build a joined assembly from per-scaffold sequence + coverage
@@ -882,6 +973,11 @@ rotate_to_reference <- function(seq, depth, gc, errors, ref_seq,
   rows <- rows[rows$strand == "+" & !is.na(rows$ref_start), , drop = FALSE]
   if (nrow(rows) == 0) return(out)
   best <- rows[which.min(rows$ref_start), , drop = FALSE]
+  # Rotate only when a block actually covers reference position 0. Extrapolating
+  # to ref 0 from a distant block is wrong across N-gaps / non-colinear scaffolds
+  # (the colinear offset is not constant), so skip when nothing spans the origin.
+  origin_tol <- as.integer(getOption("MitoPilot.scaffold_origin_tol", 50L))
+  if (best$ref_start > origin_tol) return(out)
   # Query base aligning to reference position 0 (mod n).
   rp <- ((best$qstart - best$ref_start) %% n + n) %% n
   if (rp == 0L) return(out)
@@ -911,9 +1007,10 @@ assemble_from_layout <- function(scaffolds_df, layout, gap_len = 100L,
   seqs <- stats::setNames(as.character(scaffolds_df$sequence),
                           as.character(scaffolds_df$scaffold))
   cov <- stats::setNames(lapply(seq_len(nrow(scaffolds_df)), function(i) {
-    list(depth = parse_cov_string(scaffolds_df$depth[i]),
-         gc = parse_cov_string(scaffolds_df$gc[i]),
-         err = parse_cov_string(scaffolds_df$errors[i]))
+    n_i <- nchar(as.character(scaffolds_df$sequence[i]))
+    list(depth = parse_cov_string(scaffolds_df$depth[i], n_i),
+         gc = parse_cov_string(scaffolds_df$gc[i], n_i),
+         err = parse_cov_string(scaffolds_df$errors[i], n_i))
   }), as.character(scaffolds_df$scaffold))
   depth_only <- lapply(cov, `[[`, "depth")
   joined <- join_scaffolds(seqs, layout, as.integer(gap_len), circular,
@@ -924,11 +1021,22 @@ assemble_from_layout <- function(scaffolds_df, layout, gap_len = 100L,
   depth <- stitched$depth; gc <- stitched$gc; errors <- stitched$errors
   circ_note <- character(0)
 
-  # Circularize: trim a redundant end if the molecule wraps the origin (a
-  # scaffold mapping to both ends of the reference), then rotate to the
-  # reference origin. Auto-detected; the `circular` arg forces rotation even
-  # when no redundant overlap is present.
-  cz <- circularize_sequence(seq, depth, gc, errors)
+  # Circularize when the caller asserts circular or a reference is present (the
+  # auto path). circularize_sequence detects the wrap by aligning the joined 3'
+  # end to its 5' start; the raised min_overlap plus refine_overlap's terminal-
+  # anchor and low-complexity guards reject the short AT-rich matches that used to
+  # falsely self-circularize linear joins, so no reference-coordinate gate is
+  # needed (and none would survive collapse_scaffold_blocks pruning the wrap
+  # block off the origin scaffold's extent). The app path (no ref_seq)
+  # circularizes only when the user asserts circular. The `circular` arg still
+  # forces rotation below.
+  has_ref <- !is.null(ref_seq) && length(ref_seq) == 1 && !is.na(ref_seq) && nzchar(ref_seq)
+  cz <- if (isTRUE(circular) || has_ref) {
+    circularize_sequence(seq, depth, gc, errors, min_overlap = 50L)
+  } else {
+    list(circular = FALSE, seq = seq, depth = depth, gc = gc,
+         errors = errors, overlap_len = 0L, identity = NA_real_)
+  }
   is_circular <- isTRUE(cz$circular) || isTRUE(circular)
   if (isTRUE(cz$circular)) {
     seq <- cz$seq; depth <- cz$depth; gc <- cz$gc; errors <- cz$errors

--- a/R/scaffold_join.R
+++ b/R/scaffold_join.R
@@ -297,24 +297,48 @@ parse_paf <- function(paf_lines) {
 
 #' Reduce one scaffold's same-strand blocks to a single colinear chain
 #'
-#' Blocks on one colinear alignment share a query-vs-reference diagonal
-#' (`ref_start - qstart` on the '+' strand, `ref_start + qend` on '-'). Anchoring
-#' on the largest-nmatch block and keeping only blocks within `tol` of its
-#' diagonal drops origin-wrap and distant repeat/secondary blocks that would
-#' otherwise balloon the reference extent in [collapse_scaffold_blocks()].
+#' Anchors on the largest-nmatch block and walks outwards in reference order,
+#' keeping a block only when it is monotone in BOTH the reference and the query
+#' relative to the last block kept. That drops origin-wrap and distant
+#' repeat/secondary blocks, which reverse one of the two axes and would otherwise
+#' balloon the reference extent in [collapse_scaffold_blocks()].
+#'
+#' Monotonicity rather than a fixed diagonal band: a real indel shifts the
+#' diagonal by its own length, so a banded test discards the far side of any
+#' indel bigger than the band and then recomputes the extent from the surviving
+#' half. A monotone walk admits a colinear indel of any size while still
+#' rejecting a wrap. minimap2 reports query coordinates on the forward strand
+#' regardless of `strand`, so on '-' the query runs backwards as the reference
+#' advances.
 #'
 #' @param gs single-strand PAF rows for one scaffold (columns `strand`,
-#'   `ref_start`, `qstart`, `qend`, `nmatch`, `qlen`).
-#' @param tol max diagonal deviation from the anchor; defaults to a scaffold-
-#'   relative slack that tolerates indels but not an origin wrap / distant repeat.
-#' @return the subset of `gs` on the anchor block's colinear diagonal.
+#'   `ref_start`, `ref_end`, `qstart`, `qend`, `nmatch`).
+#' @param slop bp of overlap tolerated between consecutive blocks (block ends
+#'   commonly overhang each other by a few bases).
+#' @return the subset of `gs` forming the anchor block's colinear chain.
 #' @noRd
-colinear_chain <- function(gs, tol = NULL) {
+colinear_chain <- function(gs, slop = 100L) {
   if (nrow(gs) <= 1L) return(gs)
-  dg <- ifelse(gs$strand == "-", gs$ref_start + gs$qend, gs$ref_start - gs$qstart)
-  anchor <- which.max(gs$nmatch)
-  if (is.null(tol)) tol <- max(1000L, as.integer(round(0.2 * gs$qlen[1])))
-  gs[abs(dg - dg[anchor]) <= tol, , drop = FALSE]
+  g <- gs[order(gs$ref_start, gs$ref_end), , drop = FALSE]
+  a <- which.max(g$nmatch)
+  minus <- identical(as.character(g$strand[1]), "-")
+  keep <- rep(FALSE, nrow(g))
+  keep[a] <- TRUE
+  # forward: reference advances, so the query must advance too ('+') or retreat ('-')
+  last <- a
+  if (a < nrow(g)) for (i in (a + 1L):nrow(g)) {
+    ok <- g$ref_start[i] >= g$ref_end[last] - slop &&
+      if (minus) g$qend[i] <= g$qstart[last] + slop else g$qstart[i] >= g$qend[last] - slop
+    if (isTRUE(ok)) { keep[i] <- TRUE; last <- i }
+  }
+  # backward: mirror image of the same test
+  last <- a
+  if (a > 1L) for (i in (a - 1L):1L) {
+    ok <- g$ref_end[i] <= g$ref_start[last] + slop &&
+      if (minus) g$qstart[i] >= g$qend[last] - slop else g$qend[i] <= g$qstart[last] + slop
+    if (isTRUE(ok)) { keep[i] <- TRUE; last <- i }
+  }
+  g[keep, , drop = FALSE]
 }
 
 #' Collapse a scaffold's PAF alignment blocks to one placement row
@@ -336,10 +360,10 @@ collapse_scaffold_blocks <- function(rows) {
   do.call(rbind, lapply(split(rows, rows$scaffold), function(g) {
     by_strand <- tapply(g$nmatch, g$strand, sum)
     dom <- names(by_strand)[which.max(by_strand)]
-    gs <- g[g$strand == dom, , drop = FALSE]
+    gs_all <- g[g$strand == dom, , drop = FALSE]
     # Keep only the dominant strand's colinear chain so an origin-wrap or a
     # distant repeat/secondary block cannot balloon the reference extent.
-    gs <- colinear_chain(gs)
+    gs <- colinear_chain(gs_all)
     anchor <- gs[which.min(gs$ref_start), , drop = FALSE]
     data.frame(
       scaffold  = g$scaffold[1],
@@ -347,8 +371,15 @@ collapse_scaffold_blocks <- function(rows) {
       ref_end   = max(gs$ref_end),
       strand    = dom,
       nmatch    = sum(gs$nmatch),
-      qcov      = union_len(gs$qstart, gs$qend) / gs$qlen[1],
-      qstart    = anchor$qstart,
+      # qcov over ALL the dominant strand's blocks, not the pruned chain: pruning
+      # exists to keep a wrap from inflating the reference extent, but a wrapping
+      # or rearranged scaffold still genuinely covers the query it aligns over,
+      # and scoring it on half its blocks lets min_qcov drop a real scaffold.
+      qcov      = union_len(gs_all$qstart, gs_all$qend) / gs_all$qlen[1],
+      # Colinear (ref_start, qstart) pair for the zoom view. On '-' the sequence
+      # the zoom indexes is reverse-complemented, so the forward-query PAF
+      # coordinate has to be flipped to match it.
+      qstart    = if (identical(dom, "-")) anchor$qlen - anchor$qend else anchor$qstart,
       stringsAsFactors = FALSE
     )
   }))
@@ -434,19 +465,36 @@ detect_subsumed <- function(inc, min_cover = 0.90, min_density = 0.50) {
   span <- pmax(re - rs, 1L)
   nm <- if (!is.null(inc$nmatch)) inc$nmatch else rep(NA_real_, n)
   density <- ifelse(is.na(nm), 1, nm / span)
+  qcov <- if (!is.null(inc$qcov)) inc$qcov else rep(NA_real_, n)
   for (b in seq_len(n)) {
     if (is.na(rs[b]) || is.na(re[b])) next
+    # Containment is judged on the reference extent, which says nothing about the
+    # part of B that never aligned. A scaffold still carrying substantial
+    # unaligned query sequence is not proven redundant, and dropping it would
+    # discard bases no other scaffold has.
+    if (!is.na(qcov[b]) && qcov[b] < 0.9) next
+    hits <- integer(0)
     for (a in seq_len(n)) {
       if (a == b || is.na(rs[a]) || is.na(re[a])) next
       # A must be the strictly larger extent (the container) and dense enough to
       # be a trustworthy placement.
       if (span[a] <= span[b] || density[a] < min_density) next
       ov <- min(re[a], re[b]) - max(rs[a], rs[b])
-      if (ov > 0 && ov / span[b] >= min_cover) {
-        reason[b] <- paste0("subsumed by scaffold ", inc$scaffold[a])
-        break
-      }
+      if (ov > 0 && ov / span[b] >= min_cover) hits <- c(hits, a)
     }
+    # Name the LARGEST qualifying container, not whichever came first, so the
+    # reason shown in the editor points at the scaffold actually carrying B.
+    if (length(hits)) {
+      reason[b] <- paste0("subsumed by scaffold ", inc$scaffold[hits[which.max(span[hits])]])
+    }
+  }
+  # A scaffold that is itself being excluded must not be cited as a container.
+  keep <- is.na(reason)
+  if (any(!keep)) {
+    bad <- paste0("subsumed by scaffold ", inc$scaffold[!keep])
+    orphan <- !is.na(reason) & reason %in% bad
+    reason[orphan] <- sub("^subsumed by scaffold .*$",
+                          "subsumed (container also excluded)", reason[orphan])
   }
   reason
 }
@@ -502,9 +550,14 @@ derive_scaffold_layout <- function(mappings, ref_len = NA_integer_, circular = F
   # a ballooned extent spanning nearly the whole reference; its ref_end is then not
   # a real right boundary, and deriving the next scaffold's gap from it manufactures
   # a genome-scale negative gap that over-trims (or drops) a real scaffold. Skip
-  # such a predecessor's junction (NA -> N-gap). Gate on LOW density so a genuine
-  # dense full-length contig is not misread as a wrap (a real ballooned wrap unions
+  # such a predecessor's junction. Gate on LOW density so a genuine dense
+  # full-length contig is not misread as a wrap (a real ballooned wrap unions
   # disjoint blocks and so is sparse: nmatch/span < min_density).
+  #
+  # Use 0 rather than NA for the skipped junction. NA means "unknown", which
+  # switches join_scaffolds' do_probe off and fabricates a blind N spacer over
+  # what is usually a real overlap; 0 keeps the probe on, so refine_overlap can
+  # still confirm and merge the overlap, and degrades to a butt join if it cannot.
   wrap_thresh <- if (is.finite(ref_len) && ref_len > 0) 0.9 * ref_len else Inf
   min_density <- 0.5
   gap_before <- rep(NA_real_, nrow(inc))
@@ -515,8 +568,7 @@ derive_scaffold_layout <- function(mappings, ref_len = NA_integer_, circular = F
         inc$nmatch[i - 1] / prev_span else NA_real_
       ballooned <- !is.na(prev_span) && prev_span >= wrap_thresh &&
         !is.na(prev_density) && prev_density < min_density
-      if (ballooned) next
-      gap_before[i] <- inc$ref_start[i] - inc$ref_end[i - 1]
+      gap_before[i] <- if (ballooned) 0 else inc$ref_start[i] - inc$ref_end[i - 1]
     }
   }
 
@@ -525,21 +577,28 @@ derive_scaffold_layout <- function(mappings, ref_len = NA_integer_, circular = F
   } else {
     list(inc = rep(NA_integer_, nrow(inc)), exc = rep(NA_integer_, nrow(exc)))
   }
+  # Excluded rows keep their REAL orientation and reference coordinates. A
+  # subsumed scaffold is well mapped by definition, and the editor invites the
+  # user to re-include it; blanking rc/ref_start/ref_end would hand it back
+  # forward-stranded and unplaced. Genuinely unmapped rows already hold NA, so
+  # nothing is invented (the is.na sweep below coerces their rc to FALSE).
   lay <- data.frame(
     scaffold = c(inc$scaffold, exc$scaffold),
-    rc = c(inc$strand == "-", rep(FALSE, nrow(exc))),
+    rc = c(inc$strand == "-", exc$strand == "-"),
     gap_before = c(gap_before, rep(NA_real_, nrow(exc))),
     mapped = c(inc$mapped, exc$mapped),
     include = c(rep(TRUE, nrow(inc)), rep(FALSE, nrow(exc))),
     exclude_reason = c(rep(NA_character_, nrow(inc)), exc_reason),
     qcov = c(inc$qcov, exc$qcov),
-    ref_start = c(inc$ref_start, rep(NA_integer_, nrow(exc))),
-    ref_end = c(inc$ref_end, rep(NA_integer_, nrow(exc))),
+    ref_start = c(inc$ref_start, exc$ref_start),
+    ref_end = c(inc$ref_end, exc$ref_end),
     qstart = c(qstart_col$inc, qstart_col$exc),
     stringsAsFactors = FALSE
   )
   lay$rc[is.na(lay$rc)] <- FALSE
-  lay$order <- seq_len(nrow(lay))
+  # Seed the order at each scaffold's true reference position so a re-included
+  # scaffold lands where it belongs rather than at the end. Unplaced rows sort last.
+  lay$order <- rank(ifelse(is.na(lay$ref_start), Inf, lay$ref_start), ties.method = "first")
   lay[, c("scaffold", "order", "rc", "gap_before", "mapped", "include",
           "exclude_reason", "qcov", "ref_start", "ref_end", "qstart")]
 }
@@ -580,8 +639,11 @@ low_complexity_overlap <- function(s, k = 3L, min_distinct = 4L) {
 #' @param min_identity minimum overlap identity to "confirm" the overlap.
 #' @param min_overlap minimum aligned length to "confirm" the overlap; raise it
 #'   for overlaps not predicted by the reference to suppress spurious short hits.
-#' @return list(reliable, trim_b, identity, overlap_len): `trim_b` = bases to drop
-#'   from the start of `b_seq` (the confirmed overlap length when reliable).
+#' @return list(reliable, trim_b, identity, overlap_len, pat_len, n_indel):
+#'   `trim_b` = bases to drop from the start of `b_seq` (the confirmed overlap
+#'   length when reliable). `pat_len` is the aligned length on A's side and
+#'   `n_indel` the indel bases in the alignment; the two together tell the caller
+#'   whether A's suffix and B's prefix can be paired position-for-position.
 #' @noRd
 refine_overlap <- function(a_seq, b_seq, est_overlap, min_identity = 0.7,
                            min_overlap = 10L) {
@@ -592,7 +654,8 @@ refine_overlap <- function(a_seq, b_seq, est_overlap, min_identity = 0.7,
   # wider window when the reference itself predicts a big overlap.
   maxwin <- as.integer(getOption("MitoPilot.scaffold_overlap_maxwin", 5000L))
   L <- min(nchar(a_seq), nchar(b_seq), max(est + slack, maxwin))
-  out <- list(reliable = FALSE, trim_b = 0L, identity = NA_real_, overlap_len = 0L)
+  out <- list(reliable = FALSE, trim_b = 0L, identity = NA_real_, overlap_len = 0L,
+              pat_len = 0L, n_indel = 0L)
   if (L < 10L) return(out)
   a_tail <- substring(a_seq, nchar(a_seq) - L + 1L)
   b_head <- substring(b_seq, 1L, L)
@@ -614,22 +677,39 @@ refine_overlap <- function(a_seq, b_seq, est_overlap, min_identity = 0.7,
   sub_start <- BiocGenerics::start(sub_rng)
   sub_end <- BiocGenerics::end(sub_rng)
   # The aligned pattern (a_tail) must also reach a's 3' terminus: a genuine
-  # junction overlap sits at BOTH a's suffix end and b's prefix start. Without
-  # this, a copy of b's prefix buried inside a's tail (an internal repeat, made
-  # reachable by the widened window) would falsely confirm and trim real bases.
+  # junction overlap sits at BOTH a's suffix end and b's prefix start.
   pat_rng <- pwalign::pattern(aln)@range
   pat_at_end <- (nchar(a_tail) - BiocGenerics::end(pat_rng)) <= 2L
+  # ...and the terminal columns must actually MATCH. Reaching a's end is not
+  # enough on its own: pwalign type="overlap" will happily drag the alignment
+  # through a divergent 3' tail to get there, which both confirms a junction that
+  # is not one and inflates trim_b past the real boundary. Requiring the last few
+  # columns to be ungapped identities is what separates a true junction overlap
+  # from a dragged alignment or an internal repeat.
+  # Ungapped and >= 80% identical over the last 10 columns, rather than exactly
+  # identical: a genuine overlap can carry a sequencing error at the terminus, but
+  # a dragged alignment is far worse than 8/10 there (measured on real data: 5/10
+  # with 42 indel bases, against 100% for a true junction).
+  ap <- as.character(pwalign::alignedPattern(aln))
+  sq <- as.character(pwalign::alignedSubject(aln))
+  tw <- min(10L, nchar(ap), nchar(sq))
+  pa <- substring(ap, nchar(ap) - tw + 1L)
+  sa <- substring(sq, nchar(sq) - tw + 1L)
+  tail_ok <- tw > 0L && !grepl("-", pa, fixed = TRUE) && !grepl("-", sa, fixed = TRUE) &&
+    mean(strsplit(pa, "", fixed = TRUE)[[1]] == strsplit(sa, "", fixed = TRUE)[[1]]) >= 0.8
   # Reject low-complexity confirmations (homopolymer / short tandem motif at
   # AT-rich termini) that clear identity/length by chance and would trim real
   # bases from B.
   ov_lc <- low_complexity_overlap(substring(b_head, 1L, sub_end))
-  if (ident >= min_identity && sub_start <= 2L && pat_at_end && !ov_lc) {
+  ind <- tryCatch(pwalign::nindel(aln), error = function(e) NULL)
+  out$n_indel <- if (is.null(ind)) 0L else
+    as.integer(sum(ind@insertion[, 2], ind@deletion[, 2]))
+  out$pat_len <- as.integer(BiocGenerics::end(pat_rng) - BiocGenerics::start(pat_rng) + 1L)
+  out$identity <- ident
+  if (ident >= min_identity && sub_start <= 2L && pat_at_end && tail_ok && !ov_lc) {
     out$reliable <- TRUE
     out$trim_b <- as.integer(sub_end)
-    out$identity <- ident
     out$overlap_len <- as.integer(alen)
-  } else {
-    out$identity <- ident
   }
   out
 }
@@ -750,7 +830,15 @@ join_scaffolds <- function(scaffold_seqs, layout, gap_len_default = 100L,
         jmsg <- sprintf("%s|%s overlap %d bp confirmed (%.0f%% identity), merged",
                         prev_scaf, s, ov$overlap_len, 100 * ov$identity)
         # Coverage-majority consensus across the overlap (replaces A's tail).
-        if (!is.null(prev_depth) && !is.null(dep) && trim >= 1L) {
+        # Only safe when A's suffix and B's prefix line up position-for-position:
+        # the consensus pairs them by index, so an indel inside the overlap, or an
+        # A-side aligned length that differs from the trim taken off B, would
+        # compare off-register bases and manufacture IUPAC codes across the whole
+        # junction. In that case keep A's tail unmodified (the pre-consensus
+        # behavior) and say so rather than quoting an identity that does not
+        # describe what was written.
+        alignable <- ov$n_indel == 0L && identical(as.integer(ov$pat_len), as.integer(trim))
+        if (!is.null(prev_depth) && !is.null(dep) && trim >= 1L && alignable) {
           k <- min(trim, nchar(prev_oriented))
           pl <- nchar(prev_oriented)
           a_ch <- strsplit(substring(prev_oriented, pl - k + 1L), "", fixed = TRUE)[[1]]
@@ -761,6 +849,9 @@ join_scaffolds <- function(scaffold_seqs, layout, gap_len_default = 100L,
           if (cc$n_mismatch > 0) jmsg <- sprintf(
             "%s; %d mismatches resolved by coverage (%d IUPAC, %d N)",
             jmsg, cc$n_mismatch, cc$n_iupac, cc$n_n)
+        } else if (!alignable) {
+          jmsg <- sprintf("%s; overlap not base-alignable (%d indel bp), A's bases kept",
+                          jmsg, ov$n_indel)
         }
         junctions <- c(junctions, jmsg)
       } else if (ref_overlap) {
@@ -1031,17 +1122,21 @@ assemble_from_layout <- function(scaffolds_df, layout, gap_len = 100L,
   # circularizes only when the user asserts circular. The `circular` arg still
   # forces rotation below.
   has_ref <- !is.null(ref_seq) && length(ref_seq) == 1 && !is.na(ref_seq) && nzchar(ref_seq)
-  cz <- if (isTRUE(circular) || has_ref) {
-    circularize_sequence(seq, depth, gc, errors, min_overlap = 50L)
-  } else {
-    list(circular = FALSE, seq = seq, depth = depth, gc = gc,
-         errors = errors, overlap_len = 0L, identity = NA_real_)
-  }
-  is_circular <- isTRUE(cz$circular) || isTRUE(circular)
-  if (isTRUE(cz$circular)) {
+  # ALWAYS run the detection, even when the gate below will not act on it. The
+  # gate decides whether to TRIM; leaving the detection off as well meant an
+  # unticked Circular box silently emitted the origin region twice.
+  cz <- circularize_sequence(seq, depth, gc, errors, min_overlap = 50L)
+  may_trim <- isTRUE(circular) || has_ref
+  is_circular <- (isTRUE(cz$circular) && may_trim) || isTRUE(circular)
+  if (isTRUE(cz$circular) && may_trim) {
     seq <- cz$seq; depth <- cz$depth; gc <- cz$gc; errors <- cz$errors
     circ_note <- c(circ_note, sprintf(
       "circular: trimmed %d bp redundant end overlap (%.0f%% identity)",
+      cz$overlap_len, 100 * cz$identity))
+  } else if (isTRUE(cz$circular)) {
+    circ_note <- c(circ_note, sprintf(
+      paste("WARNING: %d bp redundant end overlap detected (%.0f%% identity) but NOT",
+            "trimmed because Circular is unchecked; the origin region is present twice"),
       cz$overlap_len, 100 * cz$identity))
   }
   if (is_circular && !is.null(ref_seq) && !is.na(ref_seq) && nzchar(ref_seq)) {
@@ -1270,11 +1365,15 @@ plot_scaffold_mapping <- function(layout, ref_len, scaffold_len = NULL) {
   inc <- if ("include" %in% names(layout)) layout$include else !is.na(layout$ref_start)
   shown <- layout[inc & !is.na(layout$ref_start), , drop = FALSE]
   excluded <- layout[!inc, , drop = FALSE]
+  # Included but with no reference placement: it goes into Path 0 yet has no bar
+  # to draw, so without its own note it would be absent from the plot entirely.
+  unplaced <- layout[inc & is.na(layout$ref_start), , drop = FALSE]
   ref_len <- max(ref_len, 1, shown$ref_end, na.rm = TRUE)
 
-  # Extra top margin reserves a line for the excluded-scaffold note so it never
-  # collides with the x-axis title at the bottom.
-  top_mar <- if (nrow(excluded) > 0) 4 else 2.5
+  # Extra top margin reserves a line per note so they never collide with the
+  # x-axis title at the bottom.
+  n_notes <- (nrow(excluded) > 0) + (nrow(unplaced) > 0)
+  top_mar <- if (n_notes > 0) 2.5 + 1.5 * n_notes else 2.5
   op <- graphics::par(mar = c(4.5, 1, top_mar, 1))
   on.exit(graphics::par(op), add = TRUE)
   n <- max(nrow(shown), 1)
@@ -1309,6 +1408,13 @@ plot_scaffold_mapping <- function(layout, ref_len, scaffold_len = NULL) {
     }
     graphics::mtext(paste("Excluded from Path 0:", lab),
                     side = 3, line = 0.3, col = "#d9534f", cex = 0.85)
+  }
+  if (nrow(unplaced) > 0) {
+    graphics::mtext(
+      paste("Included but unplaced (appended with N gap):",
+            paste(unplaced$scaffold, collapse = ", ")),
+      side = 3, line = if (nrow(excluded) > 0) 1.5 else 0.3,
+      col = "#e08a00", cex = 0.85)
   }
   invisible(NULL)
 }

--- a/R/scaffold_join.R
+++ b/R/scaffold_join.R
@@ -370,6 +370,51 @@ zoom_window_base_maps <- function(ref_seq, layout_inc, oriented_seqs,
   out
 }
 
+#' Flag scaffolds whose reference extent is contained within a larger neighbor
+#'
+#' When two scaffolds map to the same reference region and one is (almost) wholly
+#' contained in the other, concatenating the contained one duplicates sequence and
+#' forces a large negative gap that would trim real bases out of the container (or
+#' silently drop the redundant scaffold). Following the contained-read convention
+#' of OLC/string-graph assemblers, the smaller scaffold is instead marked for
+#' exclusion from Path 0 and the larger (container) is kept. The user can still
+#' re-include it in the editor.
+#'
+#' @param inc mapped, included scaffold rows (need `scaffold, ref_start, ref_end`
+#'   and, ideally, `nmatch`), already restricted to well-mapped scaffolds.
+#' @param min_cover fraction of the smaller scaffold's reference extent that must
+#'   lie within the larger's extent to call it subsumed.
+#' @param min_density minimum matched-bases-per-reference-bp a scaffold must have
+#'   to act as a container; blocks a sparse origin-spanning/ballooned extent from
+#'   swallowing everything (see `collapse_scaffold_blocks`).
+#' @return character vector (length `nrow(inc)`): `NA` for kept scaffolds, else a
+#'   `"subsumed by <container>"` reason string.
+#' @noRd
+detect_subsumed <- function(inc, min_cover = 0.90, min_density = 0.50) {
+  n <- nrow(inc)
+  reason <- rep(NA_character_, n)
+  if (n < 2) return(reason)
+  rs <- inc$ref_start; re <- inc$ref_end
+  span <- pmax(re - rs, 1L)
+  nm <- if (!is.null(inc$nmatch)) inc$nmatch else rep(NA_real_, n)
+  density <- ifelse(is.na(nm), 1, nm / span)
+  for (b in seq_len(n)) {
+    if (is.na(rs[b]) || is.na(re[b])) next
+    for (a in seq_len(n)) {
+      if (a == b || is.na(rs[a]) || is.na(re[a])) next
+      # A must be the strictly larger extent (the container) and dense enough to
+      # be a trustworthy placement.
+      if (span[a] <= span[b] || density[a] < min_density) next
+      ov <- min(re[a], re[b]) - max(rs[a], rs[b])
+      if (ov > 0 && ov / span[b] >= min_cover) {
+        reason[b] <- paste0("subsumed by scaffold ", inc$scaffold[a])
+        break
+      }
+    }
+  }
+  reason
+}
+
 #' Derive scaffold layout (order + orientation + gaps) from reference mappings
 #'
 #' Only scaffolds that map reasonably well to the reference (query coverage
@@ -402,8 +447,20 @@ derive_scaffold_layout <- function(mappings, ref_len = NA_integer_, circular = F
 
   inc <- mappings[well, , drop = FALSE]
   exc <- mappings[!well, , drop = FALSE]
+  exc_reason <- if (nrow(exc) > 0)
+    ifelse(exc$mapped, "low reference coverage", "unmapped") else character(0)
   ord <- order(inc$ref_start, inc$ref_end)
   inc <- inc[ord, , drop = FALSE]
+
+  # Move contained/duplicate scaffolds out of Path 0 (see detect_subsumed): they
+  # would otherwise force a huge negative gap that trims real bases.
+  sub_reason <- detect_subsumed(inc)
+  subsumed <- !is.na(sub_reason)
+  if (any(subsumed)) {
+    exc <- rbind(exc, inc[subsumed, , drop = FALSE])
+    exc_reason <- c(exc_reason, sub_reason[subsumed])
+    inc <- inc[!subsumed, , drop = FALSE]
+  }
 
   gap_before <- rep(NA_real_, nrow(inc))
   if (nrow(inc) >= 2) {
@@ -423,6 +480,7 @@ derive_scaffold_layout <- function(mappings, ref_len = NA_integer_, circular = F
     gap_before = c(gap_before, rep(NA_real_, nrow(exc))),
     mapped = c(inc$mapped, exc$mapped),
     include = c(rep(TRUE, nrow(inc)), rep(FALSE, nrow(exc))),
+    exclude_reason = c(rep(NA_character_, nrow(inc)), exc_reason),
     qcov = c(inc$qcov, exc$qcov),
     ref_start = c(inc$ref_start, rep(NA_integer_, nrow(exc))),
     ref_end = c(inc$ref_end, rep(NA_integer_, nrow(exc))),
@@ -432,7 +490,7 @@ derive_scaffold_layout <- function(mappings, ref_len = NA_integer_, circular = F
   lay$rc[is.na(lay$rc)] <- FALSE
   lay$order <- seq_len(nrow(lay))
   lay[, c("scaffold", "order", "rc", "gap_before", "mapped", "include",
-          "qcov", "ref_start", "ref_end", "qstart")]
+          "exclude_reason", "qcov", "ref_start", "ref_end", "qstart")]
 }
 
 #' Reverse-complement a DNA string
@@ -673,9 +731,18 @@ join_scaffolds <- function(scaffold_seqs, layout, gap_len_default = 100L,
 
     if (trim > 0) seq <- substring(seq, trim + 1L)
     n <- nchar(seq)
+    if (n <= 0L) {
+      # Scaffold fully consumed by overlap trimming (redundant/contained): drop it
+      # rather than append an empty piece (which would desync src_pos), and keep
+      # the previous scaffold as the anchor for the next junction.
+      junctions <- c(junctions, sprintf(
+        "%s fully overlapped by %s; dropped as redundant",
+        s, if (!is.null(prev_scaf)) prev_scaf else "previous"))
+      next
+    }
     pieces <- c(pieces, seq)
     src_scaffold <- c(src_scaffold, rep(s, n))
-    src_pos <- c(src_pos, (trim + 1L):(trim + n))
+    src_pos <- c(src_pos, trim + seq_len(n))
     prev_oriented <- seq
     prev_scaf <- s
     prev_depth <- if (is.null(dep)) NULL else if (trim > 0) dep[-(seq_len(trim))] else dep
@@ -1126,8 +1193,13 @@ plot_scaffold_mapping <- function(layout, ref_len, scaffold_len = NULL) {
   }
   if (nrow(excluded) > 0) {
     # Place under the title (top), away from the x-axis labels.
-    graphics::mtext(paste("Excluded from Path 0 (poor/no mapping):",
-                          paste(excluded$scaffold, collapse = ", ")),
+    lab <- if (!is.null(excluded$exclude_reason)) {
+      paste(mapply(function(s, r) if (is.na(r)) s else paste0(s, " (", r, ")"),
+                   excluded$scaffold, excluded$exclude_reason), collapse = ", ")
+    } else {
+      paste(excluded$scaffold, collapse = ", ")
+    }
+    graphics::mtext(paste("Excluded from Path 0:", lab),
                     side = 3, line = 0.3, col = "#d9534f", cex = 0.85)
   }
   invisible(NULL)
@@ -1363,8 +1435,13 @@ compose_join_note <- function(layout, seq, gap_len, junctions = character(0),
   note <- sprintf("Joined %d scaffolds: %s; %d N gap bases.",
                   nrow(inc), order_str, n_gaps)
   if (nrow(exc) > 0) {
-    note <- paste0(note, sprintf(" Excluded (poor/no reference mapping): %s.",
-                                 paste(exc$scaffold, collapse = ", ")))
+    exc_lab <- if (!is.null(exc$exclude_reason)) {
+      paste(mapply(function(s, r) if (is.na(r)) s else paste0(s, " (", r, ")"),
+                   exc$scaffold, exc$exclude_reason), collapse = ", ")
+    } else {
+      paste(exc$scaffold, collapse = ", ")
+    }
+    note <- paste0(note, sprintf(" Excluded from Path 0: %s.", exc_lab))
   }
   if (length(junctions) > 0) {
     note <- paste0(note, " Junctions: ", paste(junctions, collapse = "; "), ".")

--- a/R/scaffold_join.R
+++ b/R/scaffold_join.R
@@ -387,10 +387,22 @@ collapse_scaffold_blocks <- function(rows) {
 
 #' Per-reference-position scaffold bases for ONE reference window (lazy)
 #'
-#' For the base-pair zoom: aligns just the small scaffold sub-region that maps to
-#' `[win_start, win_end]` (estimated from the minimap2 colinear offset, padded)
-#' against the reference window. This keeps each alignment tiny and works for
-#' divergent references (where minimap2 `-c` CIGAR is unreliable).
+#' For the base-pair zoom: aligns the scaffold sub-region that maps to
+#' `[win_start, win_end]` against the reference window. Keeping each alignment
+#' small works for divergent references (where minimap2 `-c` CIGAR is unreliable).
+#'
+#' The sub-region is estimated from the cached colinear offset, which is anchored
+#' on ONE block (the lowest `ref_start`), so its error grows with distance from
+#' that anchor and with every indel in between - the reason scaffolds that show a
+#' bar in the overview plot could render blank here. Three defences:
+#'
+#' 1. the sub-region widens in proportion to that distance;
+#' 2. a candidate alignment is scored against the reference window and rejected
+#'    below `min_identity`, so a drifted estimate yields an honest blank instead
+#'    of confidently wrong bases;
+#' 3. when the estimate covers little of the window (or there is no offset to
+#'    extrapolate from at all) the whole oriented scaffold is realigned to the
+#'    window and the better-covering result wins.
 #'
 #' @param ref_seq reference sequence.
 #' @param layout_inc included layout rows (need `scaffold, rc, ref_start, ref_end,
@@ -398,42 +410,130 @@ collapse_scaffold_blocks <- function(rows) {
 #' @param oriented_seqs named character vector of ORIENTED scaffold sequences.
 #' @param win_start,win_end 1-based reference window.
 #' @param pad bp of slack around the estimated scaffold sub-region.
+#' @param min_identity minimum identity to the reference window for a candidate
+#'   alignment to be drawn at all.
+#' @param max_retry_len longest scaffold to attempt the whole-scaffold retry on
+#'   (bounds the O(n*m) DP; mitogenome scaffolds are far below it).
 #' @return named list (by scaffold id) of reference-position -> base vectors,
-#'   restricted to the window.
+#'   restricted to the window. Scaffolds with no acceptable alignment are absent.
 #' @noRd
 zoom_window_base_maps <- function(ref_seq, layout_inc, oriented_seqs,
-                                  win_start, win_end, pad = 100L) {
+                                  win_start, win_end, pad = 100L,
+                                  min_identity = 0.6, max_retry_len = 50000L) {
   ws <- max(1L, as.integer(win_start)); we <- min(nchar(ref_seq), as.integer(win_end))
   rsub_s <- max(1L, ws - pad); rsub_e <- min(nchar(ref_seq), we + pad)
   ref_sub <- substring(ref_seq, rsub_s, rsub_e)
+  win_key <- as.character(ws:we)
+  win_ref <- strsplit(substring(ref_seq, ws, we), "", fixed = TRUE)[[1]]
   mx <- pwalign::nucleotideSubstitutionMatrix(match = 1, mismatch = -1)
-  out <- list()
-  for (i in seq_len(nrow(layout_inc))) {
-    s <- as.character(layout_inc$scaffold[i])
-    rstart <- layout_inc$ref_start[i]; rend <- layout_inc$ref_end[i]
-    qstart <- layout_inc$qstart[i]
-    if (is.na(rstart) || is.na(qstart) || rend < ws || rstart > we) next
-    oseq <- oriented_seqs[[s]]
-    if (is.null(oseq)) next
-    # colinear estimate of scaffold coords for [ws, we] (PAF coords are 0-based)
-    qs_est <- qstart + ((ws - 1L) - rstart)
-    qe_est <- qstart + ((we - 1L) - rstart)
-    sub_s <- max(1L, qs_est + 1L - pad); sub_e <- min(nchar(oseq), qe_est + 1L + pad)
-    if (sub_e <= sub_s) next
-    scaf_sub <- substring(oseq, sub_s, sub_e)
+
+  # Local (not global-local) alignment: the scaffold sub-region is deliberately
+  # padded wider than the reference window, and a global pattern would be forced
+  # to cram that overhang in, wrecking the placement it is meant to refine.
+  align_bm <- function(scaf_sub) {
+    if (!nzchar(scaf_sub)) return(NULL)
     aln <- tryCatch(
       pwalign::pairwiseAlignment(
         pattern = Biostrings::DNAString(scaf_sub),
         subject = Biostrings::DNAString(ref_sub),
         substitutionMatrix = mx, gapOpening = 5, gapExtension = 2,
-        type = "global-local"),
+        type = "local"),
       error = function(e) NULL)
-    if (is.null(aln)) next
+    if (is.null(aln)) return(NULL)
     ref_off <- rsub_s + BiocGenerics::start(pwalign::subject(aln)@range) - 1L
     bm <- build_ref_base_map(as.character(pwalign::alignedPattern(aln)),
                              as.character(pwalign::alignedSubject(aln)), ref_off)
-    out[[s]] <- bm[as.character(ws:we)]
+    bm[win_key]
   }
+  # Window positions covered, and identity to the reference over them. Any
+  # alignment returns bases; only this says whether they belong here.
+  score_bm <- function(bm) {
+    if (is.null(bm)) return(list(n = 0L, ident = NA_real_))
+    idx <- which(!is.na(bm))
+    if (length(idx) == 0L) return(list(n = 0L, ident = NA_real_))
+    keep <- idx[bm[idx] != "-"]
+    list(n = length(idx),
+         ident = if (length(keep)) mean(toupper(bm[keep]) == toupper(win_ref[keep])) else 0)
+  }
+
+  out <- list()
+  for (i in seq_len(nrow(layout_inc))) {
+    s <- as.character(layout_inc$scaffold[i])
+    rstart <- layout_inc$ref_start[i]; rend <- layout_inc$ref_end[i]
+    qstart <- layout_inc$qstart[i]
+    if (is.na(rstart) || is.na(rend) || rend < ws || rstart > we) next
+    oseq <- oriented_seqs[[s]]
+    if (is.null(oseq)) next
+
+    best <- NULL; best_sc <- list(n = 0L, ident = NA_real_)
+    take <- function(bm) {
+      sc <- score_bm(bm)
+      if (!is.na(sc$ident) && sc$ident >= min_identity && sc$n > best_sc$n) {
+        best <<- bm; best_sc <<- sc
+      }
+    }
+    # 1. colinear estimate of scaffold coords for [ws, we] (PAF coords 0-based),
+    #    padded in proportion to how far the window sits from the anchor block.
+    if (!is.na(qstart)) {
+      drift <- abs((ws - 1L) - rstart)
+      pad_i <- pad + min(2000L, as.integer(ceiling(0.15 * drift)))
+      qs_est <- qstart + ((ws - 1L) - rstart)
+      qe_est <- qstart + ((we - 1L) - rstart)
+      sub_s <- max(1L, qs_est + 1L - pad_i)
+      sub_e <- min(nchar(oseq), qe_est + 1L + pad_i)
+      if (sub_e > sub_s) take(align_bm(substring(oseq, sub_s, sub_e)))
+    }
+    # 2. fall back to the whole scaffold when the estimate covered under half the
+    #    window, ran off the scaffold end, or never existed (qstart NA).
+    if (best_sc$n < length(win_key) %/% 2L && nchar(oseq) <= max_retry_len) {
+      take(align_bm(oseq))
+    }
+    if (!is.null(best)) out[[s]] <- best
+  }
+  out
+}
+
+#' Flag reference extents that are ballooned origin-wrap artifacts
+#'
+#' A scaffold mapping near BOTH ends of a linear reference unions two distant
+#' blocks into a single extent spanning nearly the whole reference. That extent is
+#' an artifact rather than a placement, so it must neither drive a junction gap
+#' nor act as a containment container.
+#'
+#' The tell is a near-full-reference span carrying far fewer matched bases per
+#' reference bp than the sample's other scaffolds. The comparison has to be
+#' RELATIVE: minimap2 `nmatch` density falls with reference divergence, so an
+#' absolute floor (the 0.5 this replaces) is cleared by every scaffold against a
+#' conspecific reference and by none against an 83%-identity cross-species one -
+#' switching the guard off exactly where fragmented assemblies need it, and
+#' switching it on for genuine dense containers when the reference is close.
+#'
+#' @param span per-scaffold reference extent widths.
+#' @param density per-scaffold matched bases per reference bp (`nmatch / span`).
+#' @param ref_len reference length; falls back to the widest `ref_end` when unknown.
+#' @param ref_end per-scaffold extent ends, for that fallback.
+#' @param span_frac fraction of the reference a span must reach to be suspect.
+#' @param density_frac fraction of the cohort's best density below which a
+#'   near-full-reference span is judged an artifact.
+#' @return logical vector, one entry per scaffold.
+#' @noRd
+ballooned_extent <- function(span, density, ref_len = NA_integer_, ref_end = NULL,
+                             span_frac = 0.9, density_frac = 0.25) {
+  n <- length(span)
+  if (n == 0L) return(logical(0))
+  ref_len <- suppressWarnings(as.numeric(ref_len)[1])
+  if (!isTRUE(is.finite(ref_len)) || ref_len <= 0) {
+    ref_len <- if (!is.null(ref_end) && any(is.finite(ref_end))) {
+      max(ref_end[is.finite(ref_end)])
+    } else NA_real_
+  }
+  if (!isTRUE(is.finite(ref_len)) || ref_len <= 0) return(rep(FALSE, n))
+  fin <- is.finite(density)
+  best <- if (any(fin)) max(density[fin]) else NA_real_
+  if (!isTRUE(is.finite(best)) || best <= 0) return(rep(FALSE, n))
+  out <- is.finite(span) & span >= span_frac * ref_len &
+    fin & density < density_frac * best
+  out[is.na(out)] <- FALSE
   out
 }
 
@@ -451,13 +551,13 @@ zoom_window_base_maps <- function(ref_seq, layout_inc, oriented_seqs,
 #'   and, ideally, `nmatch`), already restricted to well-mapped scaffolds.
 #' @param min_cover fraction of the smaller scaffold's reference extent that must
 #'   lie within the larger's extent to call it subsumed.
-#' @param min_density minimum matched-bases-per-reference-bp a scaffold must have
-#'   to act as a container; blocks a sparse origin-spanning/ballooned extent from
-#'   swallowing everything (see `collapse_scaffold_blocks`).
+#' @param ref_len reference length, used to recognise a ballooned (origin-wrapping)
+#'   extent that must not act as a container. Defaults to the widest observed
+#'   `ref_end` when not supplied.
 #' @return character vector (length `nrow(inc)`): `NA` for kept scaffolds, else a
 #'   `"subsumed by <container>"` reason string.
 #' @noRd
-detect_subsumed <- function(inc, min_cover = 0.90, min_density = 0.50) {
+detect_subsumed <- function(inc, min_cover = 0.90, ref_len = NA_integer_) {
   n <- nrow(inc)
   reason <- rep(NA_character_, n)
   if (n < 2) return(reason)
@@ -465,6 +565,7 @@ detect_subsumed <- function(inc, min_cover = 0.90, min_density = 0.50) {
   span <- pmax(re - rs, 1L)
   nm <- if (!is.null(inc$nmatch)) inc$nmatch else rep(NA_real_, n)
   density <- ifelse(is.na(nm), 1, nm / span)
+  ballooned <- ballooned_extent(span, density, ref_len, re)
   qcov <- if (!is.null(inc$qcov)) inc$qcov else rep(NA_real_, n)
   for (b in seq_len(n)) {
     if (is.na(rs[b]) || is.na(re[b])) next
@@ -476,9 +577,9 @@ detect_subsumed <- function(inc, min_cover = 0.90, min_density = 0.50) {
     hits <- integer(0)
     for (a in seq_len(n)) {
       if (a == b || is.na(rs[a]) || is.na(re[a])) next
-      # A must be the strictly larger extent (the container) and dense enough to
-      # be a trustworthy placement.
-      if (span[a] <= span[b] || density[a] < min_density) next
+      # A must be the strictly larger extent (the container) and not a ballooned
+      # origin-wrap, whose extent is an artifact rather than a real placement.
+      if (span[a] <= span[b] || isTRUE(ballooned[a])) next
       ov <- min(re[a], re[b]) - max(rs[a], rs[b])
       if (ov > 0 && ov / span[b] >= min_cover) hits <- c(hits, a)
     }
@@ -538,7 +639,7 @@ derive_scaffold_layout <- function(mappings, ref_len = NA_integer_, circular = F
 
   # Move contained/duplicate scaffolds out of Path 0 (see detect_subsumed): they
   # would otherwise force a huge negative gap that trims real bases.
-  sub_reason <- detect_subsumed(inc)
+  sub_reason <- detect_subsumed(inc, ref_len = ref_len)
   subsumed <- !is.na(sub_reason)
   if (any(subsumed)) {
     exc <- rbind(exc, inc[subsumed, , drop = FALSE])
@@ -550,25 +651,22 @@ derive_scaffold_layout <- function(mappings, ref_len = NA_integer_, circular = F
   # a ballooned extent spanning nearly the whole reference; its ref_end is then not
   # a real right boundary, and deriving the next scaffold's gap from it manufactures
   # a genome-scale negative gap that over-trims (or drops) a real scaffold. Skip
-  # such a predecessor's junction. Gate on LOW density so a genuine dense
-  # full-length contig is not misread as a wrap (a real ballooned wrap unions
-  # disjoint blocks and so is sparse: nmatch/span < min_density).
+  # such a predecessor's junction. See ballooned_extent() for why the sparseness
+  # test is relative to the cohort rather than an absolute density floor.
   #
   # Use 0 rather than NA for the skipped junction. NA means "unknown", which
   # switches join_scaffolds' do_probe off and fabricates a blind N spacer over
   # what is usually a real overlap; 0 keeps the probe on, so refine_overlap can
   # still confirm and merge the overlap, and degrades to a butt join if it cannot.
-  wrap_thresh <- if (is.finite(ref_len) && ref_len > 0) 0.9 * ref_len else Inf
-  min_density <- 0.5
+  inc_span <- inc$ref_end - inc$ref_start
+  inc_density <- ifelse(is.na(inc$nmatch) | is.na(inc_span) | inc_span <= 0,
+                        NA_real_, inc$nmatch / inc_span)
+  inc_ballooned <- ballooned_extent(inc_span, inc_density, ref_len, inc$ref_end)
   gap_before <- rep(NA_real_, nrow(inc))
   if (nrow(inc) >= 2) {
     for (i in 2:nrow(inc)) {
-      prev_span <- inc$ref_end[i - 1] - inc$ref_start[i - 1]
-      prev_density <- if (!is.na(prev_span) && prev_span > 0)
-        inc$nmatch[i - 1] / prev_span else NA_real_
-      ballooned <- !is.na(prev_span) && prev_span >= wrap_thresh &&
-        !is.na(prev_density) && prev_density < min_density
-      gap_before[i] <- if (ballooned) 0 else inc$ref_start[i] - inc$ref_end[i - 1]
+      gap_before[i] <- if (isTRUE(inc_ballooned[i - 1])) 0 else
+        inc$ref_start[i] - inc$ref_end[i - 1]
     }
   }
 
@@ -593,6 +691,9 @@ derive_scaffold_layout <- function(mappings, ref_len = NA_integer_, circular = F
     ref_start = c(inc$ref_start, exc$ref_start),
     ref_end = c(inc$ref_end, exc$ref_end),
     qstart = c(qstart_col$inc, qstart_col$exc),
+    # Carried so the mapping plot can tell a dense placement from a union extent
+    # stitched across blocks.
+    nmatch = c(inc$nmatch, exc$nmatch),
     stringsAsFactors = FALSE
   )
   lay$rc[is.na(lay$rc)] <- FALSE
@@ -600,7 +701,7 @@ derive_scaffold_layout <- function(mappings, ref_len = NA_integer_, circular = F
   # scaffold lands where it belongs rather than at the end. Unplaced rows sort last.
   lay$order <- rank(ifelse(is.na(lay$ref_start), Inf, lay$ref_start), ties.method = "first")
   lay[, c("scaffold", "order", "rc", "gap_before", "mapped", "include",
-          "exclude_reason", "qcov", "ref_start", "ref_end", "qstart")]
+          "exclude_reason", "qcov", "ref_start", "ref_end", "qstart", "nmatch")]
 }
 
 #' Reverse-complement a DNA string
@@ -790,6 +891,11 @@ join_scaffolds <- function(scaffold_seqs, layout, gap_len_default = 100L,
   prev_oriented <- NULL
   prev_scaf <- NULL
   prev_depth <- NULL
+  # Layout index of the last scaffold actually written. Not always i-1: a scaffold
+  # fully consumed by overlap trimming is dropped below, and its precomputed
+  # gap_before must not be used to place the next one.
+  prev_idx <- NA_integer_
+  have_ref <- all(c("ref_start", "ref_end") %in% names(layout))
 
   for (i in seq_len(nrow(layout))) {
     s <- layout$scaffold[i]
@@ -799,8 +905,19 @@ join_scaffolds <- function(scaffold_seqs, layout, gap_len_default = 100L,
 
     trim <- 0L
     consensus <- NULL
-    if (i > 1) {
+    # Gate on a surviving predecessor, not on i > 1: with the first scaffold
+    # dropped there is nothing to junction against.
+    if (!is.na(prev_idx)) {
       gb <- layout$gap_before[i]
+      # gap_before was precomputed against layout row i-1. When that row was
+      # dropped at runtime, re-measure against the scaffold actually present.
+      # Only on a drop: the precomputed value carries the ballooned-predecessor
+      # override (0, not the raw reference difference), which a blanket
+      # recompute would undo.
+      if (have_ref && prev_idx != (i - 1L) &&
+          !is.na(layout$ref_start[i]) && !is.na(layout$ref_end[prev_idx])) {
+        gb <- layout$ref_start[i] - layout$ref_end[prev_idx]
+      }
       # Structured junction descriptor (type + measured overlap quality), kept
       # alongside the prose `junctions` for the join-quality summary.
       jtype <- NA_character_; j_ov_len <- 0L; j_ident <- NA_real_
@@ -916,6 +1033,7 @@ join_scaffolds <- function(scaffold_seqs, layout, gap_len_default = 100L,
     src_pos <- c(src_pos, trim + seq_len(n))
     prev_oriented <- seq
     prev_scaf <- s
+    prev_idx <- i
     prev_depth <- if (is.null(dep)) NULL else if (trim > 0) dep[-(seq_len(trim))] else dep
   }
 
@@ -1370,9 +1488,19 @@ plot_scaffold_mapping <- function(layout, ref_len, scaffold_len = NULL) {
   unplaced <- layout[inc & is.na(layout$ref_start), , drop = FALSE]
   ref_len <- max(ref_len, 1, shown$ref_end, na.rm = TRUE)
 
+  # A bar spans the UNION extent of a scaffold's alignment blocks, so a sparse
+  # placement is drawn solid over reference it does not actually cover - which is
+  # what makes the base-pair zoom look like it disagrees with this plot. Hatch
+  # those bars instead of filling them. Sparseness is judged relative to the
+  # cohort, since match density falls with reference divergence.
+  bar_span <- pmax(shown$ref_end - shown$ref_start, 1)
+  bar_density <- if (!is.null(shown$nmatch)) shown$nmatch / bar_span else rep(NA_real_, nrow(shown))
+  med_density <- suppressWarnings(stats::median(bar_density[is.finite(bar_density)]))
+  sparse <- is.finite(bar_density) & is.finite(med_density) & bar_density < 0.5 * med_density
+
   # Extra top margin reserves a line per note so they never collide with the
   # x-axis title at the bottom.
-  n_notes <- (nrow(excluded) > 0) + (nrow(unplaced) > 0)
+  n_notes <- (nrow(excluded) > 0) + (nrow(unplaced) > 0) + any(sparse)
   top_mar <- if (n_notes > 0) 2.5 + 1.5 * n_notes else 2.5
   op <- graphics::par(mar = c(4.5, 1, top_mar, 1))
   on.exit(graphics::par(op), add = TRUE)
@@ -1387,7 +1515,12 @@ plot_scaffold_mapping <- function(layout, ref_len, scaffold_len = NULL) {
     rc <- isTRUE(shown$rc[i])
     col <- if (rc) "#d9534f" else "#4a90d9"
     x0 <- shown$ref_start[i]; x1 <- shown$ref_end[i]
-    graphics::rect(x0, y - 0.25, x1, y + 0.25, col = col, border = "black")
+    if (isTRUE(sparse[i])) {
+      graphics::rect(x0, y - 0.25, x1, y + 0.25, col = col, border = "black",
+                     density = 12, angle = 45)
+    } else {
+      graphics::rect(x0, y - 0.25, x1, y + 0.25, col = col, border = "black")
+    }
     # orientation arrow along the block
     ax <- if (rc) c(x1, x0) else c(x0, x1)
     graphics::arrows(ax[1], y, ax[2], y, length = 0.08, col = "white", lwd = 2)
@@ -1398,23 +1531,28 @@ plot_scaffold_mapping <- function(layout, ref_len, scaffold_len = NULL) {
     }
     graphics::text(mean(c(x0, x1)), y + 0.38, labels = lab, cex = 0.8)
   }
+  # Notes stack upward from just under the title, away from the x-axis labels.
+  note_line <- 0.3
+  add_note <- function(txt, col) {
+    graphics::mtext(txt, side = 3, line = note_line, col = col, cex = 0.85)
+    note_line <<- note_line + 1.2
+  }
   if (nrow(excluded) > 0) {
-    # Place under the title (top), away from the x-axis labels.
     lab <- if (!is.null(excluded$exclude_reason)) {
       paste(mapply(function(s, r) if (is.na(r)) s else paste0(s, " (", r, ")"),
                    excluded$scaffold, excluded$exclude_reason), collapse = ", ")
     } else {
       paste(excluded$scaffold, collapse = ", ")
     }
-    graphics::mtext(paste("Excluded from Path 0:", lab),
-                    side = 3, line = 0.3, col = "#d9534f", cex = 0.85)
+    add_note(paste("Excluded from Path 0:", lab), "#d9534f")
   }
   if (nrow(unplaced) > 0) {
-    graphics::mtext(
-      paste("Included but unplaced (appended with N gap):",
-            paste(unplaced$scaffold, collapse = ", ")),
-      side = 3, line = if (nrow(excluded) > 0) 1.5 else 0.3,
-      col = "#e08a00", cex = 0.85)
+    add_note(paste("Included but unplaced (appended with N gap):",
+                   paste(unplaced$scaffold, collapse = ", ")), "#e08a00")
+  }
+  if (any(sparse)) {
+    add_note(paste("Hatched = sparse alignment; the bar is the union extent of",
+                   "several blocks, not continuous coverage"), "#777777")
   }
   invisible(NULL)
 }
@@ -1545,6 +1683,11 @@ plot_scaffold_zoom <- function(ref_seq, base_maps, scaffold_ids, win_start, win_
       if (any(mm)) cell(which(mm), y, NA, border = "#C0392B", lwd = 1.6)
       graphics::text(idx, y, sc[idx], col = "#222222", cex = 1.15,
                      font = 2, family = "mono")
+    } else {
+      # An empty row otherwise reads as missing data. Say which it is: the
+      # scaffold has no alignment the aligner would stand behind here.
+      graphics::text(mean(x), y, "(no alignment in this window)",
+                     col = "#999999", cex = 0.8)
     }
     graphics::mtext(paste("scaffold", s), side = 2, at = y, las = 1,
                     line = 0.4, cex = 0.8)

--- a/inst/config.NMNH_Hydra
+++ b/inst/config.NMNH_Hydra
@@ -66,7 +66,10 @@ params {
     }
     scaffold_join {
         cpus = 1
-        clusterOptions = "-l mres=16G,h_data=16G,h_vmem=16G,himem -S /bin/bash"
+        memory = 32
+        // Closure so the reservation grows with the retry attempt; a job killed
+        // for exceeding memory (exit 137-140) then succeeds on retry.
+        clusterOptions = { attempt -> "-l mres=${32 * attempt}G,h_data=${32 * attempt}G,h_vmem=${32 * attempt}G,himem -S /bin/bash" }
         container = process.container
         executor = process.executor
     }

--- a/inst/config.NOAA_SEDNA
+++ b/inst/config.NOAA_SEDNA
@@ -57,7 +57,7 @@ params {
     }
     scaffold_join {
         cpus = 1
-        memory = 4
+        memory = 8
         container = process.container
         executor = process.executor
     }

--- a/inst/config.awsbatch
+++ b/inst/config.awsbatch
@@ -64,7 +64,7 @@ params {
     }
     scaffold_join {
         cpus = 1
-        memory = 4
+        memory = 8
         container = process.container
         executor = process.executor
     }

--- a/inst/config.local
+++ b/inst/config.local
@@ -50,7 +50,7 @@ params {
     }
     scaffold_join {
         cpus = 1
-        memory = 4
+        memory = 8
         container = process.container
         executor = process.executor
     }

--- a/inst/config.lsf
+++ b/inst/config.lsf
@@ -58,7 +58,7 @@ params {
     }
     scaffold_join {
         cpus = 1
-        memory = 4
+        memory = 8
         clusterOptions = '<<CLUSTER_OPTIONS>>'
         container = process.container
         executor = process.executor

--- a/inst/config.pbs
+++ b/inst/config.pbs
@@ -58,7 +58,7 @@ params {
     }
     scaffold_join {
         cpus = 1
-        memory = 4
+        memory = 8
         clusterOptions = '<<CLUSTER_OPTIONS>>'
         container = process.container
         executor = process.executor

--- a/inst/config.sge
+++ b/inst/config.sge
@@ -59,7 +59,7 @@ params {
     }
     scaffold_join {
         cpus = 1
-        memory = 4
+        memory = 8
         clusterOptions = '<<CLUSTER_OPTIONS>>'
         container = process.container
         executor = process.executor

--- a/inst/config.slurm
+++ b/inst/config.slurm
@@ -58,7 +58,7 @@ params {
     }
     scaffold_join {
         cpus = 1
-        memory = 4
+        memory = 8
         clusterOptions = '<<CLUSTER_OPTIONS>>'
         container = process.container
         executor = process.executor

--- a/inst/nextflow/modules/coverage.nf
+++ b/inst/nextflow/modules/coverage.nf
@@ -7,7 +7,8 @@ process coverage {
     errorStrategy 'ignore'
     
     cpus {params.coverage.cpus}
-    memory = params.coverage.memory ?: null
+    // GB from config; a bare number would be read as BYTES.
+    memory { (params.coverage.memory instanceof Number) ? params.coverage.memory.GB * task.attempt : null }
     clusterOptions {
         def opts = [
             (params.coverage.executor == 'sge') ? '-S /bin/bash' : '',

--- a/inst/nextflow/modules/coverage_userAsmb.nf
+++ b/inst/nextflow/modules/coverage_userAsmb.nf
@@ -6,7 +6,8 @@ process coverage_userAsmb {
 
     errorStrategy 'ignore'
     cpus {params.coverage.cpus}
-    memory = params.coverage.memory ?: null
+    // GB from config; a bare number would be read as BYTES.
+    memory { (params.coverage.memory instanceof Number) ? params.coverage.memory.GB * task.attempt : null }
     clusterOptions {
         def opts = [
             (params.coverage.executor == 'sge') ? '-S /bin/bash' : '',
@@ -60,7 +61,8 @@ process coverage_userAsmb_noReads {
 
     errorStrategy 'ignore'
     cpus {params.coverage.cpus}
-    memory = params.coverage.memory ?: null
+    // GB from config; a bare number would be read as BYTES.
+    memory { (params.coverage.memory instanceof Number) ? params.coverage.memory.GB * task.attempt : null }
     clusterOptions {
         def opts = [
             (params.coverage.executor == 'sge') ? '-S /bin/bash' : '',

--- a/inst/nextflow/modules/scaffold_join.nf
+++ b/inst/nextflow/modules/scaffold_join.nf
@@ -5,11 +5,19 @@ process scaffold_join {
     executor params.scaffold_join.executor
     container params.scaffold_join.container
     cpus { params.scaffold_join.cpus }
-    memory = params.scaffold_join.memory ?: null
+    // Config memory is a plain number of GB. A bare number is BYTES to Nextflow,
+    // so it must be converted; scaling by task.attempt lets a scheduler memory
+    // kill (SGE exit 137-140) self-heal on retry instead of dying identically.
+    memory { (params.scaffold_join.memory instanceof Number) ? params.scaffold_join.memory.GB * task.attempt : null }
     clusterOptions {
+        // A Closure lets a site config scale its own reservation with the retry
+        // attempt (schedulers like SGE take memory from clusterOptions, not from
+        // the memory directive).
+        def co = params.scaffold_join.clusterOptions
+        def co_str = (co instanceof Closure) ? co.call(task.attempt) : ((co instanceof String) ? co : '')
         def opts = [
             (params.scaffold_join.executor == 'sge') ? '-S /bin/bash' : '',
-            (params.scaffold_join.clusterOptions instanceof String) ? params.scaffold_join.clusterOptions : ''
+            co_str
         ].findAll { it }.join(' ')
         opts ?: null
     }

--- a/tests/testthat/test-blast-ref-alignment-orientation.R
+++ b/tests/testthat/test-blast-ref-alignment-orientation.R
@@ -1,0 +1,84 @@
+test_that("a forward alignment passes through untouched", {
+  aln <- data.frame(
+    aligned_sample = "ACGTACGT", aligned_ref = "ACGTACGT",
+    rotation = 0L, ref_length = 8L, ref_start = 0L, strand = "+",
+    stringsAsFactors = FALSE
+  )
+  out <- normalize_blast_ref_alignment(aln)
+  expect_equal(out$aligned_sample, aln$aligned_sample)
+  expect_equal(out$aligned_ref, aln$aligned_ref)
+  expect_equal(out$strand, "+")
+  expect_false(out$ref_rc)
+})
+
+test_that("a reverse alignment is flipped into the sample's orientation", {
+  # compute_blast_ref_alignment() stores the sample reverse-complemented when that
+  # strand scored higher, which mirrors the synteny plot against the coverage map.
+  # Normalising puts the sample back in its stored frame and moves the flip to the
+  # reference.
+  sample_stored <- "AAACCCGGGTTT"
+  ref           <- "AAACCCGGGTTA"
+  aln <- data.frame(
+    aligned_sample = as.character(
+      Biostrings::reverseComplement(Biostrings::DNAString(sample_stored))),
+    aligned_ref = ref,
+    rotation = 0L, ref_length = nchar(ref), ref_start = 0L, strand = "-",
+    stringsAsFactors = FALSE
+  )
+  out <- normalize_blast_ref_alignment(aln)
+  expect_equal(out$aligned_sample, sample_stored)
+  expect_equal(out$aligned_ref,
+               as.character(Biostrings::reverseComplement(Biostrings::DNAString(ref))))
+  expect_equal(out$strand, "+")
+  expect_true(out$ref_rc)
+})
+
+test_that("gap columns survive the flip and stay paired", {
+  s <- "AC-GTTGCA"
+  r <- "ACGGT-GCA"
+  aln <- data.frame(
+    aligned_sample = s, aligned_ref = r, rotation = 0L,
+    ref_length = 8L, ref_start = 0L, strand = "-", stringsAsFactors = FALSE
+  )
+  out <- normalize_blast_ref_alignment(aln)
+  # Same number of columns, so every position still pairs with its partner.
+  expect_equal(nchar(out$aligned_sample), nchar(s))
+  expect_equal(nchar(out$aligned_ref), nchar(r))
+  # Gaps are complemented to themselves, and land at the mirrored column.
+  expect_equal(gregexpr("-", out$aligned_sample)[[1]][1],
+               nchar(s) - gregexpr("-", s)[[1]][1] + 1L)
+  expect_equal(gregexpr("-", out$aligned_ref)[[1]][1],
+               nchar(r) - gregexpr("-", r)[[1]][1] + 1L)
+})
+
+test_that("normalisation tolerates empty and malformed input", {
+  expect_null(normalize_blast_ref_alignment(NULL))
+  empty <- data.frame(aligned_sample = character(), aligned_ref = character(),
+                      strand = character(), stringsAsFactors = FALSE)
+  expect_equal(nrow(normalize_blast_ref_alignment(empty)), 0L)
+  # No strand column (pre-v2 aligner output): flagged not-flipped, left alone.
+  old <- data.frame(aligned_sample = "ACGT", aligned_ref = "ACGT",
+                    stringsAsFactors = FALSE)
+  out <- normalize_blast_ref_alignment(old)
+  expect_false(out$ref_rc)
+  expect_equal(out$aligned_sample, "ACGT")
+})
+
+test_that("split_wrapped_genes labels both arcs of an origin-wrapping feature", {
+  df <- data.frame(
+    gene = "cox1", xmin = 90, xmax = 10, direction = "+",
+    stringsAsFactors = FALSE
+  )
+  out <- split_wrapped_genes(df, x_lo = 0, x_hi = 100)
+  expect_equal(nrow(out), 2L)
+  # Both pieces carry the name: on a linearised layout the two arcs sit at
+  # opposite edges, so labelling only the longer one orphans the other.
+  expect_true(all(nzchar(out$gene)))
+  expect_equal(sort(c(out$xmin, out$xmax)), c(0, 10, 90, 100))
+})
+
+test_that("split_wrapped_genes leaves non-wrapping features alone", {
+  df <- data.frame(gene = c("cox1", "nad2"), xmin = c(10, 40), xmax = c(30, 60),
+                   direction = c("+", "-"), stringsAsFactors = FALSE)
+  expect_identical(split_wrapped_genes(df, x_lo = 0, x_hi = 100), df)
+})

--- a/tests/testthat/test-scaffold_join.R
+++ b/tests/testthat/test-scaffold_join.R
@@ -543,3 +543,250 @@ test_that("join_scaffolds keeps src_pos aligned after a partial overlap trim", {
   expect_false(any(is.na(res$src_pos)))
   expect_true(all(res$src_pos >= 1))
 })
+
+
+# =============================================================================
+# Adversarial-audit batch fixes (F3, F11, F12, F13, F15, F16, F17, F18, F24)
+# =============================================================================
+
+# --- F12 ---
+test_that("collapse_scaffold_blocks does not balloon an origin-wrap extent", {
+  rows <- data.frame(
+    scaffold = c("s", "s"),
+    qlen = c(8000L, 8000L),
+    qstart = c(0L, 4000L),
+    qend = c(4000L, 8000L),
+    strand = c("+", "+"),
+    ref_start = c(12000L, 0L),
+    ref_end = c(16000L, 4000L),
+    nmatch = c(3900L, 3800L),
+    cigar = NA_character_,
+    stringsAsFactors = FALSE
+  )
+  out <- collapse_scaffold_blocks(rows)
+  # Anchor block [12000,16000] kept; off-diagonal wrap block [0,4000] dropped.
+  expect_equal(out$ref_start, 12000)
+  expect_equal(out$ref_end, 16000)
+  expect_true(out$ref_end - out$ref_start <= 4000)
+})
+
+# --- F13 ---
+test_that("collapse_scaffold_blocks qcov uses dominant-strand blocks only", {
+  rows <- data.frame(
+    scaffold = c("s", "s"),
+    qlen = c(9000L, 9000L),
+    qstart = c(0L, 5000L),
+    qend = c(5000L, 9000L),
+    strand = c("+", "-"),
+    ref_start = c(0L, 8000L),
+    ref_end = c(5000L, 12000L),
+    nmatch = c(4000L, 3000L),
+    cigar = NA_character_,
+    stringsAsFactors = FALSE
+  )
+  out <- collapse_scaffold_blocks(rows)
+  expect_equal(out$strand, "+")
+  # dominant-only coverage 5000/9000, not the both-strand union 1.0
+  expect_lt(out$qcov, 0.99)
+  expect_equal(out$qcov, 5000 / 9000, tolerance = 1e-6)
+})
+
+# --- F11 ---
+test_that("refine_overlap confirms a large overlap beyond the est window", {
+  skip_if_not_installed("pwalign")
+  set.seed(1)
+  bp <- function(n) paste0(sample(c("A", "C", "G", "T"), n, replace = TRUE), collapse = "")
+  x <- bp(800)
+  a <- paste0(bp(1200), x)
+  b <- paste0(x, bp(1500))
+  ov <- refine_overlap(a, b, est_overlap = 300, min_identity = 0.9, min_overlap = 20L)
+  expect_true(ov$reliable)
+  expect_equal(ov$trim_b, 800)
+})
+
+# --- F11 ---
+test_that("refine_overlap rejects a low-complexity (homopolymer) seam", {
+  skip_if_not_installed("pwalign")
+  set.seed(2)
+  bp <- function(n) paste0(sample(c("A", "C", "G", "T"), n, replace = TRUE), collapse = "")
+  a <- paste0(bp(1000), strrep("A", 30))
+  b <- paste0(strrep("A", 40), bp(1000))
+  ov <- refine_overlap(a, b, est_overlap = 300, min_identity = 0.9, min_overlap = 20L)
+  expect_false(ov$reliable)
+})
+
+# --- F16 ---
+test_that("parse_cov_string strips '#' mask prefix and preserves position count", {
+  # F16: masked positions keep their value instead of becoming NA
+  expect_equal(parse_cov_string("250 #300 275 #280 260"), c(250, 300, 275, 280, 260))
+  # F15: empty cells map to NA and the count is preserved when n is supplied
+  raw <- "  0.4 0.5 0.6  "   # 7 positions: 2 leading NA, 3 values, 2 trailing NA
+  expect_equal(parse_cov_string(raw, n = 7), c(NA, NA, 0.4, 0.5, 0.6, NA, NA))
+  # strsplit drops the single final trailing empty when n is absent (documented)
+  expect_length(parse_cov_string(raw), 6)
+  # existing behavior preserved
+  expect_equal(parse_cov_string("1 2 3"), c(1, 2, 3))
+  expect_length(parse_cov_string(NA), 0)
+  expect_length(parse_cov_string(""), 0)
+})
+
+# --- F15 ---
+test_that("assemble_from_layout pads short GC/error tracks to sequence length", {
+  seq <- "ACGTACGTAC"                       # 10 bp; too short to self-circularize
+  df <- data.frame(
+    scaffold = "1", sequence = seq,
+    depth = paste(rep(5, 10), collapse = " "),
+    # GC with 2 leading + 2 trailing empty cells (rollapply NA ends), 10 positions
+    gc = "  0.4 0.5 0.6 0.5 0.4 0.5  ",
+    errors = paste(rep(0, 10), collapse = " "),
+    stringsAsFactors = FALSE)
+  lay <- data.frame(scaffold = "1", order = 1L, rc = FALSE,
+                    gap_before = NA_real_, mapped = TRUE, include = TRUE,
+                    stringsAsFactors = FALSE)
+  res <- assemble_from_layout(df, lay, gap_len = 100L, circular = FALSE, ref_seq = NULL)
+  expect_equal(length(res$gc), nchar(res$seq))
+  expect_equal(length(res$errors), nchar(res$seq))
+  expect_equal(length(res$depth), nchar(res$seq))
+})
+
+# --- F24 ---
+test_that("load_scaffold_mappings coerces numeric columns despite empty-string unmapped rows", {
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con))
+  DBI::dbExecute(con, "CREATE TABLE scaffold_mappings (
+    ID TEXT, ref_accession TEXT, scaffold INTEGER, ref_start INTEGER, ref_end INTEGER,
+    strand TEXT, nmatch INTEGER, qcov REAL, qstart INTEGER, mapped INTEGER)")
+  # Unmapped scaffold stored FIRST with empty strings: SQLite then returns the
+  # ref_start/ref_end columns as character without coercion.
+  DBI::dbExecute(con, "INSERT INTO scaffold_mappings VALUES
+    ('s1','NC_1',3,'','','','','','',0),
+    ('s1','NC_1',1,1,500,'+',480,0.96,0,1),
+    ('s1','NC_1',2,600,900,'-',280,0.9,0,1)")
+  m <- load_scaffold_mappings(con, "s1", "NC_1")
+  expect_type(m$ref_start, "integer")
+  expect_type(m$ref_end, "integer")
+  expect_type(m$qcov, "double")
+  # derive_scaffold_layout must not throw on the (previously character) columns
+  expect_silent(derive_scaffold_layout(m, ref_len = 1000, circular = FALSE))
+})
+
+# --- F3 ---
+test_that("derive_scaffold_layout does not derive a negative gap from an origin-wrapping predecessor", {
+  ref_len <- 16000L
+  mappings <- data.frame(
+    scaffold = c("wrap", "b"),
+    ref_start = c(0L, 4000L),
+    ref_end = c(16000L, 9000L),
+    strand = c("+", "+"),
+    nmatch = c(3000L, 4500L),   # wrap density 3000/16000 < 0.5 -> not a container
+    qcov = c(1, 1),
+    qstart = c(0L, 0L),
+    mapped = c(TRUE, TRUE),
+    stringsAsFactors = FALSE
+  )
+  lay <- derive_scaffold_layout(mappings, ref_len = ref_len, circular = TRUE,
+                                min_qcov = 0.5)
+  inc <- lay[lay$include, , drop = FALSE]
+  inc <- inc[order(inc$order), , drop = FALSE]
+  expect_equal(nrow(inc), 2L)                 # neither dropped/subsumed
+  gb_b <- inc$gap_before[inc$scaffold == "b"]
+  expect_true(is.na(gb_b))                    # ballooned predecessor -> unknown junction, no over-trim
+})
+
+# --- F3 ---
+test_that("derive_scaffold_layout keeps a real gap after a dense full-length predecessor", {
+  ref_len <- 16000L
+  mappings <- data.frame(
+    scaffold = c("a", "b"),
+    ref_start = c(0L, 15000L),
+    ref_end = c(14500L, 15800L),   # a spans >= 0.9*ref_len but is disjoint from b
+    strand = c("+", "+"),
+    nmatch = c(10000L, 700L),      # a density 10000/14500 = 0.69 >= 0.5 -> not a wrap
+    qcov = c(1, 1),
+    qstart = c(0L, 0L),
+    mapped = c(TRUE, TRUE),
+    stringsAsFactors = FALSE
+  )
+  lay <- derive_scaffold_layout(mappings, ref_len = ref_len, circular = FALSE,
+                                min_qcov = 0.5)
+  inc <- lay[lay$include, , drop = FALSE]
+  inc <- inc[order(inc$order), , drop = FALSE]
+  expect_equal(nrow(inc), 2L)                 # dense predecessor does not subsume b
+  gb_b <- inc$gap_before[inc$scaffold == "b"]
+  expect_equal(gb_b, 500)                     # 15000 - 14500, density guard not tripped
+})
+
+# --- F11 ---
+test_that("refine_overlap rejects a repeat buried inside A's tail (not at its 3' end)", {
+  skip_if_not_installed("pwalign")
+  set.seed(11)
+  bp <- function(n) paste0(sample(c("A", "C", "G", "T"), n, replace = TRUE), collapse = "")
+  p <- bp(100)                       # b's prefix; a carries an internal copy of it
+  a <- paste0(bp(500), p, bp(200))   # p is buried, then 200 bp of distinct 3' end
+  b <- paste0(p, bp(800))
+  ov <- refine_overlap(a, b, est_overlap = 50, min_identity = 0.9, min_overlap = 20L)
+  expect_false(ov$reliable)          # internal repeat must not confirm a junction
+  expect_equal(ov$trim_b, 0L)
+})
+
+# --- F17 ---
+test_that("assemble_from_layout circularizes on the app path only when circular is asserted", {
+  skip_if_not_installed("pwalign")
+  set.seed(170)
+  bp <- function(n) paste0(sample(c("A", "C", "G", "T"), n, replace = TRUE), collapse = "")
+  ov <- bp(60); core <- bp(300)
+  seq <- paste0(ov, core, ov)        # 420 bp with a 60 bp redundant end overlap
+  n <- nchar(seq)
+  df <- data.frame(scaffold = "1", sequence = seq,
+    depth = paste(rep(5, n), collapse = " "),
+    gc = paste(rep(0.4, n), collapse = " "),
+    errors = paste(rep(0, n), collapse = " "),
+    stringsAsFactors = FALSE)
+  lay <- data.frame(scaffold = "1", order = 1L, rc = FALSE, gap_before = NA_real_,
+                    mapped = TRUE, include = TRUE, stringsAsFactors = FALSE)
+  # App path: no reference, circular unchecked -> left linear, no end trim.
+  lin <- assemble_from_layout(df, lay, gap_len = 100L, circular = FALSE, ref_seq = NULL)
+  expect_equal(lin$topology, "linear")
+  expect_equal(nchar(lin$seq), n)
+  # Same input, Circular checked -> redundant overlap trimmed, marked circular.
+  cir <- assemble_from_layout(df, lay, gap_len = 100L, circular = TRUE, ref_seq = NULL)
+  expect_equal(cir$topology, "circular")
+  expect_equal(nchar(cir$seq), n - 60L)
+})
+
+# --- F17 ---
+test_that("circularize_sequence with raised min_overlap ignores a short spurious end match", {
+  set.seed(17)
+  core <- paste(sample(c("A", "C", "G", "T"), 400L, replace = TRUE), collapse = "")
+  motif <- paste(rep("AT", 15L), collapse = "")   # 30 bp AT-rich, < 50
+  seq <- paste0(motif, core, motif)
+  n <- nchar(seq); cov <- rep(1, n)
+  cz <- circularize_sequence(seq, cov, cov, cov, min_overlap = 50L)
+  expect_false(cz$circular)
+  expect_equal(nchar(cz$seq), n)                  # no real 3' bases trimmed
+})
+
+# --- F18 ---
+test_that("rotate_to_reference skips rotation when no block covers the reference origin", {
+  seq <- paste(rep("ACGT", 500L), collapse = "")   # 2000 bp
+  n <- nchar(seq); cov <- seq_len(n)
+  far_block <- data.frame(scaffold = "joined", qlen = n, qstart = 800L, qend = 1200L,
+    strand = "+", ref_start = 3000L, ref_end = 3400L, nmatch = 400L,
+    cigar = NA_character_, stringsAsFactors = FALSE)
+  testthat::local_mocked_bindings(run_minimap2_paf = function(...) far_block)
+  rt <- rotate_to_reference(seq, cov, cov, cov, ref_seq = seq)
+  expect_equal(rt$rotated, 0L)                     # min ref_start 3000 > tol -> no rotation
+  expect_identical(rt$seq, seq)
+})
+
+test_that("rotate_to_reference rotates to the block covering reference position 0", {
+  seq <- paste(rep("ACGT", 500L), collapse = "")
+  n <- nchar(seq); cov <- seq_len(n)
+  origin_block <- data.frame(scaffold = "joined", qlen = n, qstart = 120L, qend = 500L,
+    strand = "+", ref_start = 0L, ref_end = 380L, nmatch = 380L,
+    cigar = NA_character_, stringsAsFactors = FALSE)
+  testthat::local_mocked_bindings(run_minimap2_paf = function(...) origin_block)
+  rt <- rotate_to_reference(seq, cov, cov, cov, ref_seq = seq)
+  expect_equal(rt$rotated, 120L)                   # qstart of the origin-covering block
+})
+

--- a/tests/testthat/test-scaffold_join.R
+++ b/tests/testthat/test-scaffold_join.R
@@ -465,3 +465,81 @@ test_that("load_scaffold_mappings round-trips into derive_scaffold_layout shape"
 
   expect_null(load_scaffold_mappings(con, "s1", "NC_missing"))
 })
+
+test_that("detect_subsumed flags a contained scaffold, keeps the container", {
+  inc <- data.frame(
+    scaffold = c("A", "B"),
+    ref_start = c(0L, 500L), ref_end = c(2000L, 800L),
+    nmatch = c(1800L, 290L), stringsAsFactors = FALSE
+  )
+  r <- detect_subsumed(inc)
+  expect_true(is.na(r[1]))
+  expect_match(r[2], "subsumed by scaffold A")
+})
+
+test_that("detect_subsumed keeps disjoint and partially-overlapping scaffolds", {
+  inc <- data.frame(
+    scaffold = c("A", "B", "C"),
+    ref_start = c(0L, 1800L, 4000L), ref_end = c(2000L, 3000L, 6000L),
+    nmatch = c(1900L, 1100L, 1900L), stringsAsFactors = FALSE
+  )
+  expect_true(all(is.na(detect_subsumed(inc))))
+})
+
+test_that("detect_subsumed density guard: a sparse ballooned extent cannot subsume", {
+  # A spans the whole reference but matches almost nothing (origin-spanning /
+  # repeat artifact); it must not swallow the well-matched B.
+  inc <- data.frame(
+    scaffold = c("A", "B"),
+    ref_start = c(0L, 500L), ref_end = c(10000L, 800L),
+    nmatch = c(200L, 290L), stringsAsFactors = FALSE
+  )
+  expect_true(all(is.na(detect_subsumed(inc))))
+})
+
+test_that("derive_scaffold_layout excludes subsumed scaffold and recomputes gap across it", {
+  mappings <- data.frame(
+    scaffold = c("A", "B", "C"),
+    ref_start = c(0L, 500L, 2100L), ref_end = c(2000L, 800L, 4000L),
+    strand = c("+", "+", "+"), nmatch = c(1800L, 290L, 1850L),
+    qcov = c(0.95, 0.95, 0.95), qstart = c(0L, 0L, 0L),
+    mapped = c(TRUE, TRUE, TRUE), stringsAsFactors = FALSE
+  )
+  lay <- derive_scaffold_layout(mappings, min_qcov = 0.5)
+  expect_false(lay$include[lay$scaffold == "B"])
+  expect_match(lay$exclude_reason[lay$scaffold == "B"], "subsumed by scaffold A")
+  # gap A -> C computed across the removed B (2100 - 2000), not a huge negative
+  expect_equal(lay$gap_before[lay$scaffold == "C"], 100)
+})
+
+test_that("join_scaffolds drops a fully-overlapped scaffold without src_pos corruption", {
+  a <- paste(rep("ACGT", 50), collapse = "")   # 200 bp
+  b <- substring(a, 101)                        # last 100 bp of a (contained)
+  seqs <- list(A = a, B = b)
+  lay <- data.frame(
+    scaffold = c("A", "B"), order = 1:2, rc = c(FALSE, FALSE),
+    gap_before = c(NA, -100), include = c(TRUE, TRUE), stringsAsFactors = FALSE
+  )
+  res <- join_scaffolds(seqs, lay)
+  expect_equal(nchar(res$seq), 200L)                    # B added no new bases
+  expect_equal(length(res$src_pos), nchar(res$seq))     # src_pos stays in lockstep
+  expect_false(any(is.na(res$src_pos)))
+  expect_false(any(res$src_pos < 1))
+  expect_true(any(grepl("dropped as redundant", res$junctions)))
+})
+
+test_that("join_scaffolds keeps src_pos aligned after a partial overlap trim", {
+  # b overlaps a's tail by 40 bp; the trim path must not desync src_pos.
+  a <- paste(rep("ACGTACGTAC", 10), collapse = "")   # 100 bp
+  overlap <- substring(a, 61)                         # a's last 40 bp
+  b <- paste0(overlap, paste(rep("TTTTGGGGCC", 6), collapse = ""))  # 40 + 60
+  seqs <- list(A = a, B = b)
+  lay <- data.frame(
+    scaffold = c("A", "B"), order = 1:2, rc = c(FALSE, FALSE),
+    gap_before = c(NA, -40), include = c(TRUE, TRUE), stringsAsFactors = FALSE
+  )
+  res <- join_scaffolds(seqs, lay)
+  expect_equal(length(res$src_pos), nchar(res$seq))
+  expect_false(any(is.na(res$src_pos)))
+  expect_true(all(res$src_pos >= 1))
+})

--- a/tests/testthat/test-scaffold_join.R
+++ b/tests/testthat/test-scaffold_join.R
@@ -542,6 +542,22 @@ test_that("join_scaffolds keeps src_pos aligned after a partial overlap trim", {
   expect_equal(length(res$src_pos), nchar(res$seq))
   expect_false(any(is.na(res$src_pos)))
   expect_true(all(res$src_pos >= 1))
+  # Assert the MAPPING, not its shape. A src_pos uniformly offset by the trim
+  # amount satisfies every check above, and that offset is exactly the desync
+  # class the trim + seq_len(n) fix exists to prevent.
+  expect_equal(nchar(res$seq), 160L)                       # 100 + (100 - 40)
+  expect_equal(res$src_pos[res$src_scaffold == "A"], 1:100)
+  expect_equal(res$src_pos[res$src_scaffold == "B"], 41:100)
+
+  # Round-trip through stitch_coverage with per-scaffold distinguishable depth:
+  # B's contribution must land on B's positions 41..100, not 1..60.
+  cov <- list(
+    A = list(depth = 1:100,        gc = rep(0, 100), err = rep(0, 100)),
+    B = list(depth = 101:200,      gc = rep(0, 100), err = rep(0, 100))
+  )
+  st <- stitch_coverage(cov, lay, res)
+  expect_equal(length(st$depth), nchar(res$seq))
+  expect_equal(utils::tail(st$depth, 60), 141:200)
 })
 
 
@@ -690,7 +706,9 @@ test_that("derive_scaffold_layout does not derive a negative gap from an origin-
   inc <- inc[order(inc$order), , drop = FALSE]
   expect_equal(nrow(inc), 2L)                 # neither dropped/subsumed
   gb_b <- inc$gap_before[inc$scaffold == "b"]
-  expect_true(is.na(gb_b))                    # ballooned predecessor -> unknown junction, no over-trim
+  # Ballooned predecessor: no genome-scale negative gap, but 0 rather than NA so
+  # join_scaffolds still probes the junction instead of blindly N-padding it.
+  expect_equal(gb_b, 0)
 })
 
 # --- F3 ---
@@ -748,27 +766,96 @@ test_that("assemble_from_layout circularizes on the app path only when circular 
   lin <- assemble_from_layout(df, lay, gap_len = 100L, circular = FALSE, ref_seq = NULL)
   expect_equal(lin$topology, "linear")
   expect_equal(nchar(lin$seq), n)
+  # ...but the duplication must never be SILENT: the detection still runs and the
+  # note has to say the origin region is present twice.
+  expect_match(lin$note, "redundant end overlap detected .* NOT")
   # Same input, Circular checked -> redundant overlap trimmed, marked circular.
   cir <- assemble_from_layout(df, lay, gap_len = 100L, circular = TRUE, ref_seq = NULL)
   expect_equal(cir$topology, "circular")
   expect_equal(nchar(cir$seq), n - 60L)
+  expect_match(cir$note, "circular: trimmed 60 bp")
 })
 
 # --- F17 ---
 test_that("circularize_sequence with raised min_overlap ignores a short spurious end match", {
+  skip_if_not_installed("pwalign")
   set.seed(17)
-  core <- paste(sample(c("A", "C", "G", "T"), 400L, replace = TRUE), collapse = "")
-  motif <- paste(rep("AT", 15L), collapse = "")   # 30 bp AT-rich, < 50
+  bp <- function(n) paste0(sample(c("A", "C", "G", "T"), n, replace = TRUE), collapse = "")
+  # A RANDOM 35 bp terminal repeat, not an AT motif: low_complexity_overlap would
+  # reject an AT motif on its own, which made this test pass identically at
+  # min_overlap 20 and 50 and so proved nothing about min_overlap.
+  motif <- bp(35L)
+  core <- bp(400L)
   seq <- paste0(motif, core, motif)
   n <- nchar(seq); cov <- rep(1, n)
+  expect_false(low_complexity_overlap(motif))     # the guard under test is min_overlap
+  # 35 < 50 -> not circular at the raised threshold...
   cz <- circularize_sequence(seq, cov, cov, cov, min_overlap = 50L)
   expect_false(cz$circular)
   expect_equal(nchar(cz$seq), n)                  # no real 3' bases trimmed
+  # ...but the same 35 bp repeat IS found when the threshold is below it, which is
+  # what makes this a test of min_overlap rather than of the complexity guard.
+  cz20 <- circularize_sequence(seq, cov, cov, cov, min_overlap = 20L)
+  expect_true(cz20$circular)
+  expect_equal(nchar(cz20$seq), n - 35L)
+})
+
+# --- F17 ---
+test_that("assemble_from_layout passes min_overlap through at its call site", {
+  skip_if_not_installed("pwalign")
+  set.seed(171)
+  bp <- function(n) paste0(sample(c("A", "C", "G", "T"), n, replace = TRUE), collapse = "")
+  # 35 bp terminal repeat: below assemble_from_layout's hardcoded min_overlap = 50,
+  # so the call site must NOT circularize it. Testing circularize_sequence directly
+  # cannot catch a wrong (or missing) value at the call site.
+  motif <- bp(35L); seq <- paste0(motif, bp(400L), motif)
+  n <- nchar(seq)
+  df <- data.frame(scaffold = "1", sequence = seq,
+    depth = paste(rep(5, n), collapse = " "),
+    gc = paste(rep(0.4, n), collapse = " "),
+    errors = paste(rep(0, n), collapse = " "), stringsAsFactors = FALSE)
+  lay <- data.frame(scaffold = "1", order = 1L, rc = FALSE, gap_before = NA_real_,
+                    mapped = TRUE, include = TRUE, stringsAsFactors = FALSE)
+  res <- assemble_from_layout(df, lay, gap_len = 100L, circular = TRUE, ref_seq = NULL)
+  expect_equal(nchar(res$seq), n)
+  expect_false(grepl("trimmed 35 bp", res$note))
+})
+
+# --- F17/F18 ---
+test_that("assemble_from_layout circularizes and rotates on the reference path", {
+  skip_if_not_installed("pwalign")
+  set.seed(172)
+  bp <- function(n) paste0(sample(c("A", "C", "G", "T"), n, replace = TRUE), collapse = "")
+  ov <- bp(60L); core <- bp(400L)
+  seq <- paste0(ov, core, ov)                     # 520 bp, 60 bp redundant end overlap
+  n <- nchar(seq)
+  df <- data.frame(scaffold = "1", sequence = seq,
+    depth = paste(rep(5, n), collapse = " "),
+    gc = paste(rep(0.4, n), collapse = " "),
+    errors = paste(rep(0, n), collapse = " "), stringsAsFactors = FALSE)
+  lay <- data.frame(scaffold = "1", order = 1L, rc = FALSE, gap_before = NA_real_,
+                    mapped = TRUE, include = TRUE, stringsAsFactors = FALSE)
+  # has_ref TRUE: circularizes without the user asserting circular, then rotates.
+  # Every other assemble_from_layout test in this file passes ref_seq = NULL, so
+  # this wiring was previously uncovered.
+  origin_block <- data.frame(scaffold = "joined", qlen = n - 60L, qstart = 100L,
+    qend = 300L, strand = "+", ref_start = 0L, ref_end = 200L, nmatch = 200L,
+    cigar = NA_character_, stringsAsFactors = FALSE)
+  testthat::local_mocked_bindings(run_minimap2_paf = function(...) origin_block)
+  res <- assemble_from_layout(df, lay, gap_len = 100L, circular = FALSE,
+                              ref_seq = paste0(core, ov))
+  expect_equal(res$topology, "circular")
+  expect_equal(nchar(res$seq), n - 60L)
+  expect_match(res$note, "rotated 100 bp to reference origin")
 })
 
 # --- F18 ---
 test_that("rotate_to_reference skips rotation when no block covers the reference origin", {
-  seq <- paste(rep("ACGT", 500L), collapse = "")   # 2000 bp
+  # APERIODIC fixture. A "ACGT" tandem repeat rotated by a multiple of 4 is
+  # indistinguishable from the original, so the sequence assertion below was
+  # vacuous against a period-4 fixture.
+  set.seed(180)
+  seq <- paste(sample(c("A", "C", "G", "T"), 2000L, replace = TRUE), collapse = "")
   n <- nchar(seq); cov <- seq_len(n)
   far_block <- data.frame(scaffold = "joined", qlen = n, qstart = 800L, qend = 1200L,
     strand = "+", ref_start = 3000L, ref_end = 3400L, nmatch = 400L,
@@ -777,10 +864,12 @@ test_that("rotate_to_reference skips rotation when no block covers the reference
   rt <- rotate_to_reference(seq, cov, cov, cov, ref_seq = seq)
   expect_equal(rt$rotated, 0L)                     # min ref_start 3000 > tol -> no rotation
   expect_identical(rt$seq, seq)
+  expect_identical(rt$depth, cov)                  # coverage untouched too
 })
 
 test_that("rotate_to_reference rotates to the block covering reference position 0", {
-  seq <- paste(rep("ACGT", 500L), collapse = "")
+  set.seed(181)
+  seq <- paste(sample(c("A", "C", "G", "T"), 2000L, replace = TRUE), collapse = "")
   n <- nchar(seq); cov <- seq_len(n)
   origin_block <- data.frame(scaffold = "joined", qlen = n, qstart = 120L, qend = 500L,
     strand = "+", ref_start = 0L, ref_end = 380L, nmatch = 380L,
@@ -788,5 +877,200 @@ test_that("rotate_to_reference rotates to the block covering reference position 
   testthat::local_mocked_bindings(run_minimap2_paf = function(...) origin_block)
   rt <- rotate_to_reference(seq, cov, cov, cov, ref_seq = seq)
   expect_equal(rt$rotated, 120L)                   # qstart of the origin-covering block
+  # Assert the actual rotation, and that the coverage vectors rotated with it.
+  expect_equal(rt$seq, paste0(substring(seq, 121L), substring(seq, 1L, 120L)))
+  expect_equal(rt$depth[1], 121L)
+  expect_equal(utils::tail(rt$depth, 1L), 120L)
+  expect_equal(length(rt$depth), n)
 })
 
+
+
+# =============================================================================
+# Post-review fixes (18-finding adversarial review of the batches above)
+# =============================================================================
+
+# --- review #5 ---
+test_that("colinear_chain keeps blocks across a large real indel", {
+  # Two colinear blocks separated by a 3 kb reference-side deletion. The old
+  # fixed diagonal band (max(1000, 0.2*qlen) = 1600 here) discarded the far side,
+  # which then shrank ref_end and fabricated a gap at the next junction.
+  rows <- data.frame(
+    scaffold = c("s", "s"), qlen = c(8000L, 8000L),
+    qstart = c(0L, 4000L), qend = c(4000L, 8000L),
+    strand = c("+", "+"),
+    ref_start = c(0L, 7000L), ref_end = c(4000L, 11000L),  # 3 kb ref-side indel
+    nmatch = c(3900L, 3800L), cigar = NA_character_, stringsAsFactors = FALSE
+  )
+  cc <- collapse_scaffold_blocks(rows)
+  expect_equal(cc$ref_start, 0L)
+  expect_equal(cc$ref_end, 11000L)      # both blocks kept; extent spans the indel
+  expect_equal(cc$nmatch, 7700L)
+})
+
+test_that("colinear_chain still prunes an origin wrap", {
+  # Same two blocks, but the query advances while the reference goes BACKWARDS:
+  # not colinear, so the monotone walk must still drop one side.
+  rows <- data.frame(
+    scaffold = c("s", "s"), qlen = c(8000L, 8000L),
+    qstart = c(0L, 4000L), qend = c(4000L, 8000L),
+    strand = c("+", "+"),
+    ref_start = c(12000L, 0L), ref_end = c(16000L, 4000L),
+    nmatch = c(3900L, 3800L), cigar = NA_character_, stringsAsFactors = FALSE
+  )
+  cc <- collapse_scaffold_blocks(rows)
+  expect_lt(cc$ref_end - cc$ref_start, 8000L)   # not ballooned to the whole reference
+})
+
+# --- review #6 ---
+test_that("qcov is measured over all blocks, not the pruned chain", {
+  # An origin-wrapping scaffold covers its whole query, just not colinearly.
+  # Scoring qcov on the pruned chain halved it and let min_qcov drop a real
+  # scaffold; the placement extent still comes from the pruned chain.
+  rows <- data.frame(
+    scaffold = c("s", "s"), qlen = c(8000L, 8000L),
+    qstart = c(0L, 4000L), qend = c(4000L, 8000L),
+    strand = c("+", "+"),
+    ref_start = c(12000L, 0L), ref_end = c(16000L, 4000L),
+    nmatch = c(3900L, 3800L), cigar = NA_character_, stringsAsFactors = FALSE
+  )
+  cc <- collapse_scaffold_blocks(rows)
+  expect_equal(cc$qcov, 1)
+})
+
+# --- review #7 ---
+test_that("an excluded scaffold keeps its orientation and reference coordinates", {
+  mappings <- data.frame(
+    scaffold = c("A", "B"),
+    ref_start = c(0L, 500L), ref_end = c(3000L, 1000L),
+    strand = c("+", "-"),                     # B is minus-strand and subsumed by A
+    nmatch = c(2900L, 480L),
+    qcov = c(0.95, 0.95), qstart = c(0L, 0L),
+    mapped = c(TRUE, TRUE), stringsAsFactors = FALSE
+  )
+  lay <- derive_scaffold_layout(mappings, min_qcov = 0.5)
+  b <- lay[lay$scaffold == "B", ]
+  expect_false(b$include)
+  expect_true(b$rc)                            # orientation survives exclusion
+  expect_equal(b$ref_start, 500L)              # ...and so do the coordinates
+  expect_equal(b$ref_end, 1000L)
+  # Order is seeded from the reference position, so re-including B in the editor
+  # puts it where it belongs rather than at the end.
+  expect_lt(lay$order[lay$scaffold == "A"], b$order)
+})
+
+# --- review #9 ---
+test_that("detect_subsumed keeps a contained scaffold that carries unaligned sequence", {
+  inc <- data.frame(
+    scaffold = c("A", "B"),
+    ref_start = c(0L, 500L), ref_end = c(3000L, 1000L),
+    nmatch = c(2900L, 480L),
+    qcov = c(0.95, 0.40),      # B's aligned part nests in A, but 60% never aligned
+    stringsAsFactors = FALSE
+  )
+  expect_true(is.na(detect_subsumed(inc)[2]))
+  # ...and it IS dropped once essentially all of it is accounted for.
+  inc$qcov[2] <- 0.98
+  expect_match(detect_subsumed(inc)[2], "subsumed by scaffold A")
+})
+
+# --- review #18 ---
+test_that("detect_subsumed names the largest container", {
+  inc <- data.frame(
+    scaffold = c("small", "mid", "big"),
+    ref_start = c(500L, 400L, 0L), ref_end = c(1000L, 2000L, 6000L),
+    nmatch = c(480L, 1500L, 5500L),
+    qcov = c(0.98, 0.98, 0.98), stringsAsFactors = FALSE
+  )
+  expect_match(detect_subsumed(inc)[1], "subsumed by scaffold big")
+})
+
+# --- review #10 ---
+test_that("collapse_scaffold_blocks flips qstart onto the reverse-complemented sequence", {
+  # The zoom view indexes the ORIENTED (rc'd) scaffold, so a '-' block's
+  # forward-query PAF coordinate has to be converted, or every '-' scaffold with
+  # asymmetric soft-clipping gets a fabricated base map.
+  rows <- data.frame(
+    scaffold = "s", qlen = 1000L, qstart = 100L, qend = 900L, strand = "-",
+    ref_start = 0L, ref_end = 800L, nmatch = 780L,
+    cigar = NA_character_, stringsAsFactors = FALSE
+  )
+  cc <- collapse_scaffold_blocks(rows)
+  expect_equal(cc$qstart, 100L)          # qlen - qend = 1000 - 900
+  # '+' is unchanged
+  rows$strand <- "+"
+  expect_equal(collapse_scaffold_blocks(rows)$qstart, 100L)
+  rows$qend <- 950L
+  rows$strand <- "-"
+  expect_equal(collapse_scaffold_blocks(rows)$qstart, 50L)
+})
+
+# --- review #13 ---
+test_that("refine_overlap rejects an alignment dragged through a divergent tail", {
+  skip_if_not_installed("pwalign")
+  set.seed(131)
+  bp <- function(n) paste0(sample(c("A", "C", "G", "T"), n, replace = TRUE), collapse = "")
+  shared <- bp(120)
+  # A ends with the shared block plus 25 bp that B does not have: a genuine
+  # junction would end in exact identities, this one cannot.
+  a <- paste0(bp(400), shared, bp(25))
+  b <- paste0(shared, bp(600))
+  ov <- refine_overlap(a, b, est_overlap = 120, min_identity = 0.7, min_overlap = 10L)
+  expect_false(ov$reliable)
+  expect_equal(ov$trim_b, 0L)
+  # ...while the same pair with A actually ending at the shared block confirms.
+  a2 <- paste0(bp(400), shared)
+  ov2 <- refine_overlap(a2, b, est_overlap = 120, min_identity = 0.7, min_overlap = 10L)
+  expect_true(ov2$reliable)
+  expect_equal(ov2$trim_b, 120L)
+})
+
+# --- review #3 ---
+test_that("refine_overlap reports indels so the consensus can be skipped", {
+  skip_if_not_installed("pwalign")
+  set.seed(132)
+  bp <- function(n) paste0(sample(c("A", "C", "G", "T"), n, replace = TRUE), collapse = "")
+  shared <- bp(200)
+  a <- paste0(bp(300), shared)
+  # B's copy of the overlap carries a 1 bp insertion: pairing A and B by index
+  # across this junction would shift every downstream base.
+  b_ov <- paste0(substring(shared, 1L, 100L), "G", substring(shared, 101L))
+  b <- paste0(b_ov, bp(400))
+  ov <- refine_overlap(a, b, est_overlap = 200, min_identity = 0.7, min_overlap = 10L)
+  expect_gt(ov$n_indel, 0L)
+  expect_true(ov$pat_len > 0L)
+})
+
+test_that("join_scaffolds skips the consensus when the overlap is not base-alignable", {
+  skip_if_not_installed("pwalign")
+  set.seed(133)
+  bp <- function(n) paste0(sample(c("A", "C", "G", "T"), n, replace = TRUE), collapse = "")
+  shared <- bp(200)
+  a <- paste0(bp(300), shared)
+  b <- paste0(substring(shared, 1L, 100L), "G", substring(shared, 101L), bp(400))
+  lay <- data.frame(
+    scaffold = c("A", "B"), order = 1:2, rc = c(FALSE, FALSE),
+    gap_before = c(NA, -200), include = c(TRUE, TRUE), stringsAsFactors = FALSE
+  )
+  res <- join_scaffolds(list(A = a, B = b), lay,
+                        scaffold_depth = list(A = rep(10, nchar(a)), B = rep(50, nchar(b))))
+  # No IUPAC codes manufactured across the junction.
+  expect_false(grepl("[RYSWKMBDHVN]", res$seq))
+  expect_true(any(grepl("not base-alignable", res$junctions)))
+})
+
+# --- review #12 ---
+test_that("plot_scaffold_mapping still renders an included but unplaced scaffold", {
+  lay <- data.frame(
+    scaffold = c("A", "B"), order = 1:2, rc = c(FALSE, FALSE),
+    gap_before = c(NA_real_, NA_real_), mapped = c(TRUE, FALSE),
+    include = c(TRUE, TRUE), exclude_reason = c(NA_character_, NA_character_),
+    qcov = c(0.9, 0), ref_start = c(0L, NA_integer_), ref_end = c(1000L, NA_integer_),
+    qstart = c(0L, NA_integer_), stringsAsFactors = FALSE
+  )
+  pf <- tempfile(fileext = ".png")
+  grDevices::png(pf); on.exit(unlink(pf), add = TRUE)
+  expect_silent(plot_scaffold_mapping(lay, ref_len = 1000))
+  grDevices::dev.off()
+  expect_gt(file.info(pf)$size, 0)
+})

--- a/tests/testthat/test-scaffold_join.R
+++ b/tests/testthat/test-scaffold_join.R
@@ -1074,3 +1074,110 @@ test_that("plot_scaffold_mapping still renders an included but unplaced scaffold
   grDevices::dev.off()
   expect_gt(file.info(pf)$size, 0)
 })
+
+# --- note.txt / Eu20-2-1 regression round ---
+
+test_that("Eu20-2-1: contained scaffold is excluded and the gap spans it", {
+  # Real scaffold_mappings rows for Eu20-2-1 vs JN713150.1 (14,251 bp, ~83%
+  # identity). Scaffold 4 is wholly inside scaffold 2's reference extent; the old
+  # absolute density floor (0.5) let it through because every scaffold's nmatch
+  # density against this divergent reference is 0.10-0.27, so scaffold 4 was
+  # instead consumed by a blind 6,303 bp trim and the NEXT junction measured its
+  # gap from the dropped scaffold: 3,844 Ns.
+  mappings <- data.frame(
+    scaffold  = c("3", "2", "4", "1"),
+    ref_start = c(4L, 5837L, 6167L, 12544L),
+    ref_end   = c(5851L, 12470L, 8700L, 14229L),
+    strand    = c("+", "+", "+", "-"),
+    nmatch    = c(937L, 678L, 455L, 453L),
+    qcov      = c(0.698, 0.960, 0.957, 0.797),
+    qstart    = c(2488L, 0L, 0L, 0L),
+    mapped    = c(TRUE, TRUE, TRUE, TRUE), stringsAsFactors = FALSE
+  )
+  lay <- derive_scaffold_layout(mappings, ref_len = 14251L)
+  expect_false(lay$include[lay$scaffold == "4"])
+  expect_match(lay$exclude_reason[lay$scaffold == "4"], "subsumed by scaffold 2")
+  # gap for scaffold 1 measured from scaffold 2 (12544 - 12470), not scaffold 4
+  expect_equal(lay$gap_before[lay$scaffold == "1"], 74)
+  expect_true(all(lay$include[lay$scaffold %in% c("3", "2", "1")]))
+})
+
+test_that("ballooned_extent is relative, not an absolute density floor", {
+  span    <- c(6633, 5847, 2533, 1685)
+  density <- c(0.102, 0.160, 0.180, 0.269)   # all below the old 0.5 floor
+  expect_false(any(ballooned_extent(span, density, ref_len = 14251)))
+  # a real origin-wrap: near-full-reference span, far sparser than its cohort
+  expect_true(ballooned_extent(c(14000, 2533), c(0.032, 0.180), ref_len = 14251)[1])
+  # with only two scaffolds a median-based test would call the denser one sparse
+  expect_false(any(ballooned_extent(c(2000, 300), c(0.90, 0.967), ref_len = 2000)))
+})
+
+test_that("join_scaffolds measures a junction from the surviving predecessor", {
+  set.seed(11)
+  base <- paste(sample(c("A", "C", "G", "T"), 3000, TRUE), collapse = "")
+  a <- substring(base, 1, 2400)
+  b <- substring(base, 2301, 2400)     # entirely A's tail: consumed by the trim
+  cc <- substring(base, 2501, 3000)
+  lay <- data.frame(
+    scaffold = c("A", "B", "C"), order = 1:3, rc = c(FALSE, FALSE, FALSE),
+    # gap_before for C was precomputed against B (2500 - 1200 = 1300); B is
+    # dropped at runtime, so the real gap is C against A (2500 - 2400 = 100).
+    gap_before = c(NA_real_, -1300, 1300),
+    include = c(TRUE, TRUE, TRUE),
+    ref_start = c(0L, 1100L, 2500L), ref_end = c(2400L, 1200L, 3000L),
+    stringsAsFactors = FALSE
+  )
+  res <- join_scaffolds(list(A = a, B = b, C = cc), lay)
+  expect_true(any(grepl("dropped as redundant", res$junctions)))
+  n_run <- max(nchar(unlist(regmatches(res$seq, gregexpr("N+", res$seq)))), 0)
+  expect_equal(n_run, 100L)
+})
+
+test_that("a ballooned predecessor still yields gap_before 0 with nothing dropped", {
+  # The runtime recompute must fire ONLY on a drop: the precomputed 0 encodes the
+  # ballooned-wrap override, and a blanket recompute would restore the genome-scale
+  # negative gap it exists to suppress.
+  set.seed(12)
+  a <- paste(sample(c("A", "C", "G", "T"), 600, TRUE), collapse = "")
+  b <- paste(sample(c("A", "C", "G", "T"), 600, TRUE), collapse = "")
+  lay <- data.frame(
+    scaffold = c("A", "B"), order = 1:2, rc = c(FALSE, FALSE),
+    gap_before = c(NA_real_, 0),
+    include = c(TRUE, TRUE),
+    ref_start = c(0L, 500L), ref_end = c(13000L, 14000L),
+    stringsAsFactors = FALSE
+  )
+  res <- join_scaffolds(list(A = a, B = b), lay)
+  # gb 0 -> butt join or confirmed overlap, never a 12,500 bp negative trim
+  expect_false(grepl("N", res$seq))
+  expect_gt(nchar(res$seq), 600L)
+})
+
+test_that("zoom base map survives indel drift from the anchor block", {
+  set.seed(42)
+  ref <- paste(sample(c("A", "C", "G", "T"), 6000, TRUE), collapse = "")
+  # 200 bp deletion at 1001-1200: every window past it is 200 bp off the
+  # single-anchor colinear estimate.
+  scaf <- paste0(substring(ref, 1, 1000), substring(ref, 1201))
+  lay <- data.frame(scaffold = "1", rc = FALSE, ref_start = 0L, ref_end = 5999L,
+                    qstart = 0L, stringsAsFactors = FALSE)
+  bm <- zoom_window_base_maps(ref, lay, list("1" = scaf), 4001L, 4060L)
+  expect_true(!is.null(bm[["1"]]))
+  truth <- strsplit(substring(ref, 4001, 4060), "", fixed = TRUE)[[1]]
+  expect_equal(sum(bm[["1"]] == truth, na.rm = TRUE), 60L)
+})
+
+test_that("zoom base map works with no colinear offset and refuses a false one", {
+  set.seed(43)
+  ref <- paste(sample(c("A", "C", "G", "T"), 4000, TRUE), collapse = "")
+  scaf <- substring(ref, 1, 3000)
+  # qstart NA (the editor blanks it when the user flips RC): the old code skipped
+  # the row outright and drew nothing.
+  lay <- data.frame(scaffold = "1", rc = FALSE, ref_start = 0L, ref_end = 2999L,
+                    qstart = NA_integer_, stringsAsFactors = FALSE)
+  bm <- zoom_window_base_maps(ref, lay, list("1" = scaf), 2001L, 2060L)
+  expect_equal(sum(!is.na(bm[["1"]])), 60L)
+  # an unrelated sequence must not be rendered at all
+  junk <- paste(sample(c("A", "C", "G", "T"), 3000, TRUE), collapse = "")
+  expect_length(zoom_window_base_maps(ref, lay, list("1" = junk), 2001L, 2060L), 0L)
+})


### PR DESCRIPTION
## Summary

Correctness and usability work on the WF1 scaffold-join path, plus the synteny
view's orientation handling. Includes the already-reviewed PR #103 (merged into
this branch).

## Scaffold placement and joining (`R/scaffold_join.R`)

- **Colinear chain pruning** (`colinear_chain()`): a scaffold's dominant-strand
  PAF blocks are reduced to one monotone chain before the placement extent is
  taken, so an origin-wrap or a distant repeat block can no longer balloon
  `ref_start..ref_end` across the whole reference. `qcov` is deliberately still
  scored over *all* dominant-strand blocks, so a genuinely rearranged scaffold
  is not dropped by `min_qcov`.
- **Ballooned-extent detection** (`ballooned_extent()`): the sparseness test is
  now relative to the sample's own cohort rather than an absolute `nmatch`
  density floor. An absolute floor is cleared by everything against a
  conspecific reference and by nothing against an ~83%-identity one, i.e. it
  switched the guard off exactly where fragmented assemblies need it.
- **Contained-scaffold exclusion** (`detect_subsumed()`): a scaffold whose
  reference extent is >=90% inside a larger neighbour's is moved out of Path 0
  instead of forcing a genome-scale negative gap. Guarded by `qcov >= 0.9` so a
  scaffold still carrying unaligned query sequence is never discarded, and a
  scaffold that is itself excluded cannot be cited as a container.
- **Junction overlap confirmation** (`refine_overlap()`): an overlap must now
  reach A's 3' terminus, have ungapped and >=80%-identical terminal columns, and
  not be low-complexity. Measured on real data, a dragged alignment scores 5/10
  with 42 indel bases where a true junction scores 100%.
- **Overlap consensus is gated on alignability**: the coverage-majority
  consensus pairs A's suffix and B's prefix by index, so it now runs only when
  the alignment has no indels and A's aligned length equals the trim taken off
  B. Otherwise A's bases are kept and the junction note says so, instead of
  manufacturing IUPAC codes across the junction.
- **Dropped scaffolds no longer desync the join**: a scaffold fully consumed by
  overlap trimming is dropped rather than appended as an empty piece, and
  `prev_idx` tracking means the next junction's gap is re-measured against the
  scaffold actually present.
- **Rotation guard**: `rotate_to_reference()` only rotates when a block actually
  reaches reference position 0; extrapolating to the origin from a distant block
  is wrong across N gaps.
- **Circularization**: detection always runs, so an unticked Circular box now
  warns that the origin region is present twice rather than silently emitting
  it. Trimming still happens only on the auto path or when the user asserts it.
- **`parse_cov_string()`** preserves position count (empty cells -> NA, `#`
  outlier-mask prefixes stripped), and pads/truncates to the sequence length, so
  the stitched coverage track cannot slip out of register.
- **`load_scaffold_mappings()`** coerces the numeric columns back after SQLite
  returns them as character (unmapped rows store empty strings).

## Base-pair zoom (`zoom_window_base_maps()`)

The sub-region estimate is anchored on one block, so its error grows with
distance and with every indel in between: scaffolds showing a bar in the
overview could render blank. Three defences: the sub-region widens in proportion
to the drift, candidate alignments are scored against the reference window and
rejected below `min_identity`, and a whole-scaffold realignment is tried when the
estimate covers less than half the window. Alignment type changed
`global-local` -> `local`, since the padded scaffold sub-region is wider than the
reference window by construction. Blank rows now say why.

## Synteny orientation (`normalize_blast_ref_alignment()`)

`compute_blast_ref_alignment()` aligns on whichever strand scores higher, so a
sample stored opposite its reference came back reverse-complemented, putting the
synteny view in a different frame from the coverage map and the sequence editor.
Alignments are now normalised at load: the **sample** is always drawn in its
stored orientation and the **reference** carries the flip, labelled "shown
reverse-complemented". Independent of the `ref_based_rc` curate option (with it
on, CURATE has already flipped the assembly and this is a no-op).

Origin-wrapping features now keep their gene label on **both** arcs; labelling
only the longer one left an unidentified arrow at the opposite edge.

## Join editor (`R/app_assemble_coverage_details.R`)

- Mapping plot and bp zoom read a **live** layout that overlays the user's
  current RC/include choices, so manual edits show without re-running minimap.
  Flipping RC drops the now-invalid forward-query `qstart` rather than pairing it
  with a reverse-complemented sequence.
- Switching the reference recomputes the layout, and snaps back to the last good
  accession if the recompute fails, so the dropdown can never disagree with the
  layout the build step uses.
- Build inherits the BLAST hit from the accession the layout was **actually**
  built from (`rv$join_ref_accession`), not the raw dropdown value.
- Manual layouts now carry `ref_start`/`ref_end` and recompute `gap_before`
  rather than blanking it. An all-NA `gap_before` switches off `join_scaffolds`'
  overlap probe at *every* junction, turning each into a blind 100-N spacer with
  the shared bases duplicated, including junctions the user never touched.
- Per-sample reactives (`join_ref_accession` / `join_ref_seq` / `join_oriented`)
  are cleared on open, so a stale accession cannot be stamped onto another
  sample's Path 0.
- Exclusion reasons are surfaced in the editor, the mapping plot and the join
  note. Sparse (union-extent) bars are hatched so they read as several blocks
  rather than continuous coverage.

## Pipeline / config

`memory` is a plain GB number in `.config`, but a bare number is **bytes** to
Nextflow. `scaffold_join.nf`, `coverage.nf` and `coverage_userAsmb.nf` now
convert explicitly and scale by `task.attempt`. `scaffold_join.clusterOptions`
accepts a Closure so a site config can grow its own reservation on retry
(schedulers like SGE take memory from `clusterOptions`, not the `memory`
directive); plain strings still work. Default `scaffold_join` memory 4 -> 8 GB,
NMNH Hydra 16 -> 32 GB scaling.