### PR TITLE
Annotate: trim unannotated assembly ends, with undo

### DIFF
--- a/R/app_annotate_asmb_edits.R
+++ b/R/app_annotate_asmb_edits.R
@@ -1,0 +1,455 @@
+#' Undoable assembly edits for the Annotate details modal
+#'
+#' Backs the two controls that rewrite a unit's assembly in place: "Linearize"
+#' (rotate a circular molecule and open it) and "Trim unannotated ends" (cut a
+#' linear molecule back to its outermost annotated feature). Both snapshot the
+#' unit before their first edit so "Restore assembly" can put it back.
+#'
+#' Tracking follows the Linearize precedent: the `assemblies` row and the unit's
+#' on-disk annotate artifacts are rewritten together and an "EDITED:" note goes
+#' into `annotate.annotate_notes`, which VALIDATE strips when WF2 regenerates the
+#' assembly. Export needs no changes - it reads `assemblies.sequence` through
+#' [get_assembly()] and coordinates from `annotations`, so both follow.
+#'
+#' @noRd
+
+#' DDL for the pre-edit snapshot table.
+#' A row exists only while a unit carries an un-restored edit.
+#' @noRd
+ASSEMBLY_BACKUP_DDL <- "CREATE TABLE IF NOT EXISTS assembly_backup (
+  ID TEXT NOT NULL,
+  path INTEGER NOT NULL,
+  scaffold INTEGER NOT NULL,
+  sequence TEXT,
+  length INTEGER,
+  topology TEXT,
+  depth TEXT,
+  gc TEXT,
+  errors TEXT,
+  annotations TEXT,
+  coverage TEXT,
+  annotate_length INTEGER,
+  annotate_topology TEXT,
+  annotate_structure TEXT,
+  ops TEXT,
+  time_stamp INTEGER,
+  PRIMARY KEY (ID, path, scaffold)
+);"
+
+#' Create the snapshot table if it is missing (idempotent).
+#' @noRd
+ensure_assembly_backup <- function(con) {
+  DBI::dbExecute(con, ASSEMBLY_BACKUP_DDL)
+  invisible()
+}
+
+#' The edits recorded against this unit, or character(0) if it is unedited.
+#'
+#' Read-only on purpose, so callers outside the app's write path never create a
+#' table as a side effect of asking a question.
+#' @noRd
+assembly_backup_ops <- function(con, id, path, scaffold) {
+  tryCatch({
+    if (!DBI::dbExistsTable(con, "assembly_backup")) return(character(0))
+    ops <- DBI::dbGetQuery(
+      con,
+      "SELECT ops FROM assembly_backup WHERE ID = ? AND path = ? AND scaffold = ?",
+      params = list(as.character(id), as.integer(path), as.integer(scaffold))
+    )$ops
+    if (length(ops) == 0) return(character(0))
+    strsplit(ops[1] %|NA|% "", "\\+")[[1]]
+  }, error = function(e) character(0))
+}
+
+#' Does this unit have an edit that could be restored?
+#' @noRd
+has_assembly_backup <- function(con, id, path, scaffold) {
+  length(assembly_backup_ops(con, id, path, scaffold)) > 0
+}
+
+#' Path to a unit's annotate-stage assembly FASTA / coverage CSV.
+#' @noRd
+unit_annotate_file <- function(dir_out, id, path, scaffold, what) {
+  file.path(
+    dir_out, id, "annotate",
+    paste0(id, "_", what, "_", path, "_", scaffold,
+           if (what == "assembly") ".fasta" else ".csv")
+  )
+}
+
+#' Resolve a unit's coverage CSV the way the annotate modal's loader does
+#'
+#' Per-unit name first, then the legacy single-file fallback. Mirroring the
+#' loader matters: if the two disagree, the plot shows one file's depths while an
+#' edit rewrites another's.
+#' @noRd
+resolve_unit_coverage_file <- function(dir_out, id, path, scaffold) {
+  f <- unit_annotate_file(dir_out, id, path, scaffold, "coverageStats")
+  if (file.exists(f)) return(f)
+  alt <- list.files(file.path(dir_out, id, "annotate"),
+                    pattern = "coverageStats", full.names = TRUE)
+  if (length(alt) > 0) alt[1] else f
+}
+
+#' Render one coverage-CSV column into an `assemblies` per-position string
+#'
+#' Byte-for-byte what VALIDATE writes (`rows.collect{...}.join(' ')`), including
+#' the `#` outlier-mask prefixes and the empty slots the GC rolling window leaves
+#' at both ends. Rebuilding from the (already trimmed) CSV keeps the two records
+#' in step; slicing the stored string could not, because that join is lossy - a
+#' run of empty GC cells collapses to one separator, so position is unrecoverable.
+#' @noRd
+cov_column_string <- function(v) {
+  if (is.null(v) || length(v) == 0) return(NA_character_)
+  v <- as.character(v)
+  v[is.na(v)] <- ""
+  paste(v, collapse = " ")
+}
+
+#' Slice one of the space-separated per-position strings in `assemblies`
+#' (depth / gc / errors). Fallback for units with no coverage CSV on disk.
+#'
+#' A vector whose element count does not match the sequence has already lost its
+#' position mapping, and keeping a full-length one against a shortened sequence
+#' would silently mis-register the Assemble coverage view. Blank it instead:
+#' absent reads as absent, stale reads as truth.
+#' @noRd
+slice_cov_string <- function(x, from, to, n) {
+  if (is.null(x) || length(x) == 0 || is.na(x) || !nzchar(x)) return(NA_character_)
+  v <- strsplit(trimws(x), "\\s+")[[1]]
+  if (length(v) != n) return(NA_character_)
+  paste(v[from:to], collapse = " ")
+}
+
+#' Write the unit's annotate-stage FASTA (the copy Linearize keeps in step).
+#' @noRd
+write_unit_assembly_fasta <- function(dir_out, id, path, scaffold, seq, topology) {
+  fa <- unit_annotate_file(dir_out, id, path, scaffold, "assembly")
+  if (!dir.exists(dirname(fa))) return(invisible(NULL))
+  ss <- Biostrings::DNAStringSet(as.character(seq))
+  names(ss) <- paste0(id, ".", path, ".", scaffold, " ", topology %|NA|% "linear")
+  Biostrings::writeXStringSet(ss, fa)
+  invisible(fa)
+}
+
+#' Snapshot a unit before its first destructive edit
+#'
+#' Records the sequence, the per-position depth/gc/error strings, every
+#' annotation row, the coverage CSV and the denormalized `annotate` fields, so
+#' [restore_assembly_unit()] can put all of them back. Only the FIRST edit writes
+#' the snapshot; later edits just append their name to `ops`, so linearize then
+#' trim then restore returns to the pipeline's own output.
+#'
+#' @param op Short name of the edit being applied ("linearize", "trim").
+#' @noRd
+snapshot_assembly_unit <- function(con, id, path, scaffold, dir_out, op) {
+  id <- as.character(id); path <- as.integer(path); scaffold <- as.integer(scaffold)
+  key <- list(id, path, scaffold)
+  ensure_assembly_backup(con)
+
+  ops <- assembly_backup_ops(con, id, path, scaffold)
+  if (length(ops) > 0) {
+    if (!(op %in% ops)) {
+      DBI::dbExecute(
+        con,
+        "UPDATE assembly_backup SET ops = ? WHERE ID = ? AND path = ? AND scaffold = ?",
+        params = list(paste(c(ops, op), collapse = "+"), id, path, scaffold)
+      )
+    }
+    return(invisible(FALSE))
+  }
+
+  asm <- DBI::dbGetQuery(
+    con,
+    "SELECT sequence, length, topology, depth, gc, errors FROM assemblies
+     WHERE ID = ? AND path = ? AND scaffold = ?",
+    params = key
+  )
+  ann <- DBI::dbGetQuery(
+    con, "SELECT * FROM annotations WHERE ID = ? AND path = ? AND scaffold = ?",
+    params = key
+  )
+  meta <- DBI::dbGetQuery(
+    con, "SELECT length, topology, structure FROM annotate
+          WHERE ID = ? AND path = ? AND scaffold = ?",
+    params = key
+  )
+  cov_fn <- resolve_unit_coverage_file(dir_out, id, path, scaffold)
+  cov <- if (file.exists(cov_fn)) tryCatch(utils::read.csv(cov_fn), error = function(e) NULL) else NULL
+
+  DBI::dbExecute(
+    con,
+    "INSERT INTO assembly_backup
+       (ID, path, scaffold, sequence, length, topology, depth, gc, errors,
+        annotations, coverage, annotate_length, annotate_topology,
+        annotate_structure, ops, time_stamp)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    params = list(
+      id, path, scaffold, asm$sequence[1], asm$length[1], asm$topology[1],
+      asm$depth[1], asm$gc[1], asm$errors[1],
+      as.character(jsonlite::toJSON(ann, dataframe = "rows", na = "null")),
+      if (!is.null(cov)) as.character(jsonlite::toJSON(cov, dataframe = "rows", na = "null")) else NA_character_,
+      if (nrow(meta)) meta$length[1] else NA_integer_,
+      if (nrow(meta)) meta$topology[1] else NA_character_,
+      if (nrow(meta)) meta$structure[1] else NA_character_,
+      op, as.integer(Sys.time())
+    )
+  )
+  invisible(TRUE)
+}
+
+#' How much unannotated flank a unit carries
+#'
+#' Always reports `topology` and `length` when the unit exists, so a caller can
+#' gate on topology even for a unit with no feature model yet. `from`/`to` are
+#' the outermost annotated positions and `lead`/`trail` the bp outside them; all
+#' four are NA when the unit has no annotations.
+#'
+#' @return list(length, topology, from, to, lead, trail), or NULL if the unit has
+#'   no assembly row.
+#' @noRd
+unannotated_ends <- function(con, id, path, scaffold) {
+  key <- list(as.character(id), as.integer(path), as.integer(scaffold))
+  asm <- DBI::dbGetQuery(
+    con, "SELECT length, topology FROM assemblies WHERE ID = ? AND path = ? AND scaffold = ?",
+    params = key
+  )
+  if (nrow(asm) == 0 || is.na(asm$length[1])) return(NULL)
+  n <- as.integer(asm$length[1])
+  out <- list(length = n, topology = asm$topology[1],
+              from = NA_integer_, to = NA_integer_,
+              lead = NA_integer_, trail = NA_integer_)
+  sp <- DBI::dbGetQuery(
+    con,
+    "SELECT MIN(pos1) a, MAX(pos2) b FROM annotations
+     WHERE ID = ? AND path = ? AND scaffold = ? AND pos1 > 0",
+    params = key
+  )
+  if (nrow(sp) == 0 || is.na(sp$a[1])) return(out)
+  out$from <- as.integer(sp$a[1])
+  out$to <- min(as.integer(sp$b[1]), n)
+  out$lead <- out$from - 1L
+  out$trail <- n - out$to
+  out
+}
+
+#' Cut a linear unit back to its outermost annotated feature
+#'
+#' Rewrites `assemblies` (sequence, length, per-position depth/gc/error strings),
+#' shifts every live annotation by the same offset, rewrites the unit's
+#' annotate-stage FASTA + coverage CSV, drops the now-stale cached reference
+#' alignment, and updates `annotate.length`. No feature is ever dropped or cut,
+#' so counts, spans and `annotate.structure` are unchanged by construction.
+#'
+#' @return list(length, removed_lead, removed_trail)
+#' @noRd
+trim_assembly_ends <- function(con, id, path, scaffold, dir_out) {
+  id <- as.character(id); path <- as.integer(path); scaffold <- as.integer(scaffold)
+  key <- list(id, path, scaffold)
+
+  asm <- DBI::dbGetQuery(
+    con,
+    "SELECT sequence, topology, depth, gc, errors FROM assemblies
+     WHERE ID = ? AND path = ? AND scaffold = ?",
+    params = key
+  )
+  if (nrow(asm) == 0 || is.na(asm$sequence[1]) || !nzchar(asm$sequence[1])) {
+    stop("No sequence on record for unit ", id, ".", path, ".", scaffold, call. = FALSE)
+  }
+  if (identical(asm$topology[1], "circular")) {
+    stop("Circular assemblies cannot be trimmed. Linearize first.", call. = FALSE)
+  }
+  n <- nchar(asm$sequence[1])
+
+  ends <- unannotated_ends(con, id, path, scaffold)
+  if (is.null(ends) || is.na(ends$from)) {
+    stop("This unit has no annotations to trim to.", call. = FALSE)
+  }
+  from <- ends$from
+  to <- min(ends$to, n)
+  if (from <= 1L && to >= n) {
+    stop("The annotations already span the whole assembly; nothing to trim.", call. = FALSE)
+  }
+
+  cov_fn <- resolve_unit_coverage_file(dir_out, id, path, scaffold)
+  cov <- if (file.exists(cov_fn)) tryCatch(utils::read.csv(cov_fn), error = function(e) NULL) else NULL
+  if (!is.null(cov) && nrow(cov) > 0) {
+    # A userAsmb unit's CSV concatenates every contig of the path with restarting
+    # Positions, so row i is not base i of this scaffold.
+    if ("SeqId" %in% names(cov) && dplyr::n_distinct(cov$SeqId) > 1) {
+      stop(
+        "This unit's coverage file covers more than one contig, so its depth ",
+        "track cannot be trimmed with the sequence. Trimming is not supported ",
+        "for user-supplied multi-contig assemblies.",
+        call. = FALSE
+      )
+    }
+    pos_ok <- "Position" %in% names(cov) &&
+      identical(as.integer(cov$Position), seq_len(nrow(cov)))
+    if (nrow(cov) != n || !pos_ok) {
+      stop(
+        "The coverage track (", nrow(cov), " positions) does not line up with ",
+        "the assembly (", n, " bp), so trimming would desynchronize them. ",
+        "Re-run the annotation workflow for this sample first.",
+        call. = FALSE
+      )
+    }
+  }
+
+  snapshot_assembly_unit(con, id, path, scaffold, dir_out, "trim")
+
+  new_seq <- substr(asm$sequence[1], from, to)
+  new_len <- nchar(new_seq)
+
+  # Cut the coverage track first: the per-position strings in `assemblies` are
+  # rebuilt from it, exactly as VALIDATE builds them.
+  if (!is.null(cov) && nrow(cov) > 0) {
+    cov <- cov[from:to, , drop = FALSE]
+    cov$Position <- seq_len(nrow(cov))
+    # quote = "none", na = "" matches every other coverageStats writer; the Groovy
+    # parsers in curate/validate split on bare commas and choke otherwise.
+    readr::write_csv(cov, cov_fn, quote = "none", na = "")
+    new_depth  <- cov_column_string(cov$MeanDepth)
+    new_gc     <- cov_column_string(cov$GC)
+    new_errors <- cov_column_string(cov$ErrorRate)
+  } else {
+    new_depth  <- slice_cov_string(asm$depth[1], from, to, n)
+    new_gc     <- slice_cov_string(asm$gc[1], from, to, n)
+    new_errors <- slice_cov_string(asm$errors[1], from, to, n)
+  }
+
+  DBI::dbExecute(
+    con,
+    "UPDATE assemblies SET sequence = ?, length = ?, depth = ?, gc = ?, errors = ?,
+       edited = 1, time_stamp = ? WHERE ID = ? AND path = ? AND scaffold = ?",
+    params = list(
+      new_seq, new_len, new_depth, new_gc, new_errors,
+      as.integer(Sys.time()), id, path, scaffold
+    )
+  )
+
+  if (from > 1L) {
+    ann <- DBI::dbGetQuery(
+      con, "SELECT * FROM annotations WHERE ID = ? AND path = ? AND scaffold = ?",
+      params = key
+    )
+    # Shift live features by a constant. Soft-deleted rows (pos1 = pos2 = 0) are
+    # tombstones, not coordinates, and must stay at zero.
+    idx <- !is.na(ann$pos1) & ann$pos1 > 0
+    if (any(idx)) {
+      ann$pos1[idx] <- ann$pos1[idx] - from + 1L
+      ann$pos2[idx] <- ann$pos2[idx] - from + 1L
+      # Delete + reinsert, never UPDATE: pos1 is part of the primary key, so an
+      # in-place shift can transiently collide with a same-named sibling feature.
+      DBI::dbExecute(
+        con, "DELETE FROM annotations WHERE ID = ? AND path = ? AND scaffold = ?",
+        params = key
+      )
+      DBI::dbAppendTable(con, "annotations", ann)
+    }
+  }
+
+  drop_stale_ref_alignment(con, id, path, scaffold)
+  write_unit_assembly_fasta(dir_out, id, path, scaffold, new_seq, asm$topology[1])
+
+  DBI::dbExecute(
+    con, "UPDATE annotate SET length = ? WHERE ID = ? AND path = ? AND scaffold = ?",
+    params = list(new_len, id, path, scaffold)
+  )
+
+  list(length = new_len, removed_lead = from - 1L, removed_trail = n - to)
+}
+
+#' Drop a unit's cached reference alignment
+#'
+#' `blast_ref_alignment` holds a gapped whole-genome alignment computed against
+#' the stored sequence; the synteny view projects sample coordinates through it.
+#' Any edit to the sequence invalidates it, and nothing in the app rebuilds it,
+#' so delete rather than let the panel silently mis-register. WF1's backfill is
+#' NOT EXISTS-guarded, so the next pipeline run regenerates it.
+#' @noRd
+drop_stale_ref_alignment <- function(con, id, path, scaffold) {
+  tryCatch(
+    DBI::dbExecute(
+      con,
+      "DELETE FROM blast_ref_alignment WHERE ID = ? AND path = ? AND scaffold = ?",
+      params = list(as.character(id), as.integer(path), as.integer(scaffold))
+    ),
+    error = function(e) NULL
+  )
+  invisible()
+}
+
+#' Undo every in-app edit to a unit's assembly
+#'
+#' Writes back the snapshot taken before the first edit: sequence, length,
+#' topology, the per-position strings, all annotation rows, the coverage CSV, the
+#' annotate-stage FASTA and the denormalized `annotate` fields. The snapshot is
+#' dropped, so the unit is unedited again.
+#'
+#' @return (invisibly) list(length, topology, ops)
+#' @noRd
+restore_assembly_unit <- function(con, id, path, scaffold, dir_out) {
+  id <- as.character(id); path <- as.integer(path); scaffold <- as.integer(scaffold)
+  key <- list(id, path, scaffold)
+  if (!tryCatch(DBI::dbExistsTable(con, "assembly_backup"), error = function(e) FALSE)) {
+    stop("This unit has no recorded edit to undo.", call. = FALSE)
+  }
+  bak <- DBI::dbGetQuery(
+    con, "SELECT * FROM assembly_backup WHERE ID = ? AND path = ? AND scaffold = ?",
+    params = key
+  )
+  if (nrow(bak) == 0 || is.na(bak$sequence[1])) {
+    stop("This unit has no recorded edit to undo.", call. = FALSE)
+  }
+
+  DBI::dbExecute(
+    con,
+    "UPDATE assemblies SET sequence = ?, length = ?, topology = ?, depth = ?, gc = ?,
+       errors = ?, time_stamp = ? WHERE ID = ? AND path = ? AND scaffold = ?",
+    params = list(
+      bak$sequence[1], bak$length[1], bak$topology[1],
+      bak$depth[1], bak$gc[1], bak$errors[1],
+      as.integer(Sys.time()), id, path, scaffold
+    )
+  )
+
+  DBI::dbExecute(
+    con, "DELETE FROM annotations WHERE ID = ? AND path = ? AND scaffold = ?",
+    params = key
+  )
+  if (!is.na(bak$annotations[1]) && nzchar(bak$annotations[1])) {
+    ann <- jsonlite::fromJSON(bak$annotations[1])
+    if (is.data.frame(ann) && nrow(ann) > 0) DBI::dbAppendTable(con, "annotations", ann)
+  }
+
+  cov_fn <- resolve_unit_coverage_file(dir_out, id, path, scaffold)
+  if (!is.na(bak$coverage[1]) && nzchar(bak$coverage[1]) && dir.exists(dirname(cov_fn))) {
+    cov <- jsonlite::fromJSON(bak$coverage[1])
+    if (is.data.frame(cov) && nrow(cov) > 0) {
+      readr::write_csv(cov, cov_fn, quote = "none", na = "")
+    }
+  }
+
+  write_unit_assembly_fasta(dir_out, id, path, scaffold, bak$sequence[1], bak$topology[1])
+  drop_stale_ref_alignment(con, id, path, scaffold)
+
+  DBI::dbExecute(
+    con,
+    "UPDATE annotate SET length = ?, topology = ?, structure = ?
+     WHERE ID = ? AND path = ? AND scaffold = ?",
+    params = list(bak$annotate_length[1], bak$annotate_topology[1],
+                  bak$annotate_structure[1], id, path, scaffold)
+  )
+
+  DBI::dbExecute(
+    con, "DELETE FROM assembly_backup WHERE ID = ? AND path = ? AND scaffold = ?",
+    params = key
+  )
+  invisible(list(
+    length = bak$length[1],
+    topology = bak$topology[1],
+    annotate_topology = bak$annotate_topology[1],
+    ops = strsplit(bak$ops[1] %|NA|% "", "\\+")[[1]]
+  ))
+}

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -2611,6 +2611,13 @@ annotations_details_server <- function(id, rv) {
         req(F)
       }
 
+      ## Snapshot before the first edit, so "Restore assembly" can undo this ----
+      # After every guard above, so an aborted linearize records nothing.
+      snapshot_assembly_unit(
+        session$userData$con, rv$updating$ID, rv$updating$path, rv$updating$scaffold,
+        session$userData$dir_out, "linearize"
+      )
+
       ## Get Sequence ----
       assembly <- get_assembly(
         ID = rv$annotations$ID[selected()],
@@ -2710,7 +2717,217 @@ annotations_details_server <- function(id, rv) {
           rv$updating[, c("ID", "path", "scaffold", "topology", "annotate_notes")],
           by = c("ID", "path", "scaffold")
         )
+      # Reveal Restore, and re-measure the flanks the assembly now has as a
+      # linear molecule (Trim is only available once it is linear).
+      bump_asmb_edit()
     }) # END LINEARIZE
+
+    # Assembly edits: trim unannotated ends / restore ----
+    # Trimming is fixed to the outermost annotated feature, so no feature is ever
+    # dropped or cut and the counts, spans and gene order all stay valid. Export
+    # already does this cut in memory for linear units (R/export.R); doing it
+    # here makes it visible, undoable, and applied to everything the app shows.
+
+    # Bumped by each edit so the controls re-read the DB even when the edit does
+    # not otherwise change rv$updating.
+    asmb_edit_tick <- reactiveVal(0)
+    bump_asmb_edit <- function() asmb_edit_tick(isolate(asmb_edit_tick()) + 1)
+
+    # Everything the controls need, read from the DB rather than tracked in a
+    # reactiveVal: a manually refreshed value would depend on gargoyle observer
+    # ordering to be correct at first render. Topology comes from `assemblies`,
+    # which is the row a trim actually cuts.
+    asmb_state <- reactive({
+      asmb_edit_tick()
+      u <- rv$updating
+      req(!is.null(u), !is.null(u$ID), length(u$ID) == 1)
+      con <- session$userData$con
+      ends <- tryCatch(unannotated_ends(con, u$ID, u$path, u$scaffold),
+                       error = function(e) NULL)
+      list(
+        ends = ends,
+        edited = tryCatch(has_assembly_backup(con, u$ID, u$path, u$scaffold),
+                          error = function(e) FALSE)
+      )
+    })
+
+    # Rendered reactively so linearizing a circular assembly enables Trim, and
+    # applying either edit reveals Restore, without reopening the modal.
+    output$asmb_edit_controls <- renderUI({
+      st <- asmb_state()
+      e <- st$ends
+      reason <- if (is.null(e)) {
+        "This unit has no assembly on record."
+      } else if (!isTRUE(e$topology == "linear")) {
+        "Only linear assemblies can be trimmed. Linearize a circular assembly first."
+      } else if (is.na(e$from)) {
+        "This unit has no annotations to trim to."
+      } else if (e$lead + e$trail == 0L) {
+        "The annotations already span the whole assembly; nothing to trim."
+      } else {
+        NA_character_
+      }
+      lbl <- if (is.na(reason)) {
+        stringr::str_glue(
+          "Trim unannotated ends ({format(e$lead + e$trail, big.mark = ',')} bp)"
+        )
+      } else {
+        "Trim unannotated ends"
+      }
+      tagList(
+        if (is.na(reason)) {
+          actionButton(ns("trim_ends"), lbl, icon = icon("scissors"))
+        } else {
+          tags$span(
+            title = reason,
+            actionButton(ns("trim_ends"), lbl, icon = icon("scissors")) |>
+              shinyjs::disabled()
+          )
+        },
+        if (isTRUE(st$edited)) {
+          actionButton(ns("restore_asmb"), "Restore assembly", icon = icon("rotate-left"))
+        }
+      )
+    })
+
+    observeEvent(input$trim_ends, {
+      req(rv$updating$ID)
+      e <- asmb_state()$ends
+      if (is.null(e) || !isTRUE(e$topology == "linear") || is.na(e$from) ||
+          (e$lead + e$trail) == 0L) {
+        shinyWidgets::sendSweetAlert(title = "Nothing to trim.")
+        req(F)
+      }
+      shinyWidgets::confirmSweetAlert(
+        inputId = ns("trim_ends_confirm"),
+        title = "Trim unannotated ends?",
+        text = stringr::str_glue(
+          "Removes {e$lead} bp before the first annotation and {e$trail} bp after ",
+          "the last, leaving {format(e$to - e$from + 1, big.mark = ',')} bp. ",
+          "Feature coordinates and the coverage track shift to match. ",
+          "Use \"Restore assembly\" to undo."
+        ),
+        type = "warning",
+        btn_labels = c("Cancel", "Trim"),
+        btn_colors = c("#6c757d", "#d9534f")
+      )
+    })
+
+    observeEvent(input$trim_ends_confirm, ignoreNULL = TRUE, {
+      req(isTRUE(input$trim_ends_confirm))
+      u <- rv$updating
+      res <- tryCatch(
+        trim_assembly_ends(
+          session$userData$con, u$ID, u$path, u$scaffold, session$userData$dir_out
+        ),
+        error = function(e) {
+          shinyWidgets::sendSweetAlert(title = "Trim failed", text = conditionMessage(e))
+          NULL
+        }
+      )
+      req(res)
+      note <- stringr::str_glue(
+        "EDITED: trimmed {res$removed_lead} bp and {res$removed_trail} bp of ",
+        "unannotated ends ({res$length} bp remaining)"
+      )
+      cur_notes <- (input$notes %||% rv$updating$annotate_notes) %|NA|% ""
+      rv$updating$annotate_notes <- stringr::str_remove(
+        paste(note, cur_notes, sep = "; "), "; $"
+      )
+      rv$updating$length <- res$length
+      bump_asmb_edit()
+      update_annotate_unit(c("length", "annotate_notes"))
+      rv$data <- rv$data |>
+        dplyr::rows_update(
+          rv$updating[, c("ID", "path", "scaffold", "length", "annotate_notes")],
+          by = c("ID", "path", "scaffold")
+        )
+      trigger("update_annotate_table")
+      trigger("refresh_export")
+      # Full reload: annotations, coverage and every figure come off the trimmed
+      # record, and the reopened modal shows the new coordinates.
+      trigger("annotations_modal")
+      showNotification(
+        stringr::str_glue(
+          "Trimmed {res$removed_lead + res$removed_trail} bp of unannotated ends; ",
+          "assembly is now {format(res$length, big.mark = ',')} bp."
+        ),
+        type = "message"
+      )
+    })
+
+    observeEvent(input$restore_asmb, {
+      ops <- assembly_backup_ops(
+        session$userData$con, rv$updating$ID, rv$updating$path, rv$updating$scaffold
+      )
+      shinyWidgets::confirmSweetAlert(
+        inputId = ns("restore_asmb_confirm"),
+        title = "Restore assembly?",
+        text = paste0(
+          "This undoes the in-app assembly edits for this unit (",
+          paste(ops, collapse = ", "),
+          ") and puts back the sequence and feature model as the pipeline left ",
+          "them. Annotation edits made since then are lost."
+        ),
+        type = "warning",
+        btn_labels = c("Cancel", "Restore"),
+        btn_colors = c("#6c757d", "#0056b3")
+      )
+    })
+
+    observeEvent(input$restore_asmb_confirm, ignoreNULL = TRUE, {
+      req(isTRUE(input$restore_asmb_confirm))
+      u <- rv$updating
+      res <- tryCatch(
+        restore_assembly_unit(
+          session$userData$con, u$ID, u$path, u$scaffold, session$userData$dir_out
+        ),
+        error = function(e) {
+          shinyWidgets::sendSweetAlert(title = "Restore failed", text = conditionMessage(e))
+          NULL
+        }
+      )
+      req(res)
+      # Read back the restored annotate row rather than reconstruct it, so the
+      # table shows exactly what the DB now holds.
+      meta <- DBI::dbGetQuery(
+        session$userData$con,
+        "SELECT length, topology, structure FROM annotate
+         WHERE ID = ? AND path = ? AND scaffold = ?",
+        params = list(as.character(u$ID), as.integer(u$path), as.integer(u$scaffold))
+      )
+      # Restore undoes every edit, so drop every auto-generated note; keep what
+      # the user typed.
+      kept <- ((input$notes %||% rv$updating$annotate_notes) %|NA|% "") |>
+        stringr::str_split("; ") |>
+        unlist()
+      kept <- kept[!stringr::str_detect(kept, "^EDITED: ")]
+      rv$updating$annotate_notes <- paste(kept[nzchar(kept)], collapse = "; ")
+      cols <- c("length", "annotate_notes")
+      if (nrow(meta) > 0) {
+        rv$updating$length <- meta$length[1]
+        rv$updating$topology <- meta$topology[1]
+        rv$updating$structure <- meta$structure[1]
+        cols <- c("length", "topology", "structure", "annotate_notes")
+      }
+      bump_asmb_edit()
+      update_annotate_unit(cols)
+      rv$data <- rv$data |>
+        dplyr::rows_update(
+          rv$updating[, c("ID", "path", "scaffold", cols)],
+          by = c("ID", "path", "scaffold")
+        )
+      trigger("update_annotate_table")
+      trigger("refresh_export")
+      trigger("annotations_modal")
+      showNotification(
+        stringr::str_glue(
+          "Assembly restored ({format(res$length, big.mark = ',')} bp, ",
+          "{res$topology %|NA|% 'unknown'})."
+        ),
+        type = "message"
+      )
+    })
 
     # Mark ID verified ----
     observeEvent(input$ID_verified, {
@@ -4961,19 +5178,43 @@ annotate_details_modal <- function(rv, session = getDefaultReactiveDomain()) {
         width = "100%"
       )
     ),
-    footer = tagList(
-      if (isTRUE(session$userData$in_outlier_review)) {
-        actionButton(
-          ns("back_to_review"), "Back to Review",
-          icon = icon("arrow-left"),
-          class = "btn-success",
-          style = "float: left;"
+    # Two-row footer: up to ten controls no longer fit on one line once the trim
+    # button carries its bp count. Row 1 is the assembly-level edits, row 2 the
+    # unit's status flags (left) and the ways out (right). The uiOutputs use
+    # display:contents so their buttons are flex items of the row rather than one
+    # lump, and so the row's gap applies between them.
+    footer = div(
+      class = "annotate-footer-rows",
+      style = "display:flex; flex-direction:column; gap:6px; width:100%;",
+      div(
+        style = "display:flex; flex-wrap:wrap; gap:6px; justify-content:flex-start;",
+        actionButton(ns("linearize"), "Linearize",
+                     icon = icon("arrows-left-right-to-line")),
+        uiOutput(ns("asmb_edit_controls"), inline = TRUE, style = "display:contents;")
+      ),
+      div(
+        style = paste(
+          "display:flex; flex-wrap:wrap; gap:6px;",
+          "justify-content:space-between; align-items:center;"
+        ),
+        div(
+          style = "display:flex; flex-wrap:wrap; gap:6px;",
+          uiOutput(ns("status_toggles"), inline = TRUE, style = "display:contents;")
+        ),
+        div(
+          style = "display:flex; flex-wrap:wrap; gap:6px;",
+          if (isTRUE(session$userData$in_outlier_review)) {
+            actionButton(
+              ns("back_to_review"), "Back to Review",
+              icon = icon("arrow-left"),
+              class = "btn-success"
+            )
+          },
+          actionButton(ns("lock"), "Lock & Close", icon = icon("lock"),
+                       class = "btn-primary"),
+          actionButton(ns("close"), "Close")
         )
-      },
-      uiOutput(ns("status_toggles"), inline = TRUE),
-      actionButton(ns("linearize"), "Linearize"),
-      actionButton(ns("lock"), "Lock & Close"),
-      actionButton(ns("close"), "Close")
+      )
     )
   )
 }

--- a/R/backwards_compatibility.R
+++ b/R/backwards_compatibility.R
@@ -177,6 +177,7 @@ backwards_compatibility <- function(
       "partial_stop" %in% DBI::dbListFields(con, "annotations") &&
       "blast_ref_annotations" %in% DBI::dbListTables(con) &&
       "blast_ref_alignment" %in% DBI::dbListTables(con) &&
+      "assembly_backup" %in% DBI::dbListTables(con) &&
       isTRUE(tryCatch(
         "use_orffinder" %in% DBI::dbListFields(con, "orf_opts"),
         error = function(e) FALSE
@@ -1478,6 +1479,12 @@ backwards_compatibility <- function(
         copy = TRUE,
         by = "blast_opts"
       )
+  }
+
+  # if the pre-trim snapshot table doesn't exist, create it
+  if (!("assembly_backup" %in% DBI::dbListTables(con))) {
+    message("created assembly_backup table")
+    DBI::dbExecute(con, ASSEMBLY_BACKUP_DDL)
   }
 
   # if edit_positions column doesn't exist in assemblies, add it

--- a/R/init_db.R
+++ b/R/init_db.R
@@ -675,6 +675,9 @@ new_db <- function(
     );"
   )
 
+  # Pre-edit snapshots for the annotate modal's "Restore assembly"
+  DBI::dbExecute(con, ASSEMBLY_BACKUP_DDL)
+
   DBI::dbExecute(
     con,
     "CREATE TABLE blast_ref_annotations (

--- a/R/init_db_userAsmb.R
+++ b/R/init_db_userAsmb.R
@@ -633,6 +633,9 @@ new_db_userAsmb <- function(
     );"
   )
 
+  # Pre-edit snapshots for the annotate modal's "Restore assembly"
+  DBI::dbExecute(con, ASSEMBLY_BACKUP_DDL)
+
   DBI::dbExecute(
     con,
     "CREATE TABLE blast_ref_annotations (

--- a/inst/app/www/custom.css
+++ b/inst/app/www/custom.css
@@ -129,6 +129,13 @@ details[open] summary {
   border: 1px solid #ccc; /* Optional border around the circle */
 }
 
+/* Two-row modal footer (annotate details). Bootstrap gives adjacent footer
+   buttons a left margin, which double-spaces them against the flex gap and
+   also indents the first button of each row group. */
+.annotate-footer-rows .btn + .btn {
+  margin-left: 0;
+}
+
 .modal-lg {
   width: auto !important;
   min-width: 800px !important;


### PR DESCRIPTION
## Summary

Adds **Trim unannotated ends** and **Restore assembly** to the Annotate details
modal, and puts the existing **Linearize** control under the same undo.

Export already trims unannotated ends in memory for linear units
(`R/export.R`). Doing the cut here makes it visible, undoable, and applied to
everything the app shows rather than only to what is submitted.

## Assembly edits (`R/app_annotate_asmb_edits.R`, new)

- **Trim** cuts a linear unit back to its outermost annotated feature. Because
  the boundary is a feature boundary, no feature is ever dropped or cut, so
  counts, spans and `annotate.structure` are unchanged by construction.
  `assemblies` (sequence, length, per-position depth/gc/error strings) is
  rewritten, every live annotation shifts by the same offset, the unit's
  annotate-stage FASTA and coverage CSV are rewritten, the stale cached
  reference alignment is dropped, and `annotate.length` is updated.
- **Restore** writes back the snapshot taken before the *first* edit, so
  linearize -> trim -> restore returns to the pipeline's own output. Later edits
  only append their name to `ops`.
- Snapshots live in a new `assembly_backup` table; a row exists only while a
  unit carries an un-restored edit. Created in `init_db.R`,
  `init_db_userAsmb.R` and `backwards_compatibility()` (added to the
  up-to-date check).

### Guards

- Circular units are refused (linearize first); the button explains why.
- The coverage track must line up with the assembly (`nrow == length`,
  `Position == 1..n`) or the trim is refused rather than desynchronizing them.
- A userAsmb unit whose CSV concatenates several contigs with restarting
  `Position` values is refused outright.
- Soft-deleted annotations (`pos1 = pos2 = 0`) are tombstones and stay at zero.
- Annotations are delete-then-reinsert rather than updated in place, since
  `pos1` is part of the primary key and an in-place shift can transiently
  collide with a same-named sibling feature.
- Per-position strings are rebuilt from the (already trimmed) coverage CSV
  byte-for-byte the way VALIDATE writes them. Slicing the stored string could not
  work: that join is lossy, since a run of empty GC cells collapses to one
  separator. Where no CSV exists, a length-mismatched vector is blanked rather
  than kept against a shortened sequence.
- `blast_ref_alignment` rows are deleted on any edit. The synteny view projects
  sample coordinates through that alignment and nothing in the app rebuilds it,
  so it would silently mis-register. WF1's backfill is `NOT EXISTS`-guarded, so
  the next pipeline run regenerates it.

## UI

The controls read their state from the database rather than a tracked
`reactiveVal`, so linearizing a circular assembly enables Trim and applying
either edit reveals Restore without reopening the modal, and the first render
does not depend on gargoyle observer ordering. The trim button carries its bp
count; a disabled button carries the reason as a tooltip.

The modal footer becomes two rows: assembly-level edits on top, status flags and
the ways out below. Ten controls no longer fit on one line once the trim button
carries its count.

## Testing

Full `testthat` suite green (no regressions). **This branch adds no tests of its
own** - see below.

## Known gaps

- **No test coverage.** `trim_assembly_ends()`, `restore_assembly_unit()`,
  `snapshot_assembly_unit()` and the pure helpers (`unannotated_ends()`,
  `slice_cov_string()`, `cov_column_string()`) are all directly testable against
  an in-memory SQLite fixture, the way `test-project-consistency.R` does it.
  Worth adding before merge.
- `unannotated_ends()` takes `MIN(pos1)` / `MAX(pos2)`, but in this schema
  `pos1 > pos2` means a feature wraps the circular origin. Trim is gated to
  `topology == "linear"`, so this is only reachable if a linear unit still
  carries a stale wrap annotation - in which case the trim boundary would be
  wrong. A cheap `any(pos1 > pos2)` refusal would close it.
- `restore_assembly_unit()` does not reset `assemblies.edited`, which trim sets
  to 1. That column is write-only today, so there is no visible effect.

## Merge notes

Merges cleanly with `wf1-scaffold-join-review` and
`fix/join-merge-na-stale-assemble-opts`; full suite green on the combined tree.
Suggested to merge **last** of the three: smallest blast radius, and the one
that most wants tests added first.
