### PR TITLE
Detect stale assemble_opts pointers; fix join-group id collision

### DIFF
--- a/R/annotate_utils.R
+++ b/R/annotate_utils.R
@@ -656,6 +656,26 @@ guess_orf_gene <- function(refHits_json, threshold = ORF_ASSIGN_SIM_THRESHOLD) {
   )
 }
 
+#' Next unused join-group id for a set of annotations
+#'
+#' Join groups are tagged in the `notes` field with a `JOIN: mode=... group=N`
+#' marker, so the next id is one past the largest `group=` already present.
+#'
+#' @param notes the annotation `notes` column (may be NA, empty, or an all-NA
+#'   logical vector when the database column holds only NULLs).
+#'
+#' @return integer group id, 1 when no join markers are present.
+#' @noRd
+next_join_group <- function(notes) {
+  grps <- as.integer(
+    stringr::str_match(
+      dplyr::coalesce(as.character(notes), ""),
+      "^JOIN: mode=\\w+ group=(\\d+)"
+    )[, 2]
+  )
+  if (all(is.na(grps))) 1L else max(grps, na.rm = TRUE) + 1L
+}
+
 #' Splice a joined gene's segments into one CDS
 #'
 #' Concatenates a join group's segment (exon) sequences in 5'->3' order and

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -3914,10 +3914,7 @@ annotations_details_server <- function(id, rv) {
     do_join_merge <- function(rows_to_merge, merge_anns, join_mode, slip_note = NULL) {
       # Unique group id = one past the max existing group in this sample. A
       # whole-second Sys.time() collides when two joins happen in the same second.
-      existing_grps <- as.integer(
-        stringr::str_match(rv$annotations$notes %|NA|% "", "group=(\\d+)")[, 2]
-      )
-      grp <- if (all(is.na(existing_grps))) 1L else max(existing_grps, na.rm = TRUE) + 1L
+      grp <- next_join_group(rv$annotations$notes)
       marker <- stringr::str_glue("JOIN: mode={join_mode} group={grp}")
       # frameshift note travels to export in the marker; ";" would break the
       # "; "-joined notes field, so swap it for ","

--- a/R/app_assemble.R
+++ b/R/app_assemble.R
@@ -585,7 +585,50 @@ assemble_server <- function(id) {
       # Locking advances every non-ignored (path, scaffold) unit for the sample
       # (multi-assembly). Each unit was seeded an annotate row at assemble time.
       lock_current <- as.numeric(names(which.max(table(rv$updating$assemble_lock))))
-      rv$updating$assemble_lock <- as.numeric(!lock_current)
+      upd <- rv$updating
+      # Locking hands the sample to WF2, which rebuilds the published output path
+      # from assemble_opts. Samples that never assembled are not affected.
+      if (lock_current == 0) {
+        stale <- tryCatch(
+          stale_assemble_dirs(
+            session$userData$con,
+            session$userData$dir_out,
+            ids = upd$ID,
+            pending_only = FALSE
+          ),
+          error = function(e) NULL
+        )
+        if (!is.null(stale) && nrow(stale) > 0L) {
+          upd <- upd |> dplyr::filter(!ID %in% stale$ID)
+          shinyWidgets::sendSweetAlert(
+            title = "Assembly output not found",
+            text = shiny::tags$div(
+              shiny::tags$p(
+                "These samples were NOT locked, because Annotation and Curation ",
+                "would look for assembly output that is not on disk:"
+              ),
+              shiny::tags$ul(stale_assemble_items(stale)),
+              shiny::tags$p("Either:"),
+              shiny::tags$ul(
+                shiny::tags$li("set the assembly parameter set back to the name that exists on disk, or"),
+                shiny::tags$li("re-run Assembly so the output is published under the assigned name.")
+              ),
+              shiny::tags$p(
+                if (nrow(upd) > 0L) {
+                  "The rest of the selected samples were locked."
+                } else {
+                  "No other samples remained, so nothing was locked."
+                }
+              )
+            ),
+            html = TRUE,
+            type = "error"
+          )
+          req(nrow(upd) > 0L)
+        }
+      }
+      upd$assemble_lock <- as.numeric(!lock_current)
+      rv$updating <- upd
       dplyr::tbl(session$userData$con, "assemble") |>
         dplyr::rows_update(
           rv$updating,
@@ -928,6 +971,9 @@ assemble_server <- function(id) {
           dplyr::collect()
       }
       ## Update Assembly Table ----
+      # Captured before the write, rv$updating is cleared below.
+      prior <- dplyr::bind_rows(rv$updating, rv$updating_indirect) |>
+        dplyr::select(dplyr::any_of(c("ID", "assemble_opts")))
       update <- data.frame(
         ID = c(rv$updating$ID, rv$updating_indirect$ID),
         assemble_opts = input$assemble_opts,
@@ -946,9 +992,52 @@ assemble_server <- function(id) {
           update,
           by = "ID"
         )
+      ## Flag samples with no output under the new parameter set ----
+      dir_out <- session$userData$dir_out
+      unpublished <- prior |> dplyr::slice(0)
+      if (nrow(prior) > 0L && "assemble_opts" %in% names(prior) &&
+          length(dir_out) == 1L && !is.na(dir_out) && nzchar(dir_out)) {
+        unpublished <- prior |>
+          dplyr::filter(
+            assemble_opts != input$assemble_opts,
+            !dir.exists(assemble_out_dir(dir_out, ID, input$assemble_opts))
+          )
+      }
       rv$updating <- rv$updating_indirect <- NULL
       removeModal()
       trigger("update_assemble_table")
+      if (nrow(unpublished) > 0L) {
+        shown <- unpublished |> dplyr::slice(seq_len(min(nrow(unpublished), 10)))
+        items <- lapply(seq_len(nrow(shown)), function(i) {
+          shiny::tags$li(
+            shiny::tags$b(shown$ID[i]),
+            " previously used ",
+            shiny::tags$code(shown$assemble_opts[i])
+          )
+        })
+        if (nrow(unpublished) > nrow(shown)) {
+          items <- c(items, list(shiny::tags$li(
+            paste0("... and ", nrow(unpublished) - nrow(shown), " more")
+          )))
+        }
+        shinyWidgets::sendSweetAlert(
+          title = "No assembly output for this parameter set",
+          text = shiny::tags$div(
+            shiny::tags$p(
+              "These samples are now assigned to parameter set ",
+              shiny::tags$code(input$assemble_opts),
+              ", which has no assembly output on disk:"
+            ),
+            shiny::tags$ul(items),
+            shiny::tags$p(
+              "Re-run Assembly before locking these samples, or set the ",
+              "parameter set back to a name that exists on disk."
+            )
+          ),
+          html = TRUE,
+          type = "warning"
+        )
+      }
     })
 
     # Set BLAST Opts ----

--- a/R/app_assemble_coverage_details.R
+++ b/R/app_assemble_coverage_details.R
@@ -7,6 +7,45 @@ assembly_coverage_details_server <- function(id, rv) {
 
     init("coverage_modal")
 
+    # Reads and writes below rebuild the published output path from
+    # assemble_opts, so it is absent when the option set was reassigned or out/
+    # was moved. Report it, never create it: a directory holding only the Path 0
+    # files would look complete while the raw path assemblies stay orphaned.
+    require_assemble_output <- function(pth) {
+      if (length(pth) == 1L && !is.na(pth) && nzchar(pth) && file.exists(pth)) {
+        return(TRUE)
+      }
+      on_disk <- tryCatch(
+        assemble_dirs_on_disk(session$userData$dir_out, rv$updating$ID),
+        error = function(e) character(0)
+      )
+      shinyWidgets::sendSweetAlert(
+        title = "Assembly output not found",
+        text = tags$div(
+          tags$p(
+            "The assembly output for ", tags$b(rv$updating$ID),
+            " is not where the project database expects it:"
+          ),
+          tags$ul(tags$li(tags$code(pth))),
+          if (length(on_disk) > 0) {
+            tags$p(
+              "Assembly parameter sets published on disk: ",
+              tags$code(paste(on_disk, collapse = ", "))
+            )
+          } else {
+            tags$p("No assembly output is published for this sample.")
+          },
+          tags$p(
+            "Re-run Assembly for this sample, or set its assembly parameter ",
+            "set back to the name that exists on disk."
+          )
+        ),
+        html = TRUE,
+        type = "error"
+      )
+      FALSE
+    }
+
     # "How do I choose?" guidance modal (reopens this modal on close).
     register_tool_help("assembly_paths", input,
                        reopen = function() trigger("coverage_modal"))
@@ -366,15 +405,23 @@ assembly_coverage_details_server <- function(id, rv) {
     # View Coverage PDF ----
     observeEvent(input$view_coverage, {
       row <- as.numeric(input$view_coverage)
-      url <- file.path(
+      pdf_path <- file.path(
         dirname(getOption("MitoPilot.db") %||% "."),
         "out", rv$updating$ID,
         "assemble", rv$updating$assemble_opts,
         paste0(rv$updating$ID, "_assembly_",
                rv$focal_assembly$path[row], "_",
                rv$focal_assembly$scaffold[row], "_coverage.pdf")
-      ) |>
-        browseURL()
+      )
+      req(require_assemble_output(pdf_path))
+      # browseURL() errors when no browser is configured (headless/server).
+      tryCatch(browseURL(pdf_path), error = function(e) {
+        shiny::showNotification(
+          paste0("Cannot open a PDF viewer from this session. Path: ", pdf_path),
+          type = "warning",
+          duration = 10
+        )
+      })
     })
 
     # Copy as fasta ----
@@ -1406,6 +1453,7 @@ assembly_coverage_details_server <- function(id, rv) {
       ID <- rv$updating$ID
       dir <- file.path(session$userData$dir_out, ID, "assemble",
                        rv$updating$assemble_opts)
+      req(require_assemble_output(dir))
       # Shared with the Nextflow auto-join: writes {ID}_assembly_0.fasta and the
       # matching _coverageStats.csv in the layout annotate() reads.
       write_joined_files(dir, ID, seq_str, depth_vec, gc_vec, err_vec, topology)
@@ -1890,6 +1938,20 @@ assembly_coverage_details_server <- function(id, rv) {
       # then write everything. Deferred so a cancelled picker writes nothing.
       finalize_trim <- function(blast_row, topology = "linear") {
         bl <- blast_cols(blast_row)
+        out_dir <- file.path(
+          session$userData$dir_out,
+          rv$updating$ID,
+          "assemble",
+          rv$updating$assemble_opts
+        )
+        cov_csv <- file.path(
+          out_dir,
+          paste0(rv$updating$ID, "_assembly_",
+                 rv$focal_assembly$path[sel[1]], "_coverageStats.csv")
+        )
+        # Checked before anything is written, so a missing output cannot leave a
+        # half-written Path 0 behind.
+        req(require_assemble_output(out_dir), require_assemble_output(cov_csv))
 
       # Make new assembly
       trimmed <- purrr::map2_chr(rv$alignment$consStart, rv$alignment$consEnd, ~ {
@@ -1904,23 +1966,11 @@ assembly_coverage_details_server <- function(id, rv) {
       ) |> paste(topology)
       Biostrings::writeXStringSet(
         trimmed,
-        file.path(
-          session$userData$dir_out,
-          rv$updating$ID,
-          "assemble",
-          rv$updating$assemble_opts,
-          paste0(rv$updating$ID, "_assembly_0.fasta")
-        )
+        file.path(out_dir, paste0(rv$updating$ID, "_assembly_0.fasta"))
       )
 
       # Updated coverage stats file
-      coverage <- file.path(
-        session$userData$dir_out,
-        rv$updating$ID,
-        "assemble",
-        rv$updating$assemble_opts,
-        paste0(rv$updating$ID, "_assembly_", rv$focal_assembly$path[sel[1]], "_coverageStats.csv")
-      ) |> read.csv()
+      coverage <- read.csv(cov_csv)
 
       start_offset <- (stringr::str_extract(as.character(rv$alignment$seqs[1]), "^-+") |> nchar()) %|NA|% 0
 
@@ -1934,13 +1984,7 @@ assembly_coverage_details_server <- function(id, rv) {
 
       readr::write_csv(
         coverage,
-        file.path(
-          session$userData$dir_out,
-          rv$updating$ID,
-          "assemble",
-          rv$updating$assemble_opts,
-          paste0(rv$updating$ID, "_assembly_0_coverageStats.csv")
-        ),
+        file.path(out_dir, paste0(rv$updating$ID, "_assembly_0_coverageStats.csv")),
         quote = "none", na = ""
       )
 

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -91,6 +91,40 @@ app_server <- function(input, output, session) {
     stringr::str_remove("^[^'|^\"]+['\"]") |>
     stringr::str_extract("^[^'|^\"]+")
   session$userData$dir_out <- file.path(dirname(db), dir_out)
+
+  # The assembly output folder is named after assemble_opts, so a sample that was
+  # reassigned after it assembled points at a folder that was never created.
+  # Warn, but keep the app open: fixing this requires the app.
+  tryCatch({
+    stale <- stale_assemble_dirs(session$userData$con, session$userData$dir_out)
+    if (nrow(stale) > 0) {
+      shinyWidgets::sendSweetAlert(
+        session = session,
+        title = "Assembly output not found",
+        text = shiny::tags$div(
+          shiny::tags$p(
+            "The assembly output these samples are assigned to is not on disk. ",
+            "Either the assembly parameter set was changed after they were ",
+            "assembled, or the output was moved or deleted:"
+          ),
+          shiny::tags$ul(stale_assemble_items(stale)),
+          shiny::tags$p("Either:"),
+          shiny::tags$ul(
+            shiny::tags$li("set the sample's assembly parameter set back to the name that exists on disk, or"),
+            shiny::tags$li("re-run Assembly so the output is published under the assigned name.")
+          ),
+          shiny::tags$p(
+            "These samples are locked and awaiting annotation, so until then ",
+            "Annotation and Curation will fail or will silently run without any ",
+            "reference hits."
+          )
+        ),
+        html = TRUE,
+        type = "warning"
+      )
+    }
+  }, error = function(e) NULL)
+
   # Genetic code ----
   # Per-sample genetic codes live in samples.genetic_code (auto-selected from
   # each sample's curation ruleset) and drive translation. This project-level

--- a/R/app_server_userAsmb.R
+++ b/R/app_server_userAsmb.R
@@ -54,6 +54,36 @@ app_server_userAsmb <- function(input, output, session) {
     stringr::str_remove("^[^'|^\"]+['\"]") |>
     stringr::str_extract("^[^'|^\"]+")
   session$userData$dir_out <- file.path(dirname(db), dir_out)
+
+  # See app_server(). User-assemble projects fix assemble_opts at 'user' and offer
+  # no way to change it, so the only way to get here is missing output.
+  tryCatch({
+    stale <- stale_assemble_dirs(session$userData$con, session$userData$dir_out)
+    if (nrow(stale) > 0) {
+      shinyWidgets::sendSweetAlert(
+        session = session,
+        title = "Assembly output not found",
+        text = shiny::tags$div(
+          shiny::tags$p(
+            "The assembly output for these samples is not on disk, so the ",
+            "output folder was moved or deleted:"
+          ),
+          shiny::tags$ul(stale_assemble_items(stale)),
+          shiny::tags$p(
+            "Restore the output folder, or re-run Assembly to publish it again."
+          ),
+          shiny::tags$p(
+            "These samples are locked and awaiting annotation, so until then ",
+            "Annotation and Curation will fail or will silently run without any ",
+            "reference hits."
+          )
+        ),
+        html = TRUE,
+        type = "warning"
+      )
+    }
+  }, error = function(e) NULL)
+
   # No-raw-data mode ----
   # rawDir = 'NA' in .config signals an assembly-only project (no reads/coverage).
   # Used to hide read-derived columns in the Assemble table.

--- a/R/project_consistency.R
+++ b/R/project_consistency.R
@@ -1,0 +1,166 @@
+#' Published assembly output directory for a sample
+#'
+#' The ASSEMBLE workflow publishes to `out/<ID>/assemble/<assemble_opts>/`
+#' (`inst/nextflow/modules/assemble.nf`), so the option-set name doubles as a
+#' directory name. Every downstream stage rebuilds this path from the current
+#' `assemble.assemble_opts` value.
+#'
+#' @param dir_out Project output directory (`session$userData$dir_out`).
+#' @param ID Sample ID.
+#' @param opts Option set name (`assemble.assemble_opts`).
+#'
+#' @noRd
+assemble_out_dir <- function(dir_out, ID, opts) {
+  file.path(dir_out, ID, "assemble", opts)
+}
+
+#' Option-set directories that actually exist on disk for a sample
+#'
+#' @param dir_out Project output directory.
+#' @param ID Sample ID.
+#'
+#' @return Character vector of directory names, possibly empty.
+#'
+#' @noRd
+assemble_dirs_on_disk <- function(dir_out, ID) {
+  if (length(dir_out) != 1L || is.na(dir_out) || !nzchar(dir_out)) {
+    return(character(0))
+  }
+  base <- file.path(dir_out, ID, "assemble")
+  if (!dir.exists(base)) {
+    return(character(0))
+  }
+  found <- basename(list.dirs(base, recursive = FALSE, full.names = TRUE))
+  found[!startsWith(found, ".")]
+}
+
+#' Samples whose published assembly is not where the database says it is
+#'
+#' `assemble.assemble_opts` is a mutable pointer that is also the on-disk
+#' directory name. Reassigning a sample to a different option set after it has
+#' assembled leaves the published output under the old name, so every stage that
+#' rebuilds the path (WF2 annotate / curate / ORF, the coverage viewer, the
+#' output folder button) points somewhere that was never created.
+#'
+#' The test matches what WF2 itself dereferences
+#' (`inst/nextflow/modules/annotate_workflow.nf`): the per-path assembly FASTA,
+#' not merely the directory. Creating an empty directory therefore does not
+#' silence this check.
+#'
+#' @param con An open connection to a project database.
+#' @param dir_out Project output directory.
+#' @param ids Optional sample IDs to restrict the check to. `NULL` checks the
+#'   whole project.
+#' @param pending_only Only report samples WF2 would actually try to process,
+#'   i.e. locked, with annotation still queued. Set `FALSE` when checking
+#'   samples that are about to be locked.
+#'
+#' @return A data frame with columns `ID`, `assemble_opts`, `expected` and
+#'   `on_disk` (comma separated, `""` when nothing was published). Zero rows
+#'   when the project is consistent or cannot be checked.
+#'
+#' @noRd
+stale_assemble_dirs <- function(con, dir_out, ids = NULL, pending_only = TRUE) {
+  empty <- data.frame(
+    ID = character(0),
+    assemble_opts = character(0),
+    expected = character(0),
+    on_disk = character(0),
+    stringsAsFactors = FALSE
+  )
+  if (length(dir_out) != 1L || is.na(dir_out) || !nzchar(dir_out) ||
+      !dir.exists(dir_out)) {
+    return(empty)
+  }
+  if (!is.null(ids)) {
+    ids <- unique(ids[!is.na(ids)])
+    if (length(ids) == 0L) {
+      return(empty)
+    }
+  }
+  # Mirrors the WF2 gate: annotate_workflow.nf selects from assemblies joined to
+  # assemble and annotate, requiring assemble_lock = 1, ignore = 0 and an
+  # annotation that is switched on and unlocked.
+  sql <- paste(
+    "SELECT DISTINCT b.ID AS ID, b.assemble_opts AS assemble_opts, a.path AS path",
+    "FROM assemble b JOIN assemblies a ON a.ID = b.ID",
+    "WHERE COALESCE(a.ignore, 0) = 0"
+  )
+  if (isTRUE(pending_only)) {
+    sql <- paste(
+      sql,
+      "AND b.assemble_lock = 1",
+      "AND EXISTS (SELECT 1 FROM annotate an WHERE an.ID = b.ID",
+      "AND an.annotate_switch = 1 AND an.annotate_lock = 0)"
+    )
+  }
+  if (!is.null(ids)) {
+    sql <- paste0(
+      sql, " AND b.ID IN (",
+      paste0("'", gsub("'", "''", ids), "'", collapse = ", "), ")"
+    )
+  }
+  rows <- tryCatch(DBI::dbGetQuery(con, sql), error = function(e) NULL)
+  if (is.null(rows) || nrow(rows) == 0L) {
+    return(empty)
+  }
+  opts <- as.character(rows$assemble_opts)
+  unset <- is.na(opts) | !nzchar(trimws(opts))
+  dir <- assemble_out_dir(dir_out, rows$ID, opts)
+  fasta <- file.path(dir, paste0(rows$ID, "_assembly_", rows$path, ".fasta"))
+  missing <- unset | !file.exists(fasta)
+  if (!any(missing)) {
+    return(empty)
+  }
+  rows <- rows[missing, , drop = FALSE]
+  opts <- ifelse(unset[missing], NA_character_, opts[missing])
+  dir <- ifelse(unset[missing], NA_character_, dir[missing])
+  keep <- !duplicated(paste(rows$ID, opts))
+  data.frame(
+    ID = rows$ID[keep],
+    assemble_opts = opts[keep],
+    expected = dir[keep],
+    on_disk = vapply(
+      rows$ID[keep],
+      function(id) paste(assemble_dirs_on_disk(dir_out, id), collapse = ", "),
+      character(1),
+      USE.NAMES = FALSE
+    ),
+    stringsAsFactors = FALSE
+  )
+}
+
+#' Bullet list describing stale assembly output, for a sweet alert
+#'
+#' @param stale Output of [stale_assemble_dirs()].
+#' @param max_items Cap on enumerated samples.
+#'
+#' @noRd
+stale_assemble_items <- function(stale, max_items = 10L) {
+  shown <- stale[seq_len(min(nrow(stale), max_items)), , drop = FALSE]
+  items <- lapply(seq_len(nrow(shown)), function(i) {
+    shiny::tags$li(
+      shiny::tags$b(shown$ID[i]),
+      if (is.na(shown$assemble_opts[i])) {
+        " has no assembly parameter set assigned"
+      } else {
+        list(
+          " points at parameter set ",
+          shiny::tags$code(shown$assemble_opts[i])
+        )
+      },
+      ", but the assembly output on disk is ",
+      if (nzchar(shown$on_disk[i])) {
+        shiny::tags$code(shown$on_disk[i])
+      } else {
+        "missing"
+      }
+    )
+  })
+  if (nrow(stale) > nrow(shown)) {
+    items <- c(items, list(shiny::tags$li(
+      paste0("... and ", nrow(stale) - nrow(shown), " more")
+    )))
+  }
+  items
+}

--- a/inst/nextflow/modules/annotate_workflow.nf
+++ b/inst/nextflow/modules/annotate_workflow.nf
@@ -46,18 +46,30 @@ workflow ANNOTATE {
                 }
             }
 
+            // params.publishDir is relative, so resolve against launchDir (as CURATE does).
+            def assembleRel = params.publishDir + '/' + it[0] + '/assemble/' + it[3]
+            def assemblyRel = assembleRel + '/' + it[0] + '_assembly_' + it[1] + '.fasta'
+            // Only judged when the project output tree is local; the unit is still
+            // emitted either way so annotate() fails as loudly as it always has.
+            def outRoot = new File(launchDir.toString(), params.publishDir)
+            if (outRoot.isDirectory() && !new File(launchDir.toString(), assemblyRel).exists()) {
+                def assembleBase = new File(outRoot, it[0] + '/assemble')
+                def onDisk = assembleBase.isDirectory() ?
+                    assembleBase.listFiles()?.findAll { d -> d.isDirectory() && !d.name.startsWith('.') }?.collect { d -> d.name }?.sort() : null
+                log.warn "ANNOTATE: ${it[0]} (path ${it[1]}, scaffold ${it[2]}): expected assembly ${assemblyRel} not found. " +
+                    (onDisk ?
+                        "Assembly parameter set directories present for this sample: ${onDisk.join(', ')}. " +
+                        "assemble_opts may have been changed after this sample was assembled, or the published output may have been moved or deleted." :
+                        "No assembly output is present for this sample at all; it may have been moved or deleted.")
+            }
+
             tuple(
                 it[0],                                          // ID
                 it[1],                                          // path
                 it[2],                                          // scaffold
-                file(                                           // Assembly (per-path; annotate() isolates this scaffold)
-                    params.publishDir + '/' +
-                    it[0] + '/assemble/' + it[3] + '/' +
-                    it[0] + '_assembly_' + it[1] + '.fasta'
-                ),
+                file(assemblyRel),                              // Assembly (per-path; annotate() isolates this scaffold)
                 file(                                           // Coverage (per-path; subset to this scaffold)
-                    params.publishDir + '/' +
-                    it[0] + '/assemble/' + it[3] + '/' +
+                    assembleRel + '/' +
                     it[0] + '_assembly_' + it[1] + '_coverageStats.csv'
                 ),
                 [

--- a/tests/testthat/test-join-group.R
+++ b/tests/testthat/test-join-group.R
@@ -1,0 +1,130 @@
+# Rebuilds a notes cell exactly as do_join_merge() in R/app_annotate_details.R
+# does, so the reader regexes below are exercised against production strings.
+make_join_note <- function(join_mode, grp, slip_note = NULL,
+                           old_note = NA_character_) {
+  marker <- stringr::str_glue("JOIN: mode={join_mode} group={grp}")
+  if (identical(join_mode, "frameshift") && !is.null(slip_note) &&
+      nzchar(trimws(slip_note))) {
+    marker <- paste0(
+      marker, " note=", stringr::str_replace_all(trimws(slip_note), ";", ",")
+    )
+  }
+  paste(marker, old_note %|NA|% "", sep = "; ") |> stringr::str_remove("; $")
+}
+
+# The export reader (R/export.R, around lines 363-371).
+read_join_marker <- function(note) {
+  m <- stringr::str_match(
+    note %|NA|% "", "^JOIN: mode=(\\w+) group=(\\d+)( note=([^;]*))?"
+  )
+  list(mode = m[, 2], group = m[, 3], note = m[, 5])
+}
+
+# The group member scan (R/export.R around line 377, mirrored in the modal).
+join_member_hits <- function(notes, grp) {
+  stringr::str_detect(
+    dplyr::coalesce(notes, ""),
+    paste0("^JOIN: mode=\\w+ group=", grp, "\\b")
+  )
+}
+
+# The un-join observer's stripping regex (R/app_annotate_details.R line ~4130).
+strip_join_marker <- function(notes) {
+  stringr::str_remove(
+    notes, "^JOIN: mode=\\w+ group=\\d+( note=[^;]*)?(; )?"
+  )
+}
+
+test_that("next_join_group returns 1 when there are no join markers", {
+  expect_equal(next_join_group(c(NA_character_, NA_character_)), 1L)
+  expect_equal(next_join_group(character(0)), 1L)
+  expect_equal(next_join_group(c("manual edit", "", NA)), 1L)
+})
+
+test_that("next_join_group returns 1 for an all-NA logical column", {
+  expect_equal(next_join_group(c(NA, NA, NA)), 1L)
+})
+
+test_that("next_join_group steps past the largest existing group", {
+  expect_equal(next_join_group("JOIN: mode=exon group=1; old note"), 2L)
+  expect_equal(
+    next_join_group(c(NA, "JOIN: mode=exon group=1", "JOIN: mode=frameshift group=2")),
+    3L
+  )
+})
+
+test_that("next_join_group compares group ids numerically", {
+  notes <- c("JOIN: mode=exon group=2", "JOIN: mode=exon group=10")
+  expect_equal(next_join_group(notes), 11L)
+})
+
+test_that("next_join_group handles a full annotation table's notes column", {
+  notes <- rep(NA_character_, 37)
+  notes[5] <- "JOIN: mode=exon group=1"
+  notes[12] <- "JOIN: mode=exon group=1; manual edit"
+  expect_equal(next_join_group(notes), 2L)
+})
+
+test_that("next_join_group is vectorized where %|NA|% is not", {
+  expect_error(c(NA, "a") %|NA|% "")
+  expect_equal(next_join_group(c(NA, "a")), 1L)
+})
+
+test_that("next_join_group only counts anchored JOIN markers", {
+  expect_equal(next_join_group("read depth drops where group=5 starts"), 1L)
+  expect_equal(
+    next_join_group(c("group=7", "see group=12 in the notes", NA)),
+    1L
+  )
+  expect_equal(next_join_group("JOIN: mode=exon group=3; see group=99"), 4L)
+})
+
+test_that("a marker built by do_join_merge round trips through the export reader", {
+  note <- make_join_note("exon", 3, old_note = "manual edit")
+  expect_equal(note, "JOIN: mode=exon group=3; manual edit")
+
+  got <- read_join_marker(note)
+  expect_equal(got$mode, "exon")
+  expect_equal(got$group, "3")
+  expect_true(is.na(got$note))
+  expect_equal(next_join_group(note), 4L)
+})
+
+test_that("a frameshift slippage note survives the round trip", {
+  note <- make_join_note(
+    "frameshift", 2,
+    slip_note = " slip at 4021; confirmed, twice ",
+    old_note = "manual edit"
+  )
+  expect_equal(
+    note,
+    "JOIN: mode=frameshift group=2 note=slip at 4021, confirmed, twice; manual edit"
+  )
+
+  got <- read_join_marker(note)
+  expect_equal(got$mode, "frameshift")
+  expect_equal(got$group, "2")
+  expect_equal(got$note, "slip at 4021, confirmed, twice")
+  expect_equal(strip_join_marker(note), "manual edit")
+})
+
+test_that("the member scan does not match a group with the same prefix", {
+  notes <- c(
+    make_join_note("exon", 1),
+    make_join_note("exon", 10),
+    make_join_note("exon", 1, old_note = "second segment"),
+    NA_character_
+  )
+  expect_equal(join_member_hits(notes, "1"), c(TRUE, FALSE, TRUE, FALSE))
+  expect_equal(join_member_hits(notes, "10"), c(FALSE, TRUE, FALSE, FALSE))
+})
+
+test_that("un-joining a row with no original note leaves no dangling separator", {
+  note <- make_join_note("exon", 1)
+  expect_equal(note, "JOIN: mode=exon group=1")
+  expect_equal(strip_join_marker(note), "")
+
+  fs <- make_join_note("frameshift", 1, slip_note = "slip at 4021")
+  expect_equal(fs, "JOIN: mode=frameshift group=1 note=slip at 4021")
+  expect_equal(strip_join_marker(fs), "")
+})

--- a/tests/testthat/test-project-consistency.R
+++ b/tests/testthat/test-project-consistency.R
@@ -1,0 +1,388 @@
+# Fixture columns follow the real project schema (R/init_db.R): `assemble` has
+# assemble_lock, `assemblies` has ignore, and `annotate` carries the WF2 gate.
+make_consistency_db <- function(assemble, assemblies = NULL, annotate = NULL) {
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  DBI::dbExecute(con, "CREATE TABLE assemble (
+    ID TEXT NOT NULL,
+    assemble_switch INTEGER,
+    assemble_lock INTEGER,
+    assemble_opts TEXT,
+    PRIMARY KEY (ID)
+  )")
+  DBI::dbExecute(con, "CREATE TABLE assemblies (
+    ID TEXT NOT NULL,
+    path INTEGER NOT NULL,
+    scaffold INTEGER NOT NULL,
+    ignore INTEGER,
+    PRIMARY KEY (ID, path, scaffold)
+  )")
+  DBI::dbExecute(con, "CREATE TABLE annotate (
+    ID TEXT NOT NULL,
+    path INTEGER NOT NULL DEFAULT 1,
+    scaffold INTEGER NOT NULL DEFAULT 1,
+    annotate_switch INTEGER,
+    annotate_lock INTEGER,
+    PRIMARY KEY (ID, path, scaffold)
+  )")
+  DBI::dbWriteTable(con, "assemble", assemble, append = TRUE)
+  if (!is.null(assemblies) && nrow(assemblies) > 0) {
+    DBI::dbWriteTable(con, "assemblies", assemblies, append = TRUE)
+  }
+  if (is.null(annotate)) {
+    annotate <- tbl_annotate(unique(assemble$ID))
+  }
+  if (nrow(annotate) > 0) {
+    DBI::dbWriteTable(con, "annotate", annotate, append = TRUE)
+  }
+  con
+}
+
+# Row builders. Defaults describe a sample WF2 would really process: locked,
+# not ignored, annotation switched on and still unlocked.
+tbl_assemble <- function(ID, assemble_opts = "default", assemble_lock = 1) {
+  data.frame(
+    ID = ID, assemble_switch = 1, assemble_lock = assemble_lock,
+    assemble_opts = assemble_opts, stringsAsFactors = FALSE
+  )
+}
+tbl_assemblies <- function(ID, path = 1, scaffold = 1, ignore = 0) {
+  data.frame(
+    ID = ID, path = path, scaffold = scaffold, ignore = ignore,
+    stringsAsFactors = FALSE
+  )
+}
+tbl_annotate <- function(ID, path = 1, scaffold = 1, annotate_switch = 1,
+                         annotate_lock = 0) {
+  data.frame(
+    ID = ID, path = path, scaffold = scaffold,
+    annotate_switch = annotate_switch, annotate_lock = annotate_lock,
+    stringsAsFactors = FALSE
+  )
+}
+
+# Helper: temp output tree. `dirs` maps ID -> option set names and creates the
+# directories only; `fasta` maps ID -> list(opts, paths) and additionally writes
+# the per-path assembly FASTA that WF2 dereferences.
+make_out_tree <- function(dirs = list(), fasta = list()) {
+  td <- tempfile()
+  dir.create(td, recursive = TRUE)
+  for (id in names(dirs)) {
+    for (opts in dirs[[id]]) {
+      dir.create(file.path(td, id, "assemble", opts), recursive = TRUE)
+    }
+  }
+  for (id in names(fasta)) {
+    spec <- fasta[[id]]
+    d <- file.path(td, id, "assemble", spec$opts)
+    dir.create(d, recursive = TRUE, showWarnings = FALSE)
+    for (p in spec$paths) {
+      writeLines(">seq", file.path(d, paste0(id, "_assembly_", p, ".fasta")))
+    }
+  }
+  td
+}
+
+test_that("assemble_out_dir builds the published path and is vectorized", {
+  expect_equal(assemble_out_dir("out", "s1", "default"), "out/s1/assemble/default")
+  expect_equal(
+    assemble_out_dir("out", c("s1", "s2"), c("default", "fast")),
+    c("out/s1/assemble/default", "out/s2/assemble/fast")
+  )
+})
+
+test_that("a consistent project reports nothing", {
+  td <- make_out_tree(fasta = list(
+    s1 = list(opts = "default", paths = 1),
+    s2 = list(opts = "default", paths = 1)
+  ))
+  on.exit(unlink(td, recursive = TRUE))
+
+  con <- make_consistency_db(
+    assemble = tbl_assemble(c("s1", "s2")),
+    assemblies = tbl_assemblies(c("s1", "s2"))
+  )
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  expect_equal(nrow(stale_assemble_dirs(con, td)), 0)
+})
+
+test_that("a sample reassigned after assembly is reported with what is on disk", {
+  td <- make_out_tree(fasta = list(
+    s1 = list(opts = "default", paths = 1),
+    s2 = list(opts = "default", paths = 1)
+  ))
+  on.exit(unlink(td, recursive = TRUE))
+
+  # s1 was assembled under 'default' but now points at 'aggressive'
+  con <- make_consistency_db(
+    assemble = tbl_assemble(c("s1", "s2"), c("aggressive", "default")),
+    assemblies = tbl_assemblies(c("s1", "s2"))
+  )
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  res <- stale_assemble_dirs(con, td)
+  expect_equal(nrow(res), 1)
+  expect_equal(res$ID, "s1")
+  expect_equal(res$assemble_opts, "aggressive")
+  expect_equal(res$expected, paste0(td, "/s1/assemble/aggressive"))
+  expect_equal(res$on_disk, "default")
+})
+
+test_that("an option-set directory with no assembly FASTA is still reported", {
+  # The directory exists (an empty publish dir, or output cleared by hand) but
+  # the file WF2 dereferences does not.
+  td <- make_out_tree(dirs = list(s1 = "default"))
+  on.exit(unlink(td, recursive = TRUE))
+
+  con <- make_consistency_db(
+    assemble = tbl_assemble("s1"),
+    assemblies = tbl_assemblies("s1")
+  )
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  res <- stale_assemble_dirs(con, td)
+  expect_equal(nrow(res), 1)
+  expect_equal(res$ID, "s1")
+  expect_equal(res$assemble_opts, "default")
+  expect_equal(res$on_disk, "default")
+})
+
+test_that("a multi-path sample is reported once, not once per path", {
+  # path 1 published, path 2 did not
+  td <- make_out_tree(fasta = list(s1 = list(opts = "default", paths = 1)))
+  on.exit(unlink(td, recursive = TRUE))
+
+  con <- make_consistency_db(
+    assemble = tbl_assemble("s1"),
+    assemblies = tbl_assemblies("s1", path = c(1, 1, 2), scaffold = c(1, 2, 1))
+  )
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  res <- stale_assemble_dirs(con, td)
+  expect_equal(nrow(res), 1)
+  expect_equal(res$ID, "s1")
+
+  # both paths missing collapses to the same single row
+  unlink(file.path(td, "s1", "assemble", "default", "s1_assembly_1.fasta"))
+  expect_equal(nrow(stale_assemble_dirs(con, td)), 1)
+})
+
+test_that("a sample that never assembled is not reported", {
+  # s2 is in `assemble` but has no assemblies (e.g. locked out before running),
+  # so its missing output directory is expected, not stale
+  td <- make_out_tree(fasta = list(s1 = list(opts = "default", paths = 1)))
+  on.exit(unlink(td, recursive = TRUE))
+
+  con <- make_consistency_db(
+    assemble = tbl_assemble(c("s1", "s2")),
+    assemblies = tbl_assemblies("s1")
+  )
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  expect_equal(nrow(stale_assemble_dirs(con, td)), 0)
+})
+
+test_that("a sample whose scaffolds are all ignored is not reported", {
+  td <- make_out_tree()
+  on.exit(unlink(td, recursive = TRUE))
+
+  con <- make_consistency_db(
+    assemble = tbl_assemble(c("s1", "s2")),
+    assemblies = rbind(
+      tbl_assemblies("s1", path = c(1, 1), scaffold = c(1, 2), ignore = 1),
+      tbl_assemblies("s2", path = c(1, 1), scaffold = c(1, 2), ignore = c(1, 0))
+    )
+  )
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  res <- stale_assemble_dirs(con, td)
+  expect_equal(res$ID, "s2")
+})
+
+test_that("a stale sample with no output at all reports an empty on_disk", {
+  td <- make_out_tree(fasta = list(s1 = list(opts = "default", paths = 1)))
+  on.exit(unlink(td, recursive = TRUE))
+
+  con <- make_consistency_db(
+    assemble = tbl_assemble(c("s1", "s2")),
+    assemblies = tbl_assemblies(c("s1", "s2"))
+  )
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  res <- stale_assemble_dirs(con, td)
+  expect_equal(res$ID, "s2")
+  expect_equal(res$on_disk, "")
+})
+
+test_that("every option set on disk is listed, comma separated", {
+  td <- make_out_tree(dirs = list(s1 = c("alpha", "beta")))
+  on.exit(unlink(td, recursive = TRUE))
+
+  con <- make_consistency_db(
+    assemble = tbl_assemble("s1", "gamma"),
+    assemblies = tbl_assemblies("s1")
+  )
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  res <- stale_assemble_dirs(con, td)
+  expect_equal(nrow(res), 1)
+  expect_equal(
+    sort(strsplit(res$on_disk, ", ", fixed = TRUE)[[1]]),
+    c("alpha", "beta")
+  )
+})
+
+test_that("pending_only limits the check to samples WF2 would process", {
+  td <- make_out_tree()
+  on.exit(unlink(td, recursive = TRUE))
+
+  con <- make_consistency_db(
+    assemble = rbind(
+      tbl_assemble("unlocked", assemble_lock = 0),
+      tbl_assemble("done"),
+      tbl_assemble("queued"),
+      tbl_assemble("switched_off")
+    ),
+    assemblies = tbl_assemblies(c("unlocked", "done", "queued", "switched_off")),
+    annotate = rbind(
+      tbl_annotate("unlocked"),
+      tbl_annotate("done", annotate_lock = 1),
+      tbl_annotate("queued"),
+      tbl_annotate("switched_off", annotate_switch = 0)
+    )
+  )
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  expect_equal(stale_assemble_dirs(con, td)$ID, "queued")
+  expect_equal(
+    sort(stale_assemble_dirs(con, td, pending_only = FALSE)$ID),
+    c("done", "queued", "switched_off", "unlocked")
+  )
+})
+
+test_that("ids restricts the query", {
+  td <- make_out_tree()
+  on.exit(unlink(td, recursive = TRUE))
+
+  con <- make_consistency_db(
+    assemble = tbl_assemble(c("s1", "s2", "s3")),
+    assemblies = tbl_assemblies(c("s1", "s2", "s3"))
+  )
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  expect_equal(sort(stale_assemble_dirs(con, td)$ID), c("s1", "s2", "s3"))
+  expect_equal(stale_assemble_dirs(con, td, ids = "s2")$ID, "s2")
+  expect_equal(sort(stale_assemble_dirs(con, td, ids = c("s1", "s3"))$ID), c("s1", "s3"))
+  expect_equal(nrow(stale_assemble_dirs(con, td, ids = character(0))), 0)
+  expect_equal(nrow(stale_assemble_dirs(con, td, ids = NA_character_)), 0)
+})
+
+test_that("an ID containing an apostrophe does not break the query", {
+  td <- make_out_tree()
+  on.exit(unlink(td, recursive = TRUE))
+
+  con <- make_consistency_db(
+    assemble = tbl_assemble(c("O'Brien_1", "s2")),
+    assemblies = tbl_assemblies(c("O'Brien_1", "s2"))
+  )
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  res <- stale_assemble_dirs(con, td, ids = "O'Brien_1")
+  expect_equal(res$ID, "O'Brien_1")
+  expect_equal(nrow(res), 1)
+})
+
+test_that("a sample with no assembly option set assigned is reported", {
+  td <- make_out_tree(dirs = list(s1 = "default", s2 = "default"))
+  on.exit(unlink(td, recursive = TRUE))
+
+  con <- make_consistency_db(
+    assemble = tbl_assemble(c("s1", "s2"), c(NA_character_, "")),
+    assemblies = tbl_assemblies(c("s1", "s2"))
+  )
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  res <- stale_assemble_dirs(con, td)
+  expect_equal(sort(res$ID), c("s1", "s2"))
+  expect_true(all(is.na(res$assemble_opts)))
+  expect_true(all(is.na(res$expected)))
+  expect_equal(res$on_disk, c("default", "default"))
+})
+
+test_that("an unusable dir_out is skipped without error", {
+  con <- make_consistency_db(
+    assemble = tbl_assemble("s1"),
+    assemblies = tbl_assemblies("s1")
+  )
+  on.exit(DBI::dbDisconnect(con))
+
+  for (bad in list(NA_character_, "", character(0), NULL,
+                   file.path(tempdir(), "no_such_project_dir"))) {
+    expect_equal(nrow(stale_assemble_dirs(con, bad)), 0)
+  }
+})
+
+test_that("a database without the project tables is skipped without error", {
+  td <- make_out_tree(dirs = list(s1 = "default"))
+  on.exit(unlink(td, recursive = TRUE))
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  expect_equal(nrow(stale_assemble_dirs(con, td)), 0)
+  expect_equal(nrow(stale_assemble_dirs(con, td, pending_only = FALSE)), 0)
+})
+
+test_that("assemble_dirs_on_disk lists option sets only for known samples", {
+  td <- make_out_tree(dirs = list(s1 = c("alpha", "beta")))
+  on.exit(unlink(td, recursive = TRUE))
+
+  expect_equal(sort(assemble_dirs_on_disk(td, "s1")), c("alpha", "beta"))
+  expect_equal(assemble_dirs_on_disk(td, "nope"), character(0))
+  expect_equal(assemble_dirs_on_disk(NA_character_, "s1"), character(0))
+  expect_equal(assemble_dirs_on_disk("", "s1"), character(0))
+})
+
+test_that("assemble_dirs_on_disk ignores dot-directories", {
+  td <- make_out_tree(dirs = list(s1 = c("alpha", ".nextflow", ".cache")))
+  on.exit(unlink(td, recursive = TRUE))
+
+  expect_equal(assemble_dirs_on_disk(td, "s1"), "alpha")
+})
+
+test_that("stale_assemble_items describes each stale sample", {
+  stale <- data.frame(
+    ID = c("s1", "s2", "s3"),
+    assemble_opts = c("aggressive", NA, "default"),
+    expected = c("out/s1/assemble/aggressive", NA, "out/s3/assemble/default"),
+    on_disk = c("default", "default, fast", ""),
+    stringsAsFactors = FALSE
+  )
+  txt <- vapply(stale_assemble_items(stale), as.character, character(1))
+
+  expect_length(txt, 3)
+  expect_match(txt[1], "<b>s1</b>")
+  expect_match(txt[1], "points at parameter set")
+  expect_match(txt[1], "<code>aggressive</code>")
+  expect_match(txt[1], "<code>default</code>")
+  expect_match(txt[2], "has no assembly parameter set assigned")
+  expect_match(txt[2], "<code>default, fast</code>")
+  expect_match(txt[3], "missing")
+  expect_false(grepl("<code></code>", txt[3], fixed = TRUE))
+})
+
+test_that("stale_assemble_items caps the list and counts the remainder", {
+  stale <- data.frame(
+    ID = paste0("s", 1:12),
+    assemble_opts = "default",
+    expected = "out",
+    on_disk = "",
+    stringsAsFactors = FALSE
+  )
+  items <- stale_assemble_items(stale)
+  expect_length(items, 11)
+  expect_match(as.character(items[[11]]), "... and 2 more", fixed = TRUE)
+
+  expect_length(stale_assemble_items(stale, max_items = 12L), 12)
+  expect_length(stale_assemble_items(stale[0, , drop = FALSE]), 0)
+})


### PR DESCRIPTION
## Summary

Two unrelated fixes that share a theme: state the database records disagreeing
with what is actually on disk (or in the notes field), and failing silently.

## 1. Stale `assemble_opts` pointers (`R/project_consistency.R`, new)

ASSEMBLE publishes to `out/<ID>/assemble/<assemble_opts>/`, so the option-set
name doubles as a directory name, and `assemble.assemble_opts` is a mutable
pointer that every downstream stage rebuilds the path from. Reassigning a sample
to a different option set **after** it has assembled leaves the published output
under the old name. Nothing noticed: WF2 annotate/curate/ORF, the coverage
viewer and the output-folder button all pointed somewhere that was never
created, and the run either failed obscurely or completed with no reference hits.

- `stale_assemble_dirs()` mirrors the WF2 gate exactly
  (`annotate_workflow.nf`: `assemble_lock = 1`, `ignore = 0`, annotation
  switched on and unlocked) and tests for the per-path assembly **FASTA**, not
  merely the directory, so an empty publish dir does not silence it.
- Reported at three points: **app startup** (warn, keep the app open, since
  fixing this needs the app), **at lock time** (block the affected samples, lock
  the rest, explain both remedies), and **when the parameter set is reassigned**.
- `ANNOTATE` in `annotate_workflow.nf` logs a warning naming the option-set
  directories that *do* exist. The unit is still emitted either way, so
  `annotate()` fails as loudly as it always has.
- Coverage-details reads and writes are guarded by `require_assemble_output()`,
  checked **before** anything is written so a missing output cannot leave a
  half-written Path 0 behind. It reports, never creates: a directory holding only
  the Path 0 files would look complete while the raw path assemblies stay
  orphaned.
- `browseURL()` for the coverage PDF is wrapped, since it errors outright when no
  browser is configured (headless / server).

## 2. Join-group id collision (`next_join_group()`)

`do_join_merge()` derived the next join-group id with an unanchored
`group=(\d+)` over `rv$annotations$notes`, and applied `%|NA|%` to a vector,
which is not vectorized. Two consequences: a free-text note mentioning
`group=` anywhere could inflate or steal the id, and an all-NA logical `notes`
column (a DB column holding only NULLs) errored instead of returning 1.

`next_join_group()` anchors on `^JOIN: mode=\w+ group=(\d+)`, matching the
readers in `R/export.R` and the un-join observer, and coalesces safely.

## Testing

Full `testthat` suite green. Adds:

- `test-project-consistency.R` (59 assertions): consistent projects, reassigned
  samples, empty publish dirs, multi-path samples reported once, samples that
  never assembled, all-ignored scaffolds, `pending_only` scoping, `ids`
  filtering, IDs containing apostrophes, unset option sets, unusable `dir_out`,
  and databases missing the project tables.
- `test-join-group.R` (29 assertions): round-trips markers built by
  `do_join_merge()` through the `export.R` reader, the member scan and the
  un-join stripper, including the `group=1` vs `group=10` prefix case.

## Merge notes

Merges cleanly with `wf1-scaffold-join-review` and `annotate-trim-assembly`;
full suite green on the combined tree. Suggested to merge **after**
`wf1-scaffold-join-review`: `require_assemble_output()` sits inside
`persist_path0()`, which that branch's new join-build observer calls, so merging
in this order hardens the new write path automatically.
