### PR TITLE
Keep synteny alignment in step with annotate assembly edits

### DIFF
--- a/R/app_annotate_asmb_edits.R
+++ b/R/app_annotate_asmb_edits.R
@@ -237,8 +237,8 @@ unannotated_ends <- function(con, id, path, scaffold) {
 #'
 #' Rewrites `assemblies` (sequence, length, per-position depth/gc/error strings),
 #' shifts every live annotation by the same offset, rewrites the unit's
-#' annotate-stage FASTA + coverage CSV, drops the now-stale cached reference
-#' alignment, and updates `annotate.length`. No feature is ever dropped or cut,
+#' annotate-stage FASTA + coverage CSV, restricts the cached reference alignments
+#' to the retained range, and updates `annotate.length`. No feature is ever cut,
 #' so counts, spans and `annotate.structure` are unchanged by construction.
 #'
 #' @return list(length, removed_lead, removed_trail)
@@ -349,7 +349,7 @@ trim_assembly_ends <- function(con, id, path, scaffold, dir_out) {
     }
   }
 
-  drop_stale_ref_alignment(con, id, path, scaffold)
+  project_ref_alignment_trim(con, id, path, scaffold, n, from, to)
   write_unit_assembly_fasta(dir_out, id, path, scaffold, new_seq, asm$topology[1])
 
   DBI::dbExecute(
@@ -364,19 +364,241 @@ trim_assembly_ends <- function(con, id, path, scaffold, dir_out) {
 #'
 #' `blast_ref_alignment` holds a gapped whole-genome alignment computed against
 #' the stored sequence; the synteny view projects sample coordinates through it.
-#' Any edit to the sequence invalidates it, and nothing in the app rebuilds it,
-#' so delete rather than let the panel silently mis-register. WF1's backfill is
-#' NOT EXISTS-guarded, so the next pipeline run regenerates it.
+#' Any edit to the sequence invalidates it, so a row that can no longer be
+#' repaired in place is deleted rather than left to mis-register the panel. The
+#' modal recomputes a missing row on demand ([ensure_ref_alignment()]), and WF1's
+#' backfill is NOT EXISTS-guarded, so the next pipeline run also regenerates it.
 #' @noRd
-drop_stale_ref_alignment <- function(con, id, path, scaffold) {
+drop_stale_ref_alignment <- function(con, id, path, scaffold, accession = NULL) {
+  tryCatch(
+    if (is.null(accession)) {
+      DBI::dbExecute(
+        con,
+        "DELETE FROM blast_ref_alignment WHERE ID = ? AND path = ? AND scaffold = ?",
+        params = list(as.character(id), as.integer(path), as.integer(scaffold))
+      )
+    } else {
+      DBI::dbExecute(
+        con,
+        "DELETE FROM blast_ref_alignment
+         WHERE ID = ? AND path = ? AND scaffold = ? AND accession = ?",
+        params = list(as.character(id), as.integer(path), as.integer(scaffold),
+                      as.character(accession))
+      )
+    },
+    error = function(e) NULL
+  )
+  invisible()
+}
+
+#' Every cached alignment row for one unit, or NULL.
+#' @noRd
+ref_alignment_rows <- function(con, id, path, scaffold) {
+  tryCatch({
+    if (!DBI::dbExistsTable(con, "blast_ref_alignment")) return(NULL)
+    rows <- DBI::dbGetQuery(
+      con,
+      "SELECT * FROM blast_ref_alignment WHERE ID = ? AND path = ? AND scaffold = ?",
+      params = list(as.character(id), as.integer(path), as.integer(scaffold))
+    )
+    if (nrow(rows) == 0) NULL else rows
+  }, error = function(e) NULL)
+}
+
+#' Write a repaired alignment back over its cached row.
+#'
+#' UPDATE rather than INSERT OR REPLACE so `accession`, `ref_length` and `strand`
+#' keep the aligner's own values.
+#' @noRd
+update_ref_alignment_row <- function(con, id, path, scaffold, accession, res) {
   tryCatch(
     DBI::dbExecute(
       con,
-      "DELETE FROM blast_ref_alignment WHERE ID = ? AND path = ? AND scaffold = ?",
-      params = list(as.character(id), as.integer(path), as.integer(scaffold))
+      "UPDATE blast_ref_alignment
+         SET aligned_sample = ?, aligned_ref = ?, rotation = ?, ref_start = ?,
+             time_stamp = ?
+       WHERE ID = ? AND path = ? AND scaffold = ? AND accession = ?",
+      params = list(
+        res$aligned_sample, res$aligned_ref,
+        as.integer(res$rotation), as.integer(res$ref_start),
+        as.integer(Sys.time()),
+        as.character(id), as.integer(path), as.integer(scaffold),
+        as.character(accession)
+      )
     ),
     error = function(e) NULL
   )
+  invisible()
+}
+
+#' Restrict a stored alignment to a sub-range of the sample (trim)
+#'
+#' The trimmed sequence is a substring of the aligned one, so the alignment does
+#' not need recomputing: drop the cut bases out of the sample track and keep every
+#' column that still carries a reference base. Exact for the retained region and
+#' O(alignment length).
+#'
+#' Two invariants the synteny plot depends on are preserved. Ungapped
+#' `aligned_ref` still equals the whole (rotated) reference, because only columns
+#' that are gaps on BOTH tracks are dropped; and ungapped `aligned_sample` equals
+#' the trimmed assembly, because a cut base becomes a sample gap.
+#'
+#' `strand` is the aligner's own value, so on a "-" row `aligned_sample` is the
+#' reverse complement of the assembly and the kept window mirrors with it.
+#'
+#' @param n length of the assembly the stored row was computed against.
+#' @param from,to 1-based retained range in assembly coordinates.
+#' @return list(aligned_sample, aligned_ref, rotation, ref_start), or NULL if the
+#'   row cannot be projected and should be dropped instead.
+#' @noRd
+project_alignment_trim <- function(aligned_sample, aligned_ref, strand, rotation,
+                                   n, from, to) {
+  if (length(aligned_sample) != 1 || length(aligned_ref) != 1) return(NULL)
+  if (is.na(aligned_sample) || is.na(aligned_ref)) return(NULL)
+  if (!nzchar(aligned_sample) || !nzchar(aligned_ref)) return(NULL)
+  s <- strsplit(aligned_sample, "")[[1]]
+  r <- strsplit(aligned_ref, "")[[1]]
+  if (length(s) != length(r)) return(NULL)
+  is_s <- s != "-"
+  # A row whose sample track is a different length from the assembly is already
+  # stale from some other cause; repairing it would cement the error.
+  if (sum(is_s) != n) return(NULL)
+  if (from < 1L || to > n || from > to) return(NULL)
+
+  win <- if (identical(strand, "-")) c(n - to + 1L, n - from + 1L) else c(from, to)
+  sidx <- cumsum(is_s)
+  keep <- is_s & sidx >= win[1] & sidx <= win[2]
+  cut <- is_s & !keep
+  s[cut] <- "-"
+  drop_col <- cut & r == "-"
+  s <- s[!drop_col]
+  r <- r[!drop_col]
+
+  first <- which(s != "-")
+  if (length(first) == 0) return(NULL)
+  list(
+    aligned_sample = paste(s, collapse = ""),
+    aligned_ref    = paste(r, collapse = ""),
+    rotation       = rotation,
+    ref_start      = sum(r[seq_len(first[1] - 1L)] != "-")
+  )
+}
+
+#' Re-cut a stored alignment for a rotated sample (linearize)
+#'
+#' Linearize rotates the assembly so a chosen gene boundary becomes position 1.
+#' The homology is unchanged, only the origin moved, so the alignment can be
+#' rotated with it: cut the column vector at the new origin's column and swap the
+#' halves. That rotates BOTH tracks by the same cut, so the pair stays collinear;
+#' the reference simply starts at a different base, which is what `rotation`
+#' records. O(alignment length), and exact.
+#'
+#' Only valid when the reference is circular, which the caller checks: permuting
+#' a linear reference would invent an origin it does not have.
+#'
+#' @param start 1-based assembly position that becomes position 1.
+#' @param n assembly length (unchanged by the rotation).
+#' @return list(aligned_sample, aligned_ref, rotation, ref_start), or NULL if the
+#'   row cannot be rotated and should be dropped instead.
+#' @noRd
+rotate_alignment_columns <- function(aligned_sample, aligned_ref, strand, rotation,
+                                     ref_length, n, start) {
+  if (length(aligned_sample) != 1 || length(aligned_ref) != 1) return(NULL)
+  if (is.na(aligned_sample) || is.na(aligned_ref)) return(NULL)
+  if (!nzchar(aligned_sample) || !nzchar(aligned_ref)) return(NULL)
+  if (is.na(ref_length) || ref_length <= 0) return(NULL)
+  if (is.na(start) || start <= 1L || start > n) return(NULL)
+  s <- strsplit(aligned_sample, "")[[1]]
+  r <- strsplit(aligned_ref, "")[[1]]
+  if (length(s) != length(r)) return(NULL)
+  is_s <- s != "-"
+  if (sum(is_s) != n) return(NULL)
+  if (sum(r != "-") != ref_length) return(NULL)
+
+  # Sample index of the base that becomes position 1, in the stored strand's
+  # coordinates. On a "-" row the stored track is the reverse complement, and
+  # rotating the assembly left by (start - 1) rotates its reverse complement left
+  # by (n - start + 1), so the new origin is base n - start + 2.
+  k <- if (identical(strand, "-")) n - start + 2L else start
+  if (k < 2L || k > n) return(NULL)
+  cut <- which(is_s)[k]
+
+  ord <- c(cut:length(s), seq_len(cut - 1L))
+  r_off <- sum(r[seq_len(cut - 1L)] != "-")
+  s <- s[ord]
+  r <- r[ord]
+
+  first <- which(s != "-")
+  if (length(first) == 0) return(NULL)
+  list(
+    aligned_sample = paste(s, collapse = ""),
+    aligned_ref    = paste(r, collapse = ""),
+    rotation       = (rotation + r_off) %% ref_length,
+    ref_start      = sum(r[seq_len(first[1] - 1L)] != "-")
+  )
+}
+
+#' Which of these accessions are circular references?
+#' @noRd
+circular_ref_accessions <- function(con, accessions) {
+  accessions <- unique(stats::na.omit(as.character(accessions)))
+  if (length(accessions) == 0) return(character(0))
+  tryCatch({
+    rows <- DBI::dbGetQuery(
+      con,
+      sprintf("SELECT accession, topology FROM blast_ref_sequences WHERE accession IN (%s)",
+              paste(rep("?", length(accessions)), collapse = ",")),
+      params = as.list(accessions)
+    )
+    rows$accession[!is.na(rows$topology) & rows$topology == "circular"]
+  }, error = function(e) character(0))
+}
+
+#' Keep a unit's cached alignments in step with a trim
+#'
+#' Repairs every candidate reference's row in place; a row that cannot be
+#' projected is dropped so the modal recomputes it instead of drawing it wrong.
+#' @noRd
+project_ref_alignment_trim <- function(con, id, path, scaffold, n, from, to) {
+  rows <- ref_alignment_rows(con, id, path, scaffold)
+  if (is.null(rows)) return(invisible())
+  for (i in seq_len(nrow(rows))) {
+    res <- tryCatch(
+      project_alignment_trim(
+        rows$aligned_sample[i], rows$aligned_ref[i], rows$strand[i],
+        rows$rotation[i], n, from, to
+      ),
+      error = function(e) NULL
+    )
+    if (is.null(res)) {
+      drop_stale_ref_alignment(con, id, path, scaffold, rows$accession[i])
+    } else {
+      update_ref_alignment_row(con, id, path, scaffold, rows$accession[i], res)
+    }
+  }
+  invisible()
+}
+
+#' Keep a unit's cached alignments in step with a linearize rotation
+#' @noRd
+rotate_ref_alignment <- function(con, id, path, scaffold, n, start) {
+  rows <- ref_alignment_rows(con, id, path, scaffold)
+  if (is.null(rows)) return(invisible())
+  circular <- circular_ref_accessions(con, rows$accession)
+  for (i in seq_len(nrow(rows))) {
+    res <- if (!(rows$accession[i] %in% circular)) NULL else tryCatch(
+      rotate_alignment_columns(
+        rows$aligned_sample[i], rows$aligned_ref[i], rows$strand[i],
+        rows$rotation[i], rows$ref_length[i], n, start
+      ),
+      error = function(e) NULL
+    )
+    if (is.null(res)) {
+      drop_stale_ref_alignment(con, id, path, scaffold, rows$accession[i])
+    } else {
+      update_ref_alignment_row(con, id, path, scaffold, rows$accession[i], res)
+    }
+  }
   invisible()
 }
 

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -216,6 +216,11 @@ annotations_details_server <- function(id, rv) {
     # Active synteny-plot reference accession (user pick, else top hit).
     active_ref_acc <- reactiveVal(NULL)
 
+    # (unit, accession) pairs whose on-demand alignment already failed once this
+    # session. Keeps a reference that cannot be aligned from re-running the
+    # aligner on every modal open.
+    aln_recompute_failed <- new.env(parent = emptyenv())
+
     # Load reference annotations / sequence / alignment for one accession into rv.
     # Used on modal open and whenever the user switches the reference in the picker.
     load_blast_ref <- function(acc) {
@@ -240,7 +245,7 @@ annotations_details_server <- function(id, rv) {
       # Normalised on load so every consumer below sees the sample in its STORED
       # orientation (matching the coverage map) with any reverse-complement moved
       # onto the reference track. See normalize_blast_ref_alignment().
-      rv$blast_ref_aln <- tryCatch(
+      read_aln <- function() tryCatch(
         normalize_blast_ref_alignment(
           dplyr::tbl(session$userData$con, "blast_ref_alignment") |>
             dplyr::filter(ID == !!rv$updating$ID,
@@ -251,6 +256,34 @@ annotations_details_server <- function(id, rv) {
         ),
         error = function(e) NULL
       )
+      aln <- read_aln()
+      # No cached alignment: build one now rather than leave the panel without a
+      # synteny view. Happens when an assembly edit invalidated the row beyond
+      # repair, when the pipeline's align step failed, or on a project old enough
+      # to predate it. ~6 s for a mitogenome pair and blocking, so it runs behind
+      # a spinner, only for the reference actually being displayed, and a failure
+      # is remembered for the session so reopening the modal cannot loop on it.
+      key <- paste(rv$updating$ID, rv$updating$path, rv$updating$scaffold, acc)
+      if ((is.null(aln) || nrow(aln) == 0) && !isTRUE(aln_recompute_failed[[key]])) {
+        waiter::waiter_show(
+          html = tagList(
+            waiter::spin_fading_circles(),
+            tags$h4(style = "color:white; margin-top:1em;",
+                    "Computing reference alignment, hold tight...")
+          ),
+          color = "rgba(40,40,40,0.85)"
+        )
+        ok <- tryCatch(
+          ensure_ref_alignment(
+            session$userData$con, rv$updating$ID, rv$updating$path,
+            rv$updating$scaffold, acc
+          ),
+          error = function(e) FALSE,
+          finally = waiter::waiter_hide()
+        )
+        if (isTRUE(ok)) aln <- read_aln() else aln_recompute_failed[[key]] <- TRUE
+      }
+      rv$blast_ref_aln <- aln
     }
 
     # Prepare modal data ----
@@ -2640,9 +2673,20 @@ annotations_details_server <- function(id, rv) {
       )
       ## Rotate to cut point ----
       if (start > 1) {
+        asmb_len <- assembly@ranges@width
         assembly <- Biostrings::xscat(
-          Biostrings::subseq(assembly, start, assembly@ranges@width),
+          Biostrings::subseq(assembly, start, asmb_len),
           Biostrings::subseq(assembly, 1, start - 1)
+        )
+
+        ## Keep the cached reference alignments in step ----
+        # Rotating the sample rotates the alignment with it (circular reference),
+        # so the synteny view stays correct without realigning. A row that cannot
+        # be rotated is dropped rather than left to mis-register; load_blast_ref
+        # recomputes it on the next open.
+        rotate_ref_alignment(
+          session$userData$con, rv$updating$ID, rv$updating$path,
+          rv$updating$scaffold, asmb_len, start
         )
 
         ## Rotate coverage ----
@@ -2733,6 +2777,9 @@ annotations_details_server <- function(id, rv) {
       # Reveal Restore, and re-measure the flanks the assembly now has as a
       # linear molecule (Trim is only available once it is linear).
       bump_asmb_edit()
+      # Re-read the alignment the rotation just rewrote, so the open modal's
+      # synteny view redraws from it instead of the pre-rotation copy.
+      load_blast_ref(active_ref_acc())
     }) # END LINEARIZE
 
     # Assembly edits: trim unannotated ends / restore ----

--- a/R/blast_ref_utils.R
+++ b/R/blast_ref_utils.R
@@ -1257,6 +1257,115 @@ normalize_blast_ref_alignment <- function(aln) {
   aln
 }
 
+#' Reference rotation offset for one unit's synteny alignment
+#'
+#' Mirrors the SQL in \code{blast_ref_align_workflow.nf}: a circular reference is
+#' rotated so the sample's \code{start_gene} anchors both sequences; a linear
+#' reference keeps its native coordinates.
+#'
+#' @return 0-based offset, 0 when unknown or the reference is linear.
+#' @noRd
+unit_ref_rotation <- function(con, id, path, scaffold, accession) {
+  tryCatch({
+    topo <- DBI::dbGetQuery(
+      con, "SELECT topology FROM blast_ref_sequences WHERE accession = ?",
+      params = list(as.character(accession))
+    )$topology
+    if (length(topo) == 0 || is.na(topo[1]) || topo[1] != "circular") return(0L)
+    sg <- DBI::dbGetQuery(
+      con,
+      "SELECT o.start_gene FROM annotate a
+         JOIN annotate_opts o ON o.annotate_opts = a.annotate_opts
+       WHERE a.ID = ? AND a.path = ? AND a.scaffold = ?",
+      params = list(as.character(id), as.integer(path), as.integer(scaffold))
+    )$start_gene
+    if (length(sg) == 0 || is.na(sg[1]) || !nzchar(sg[1])) return(0L)
+    pos <- DBI::dbGetQuery(
+      con,
+      "SELECT MIN(pos1) AS p FROM blast_ref_annotations
+       WHERE accession = ? AND gene = ?",
+      params = list(as.character(accession), as.character(sg[1]))
+    )$p
+    if (length(pos) == 0 || is.na(pos[1])) return(0L)
+    as.integer(pos[1]) - 1L
+  }, error = function(e) 0L)
+}
+
+#' Compute and cache one unit's reference alignment on demand
+#'
+#' The synteny view reads \code{blast_ref_alignment}, which WF2 populates. An
+#' in-app assembly edit can invalidate a row beyond repair, and an old or failed
+#' run may never have written one, leaving the panel without its alignment until
+#' the pipeline is re-run. This runs the same aligner the pipeline does
+#' ([compute_blast_ref_alignment()]) against the CURRENT stored sequence and
+#' caches the result, so the view repairs itself.
+#'
+#' Roughly 6 s and ~1.3 GB for a full mitogenome pair, single-threaded and
+#' blocking, so callers should show a spinner and only ask for the reference the
+#' user is actually looking at.
+#'
+#' @param max_cells refuse pairs whose dynamic-programming matrix exceeds this
+#'   many cells. The aligner costs ~5 bytes per cell, so the default is ~3 GB.
+#'   The pipeline runs the same alignment under a memory directive and can fail a
+#'   task; here an oversized pair would take the whole app down with it.
+#'
+#' @return TRUE if a row was written.
+#' @noRd
+ensure_ref_alignment <- function(con, id, path, scaffold, accession,
+                                 max_cells = 6e8) {
+  if (is.null(accession) || is.na(accession) || !nzchar(accession)) return(FALSE)
+  tryCatch({
+    if (!DBI::dbExistsTable(con, "blast_ref_alignment")) return(FALSE)
+    key <- list(as.character(id), as.integer(path), as.integer(scaffold))
+    asm <- DBI::dbGetQuery(
+      con, "SELECT sequence FROM assemblies WHERE ID = ? AND path = ? AND scaffold = ?",
+      params = key
+    )$sequence
+    if (length(asm) == 0 || is.na(asm[1]) || !nzchar(asm[1])) return(FALSE)
+    ref <- DBI::dbGetQuery(
+      con, "SELECT sequence FROM blast_ref_sequences WHERE accession = ?",
+      params = list(as.character(accession))
+    )$sequence
+    if (length(ref) == 0 || is.na(ref[1]) || !nzchar(ref[1])) return(FALSE)
+    if (as.numeric(nchar(asm[1])) * as.numeric(nchar(ref[1])) > max_cells) {
+      message("ensure_ref_alignment: ", id, ".", path, ".", scaffold,
+              " vs ", accession, " is too large to align in the app; ",
+              "re-run the pipeline for this sample instead")
+      return(FALSE)
+    }
+
+    out <- tempfile(fileext = ".csv")
+    on.exit(unlink(out), add = TRUE)
+    compute_blast_ref_alignment(
+      assembly_seq = asm[1],
+      ref_seq      = ref[1],
+      rotation     = unit_ref_rotation(con, id, path, scaffold, accession),
+      output_file  = out
+    )
+    if (!file.exists(out)) return(FALSE)
+    res <- utils::read.csv(out, stringsAsFactors = FALSE)
+    if (nrow(res) == 0 || is.na(res$aligned_sample[1]) || !nzchar(res$aligned_sample[1])) {
+      return(FALSE)
+    }
+    DBI::dbExecute(
+      con,
+      "INSERT OR REPLACE INTO blast_ref_alignment
+         (ID, path, scaffold, accession, aligned_sample, aligned_ref, rotation,
+          ref_length, ref_start, strand, time_stamp)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      params = list(
+        as.character(id), as.integer(path), as.integer(scaffold),
+        as.character(accession),
+        res$aligned_sample[1], res$aligned_ref[1],
+        as.integer(res$rotation[1]), as.integer(res$ref_length[1]),
+        as.integer(res$ref_start[1]), as.character(res$strand[1]),
+        as.integer(Sys.time())
+      )
+    )
+    TRUE
+  }, error = function(e) FALSE)
+}
+
 #' Pre-compute a whole-genome pairwise alignment of a sample against its BLAST
 #' reference and write the result for ingestion into the
 #' \code{blast_ref_alignment} SQLite table.

--- a/tests/testthat/test-blast-ref-alignment-edits.R
+++ b/tests/testthat/test-blast-ref-alignment-edits.R
@@ -1,0 +1,257 @@
+
+# Assembly edits in the Annotate modal (trim / linearize) rewrite the sequence the
+# cached synteny alignment was computed against. These check the two O(L) repairs
+# that keep `blast_ref_alignment` in step without realigning.
+
+# Non-gap column pairs of an alignment, as (sample base index, ref base index) in
+# the stored strand's own coordinates. This IS the alignment: the synteny plot
+# draws nothing else, so preserving this mapping is the correctness property.
+aln_pairs <- function(s, r) {
+  sc <- strsplit(s, "")[[1]]
+  rc <- strsplit(r, "")[[1]]
+  ok <- sc != "-" & rc != "-"
+  data.frame(s = cumsum(sc != "-")[ok], r = cumsum(rc != "-")[ok])
+}
+
+ungapped <- function(x) gsub("-", "", x, fixed = TRUE)
+
+no_rn <- function(df) {
+  rownames(df) <- NULL
+  df
+}
+
+rc <- function(x) {
+  as.character(Biostrings::reverseComplement(Biostrings::DNAString(x)))
+}
+
+# A genuine aligner-produced row, so the fixtures carry real gap structure.
+make_aln <- function(assembly_seq, ref_seq, rotation = 0L) {
+  f <- tempfile(fileext = ".csv")
+  on.exit(unlink(f))
+  compute_blast_ref_alignment(assembly_seq, ref_seq, rotation, f)
+  utils::read.csv(f, stringsAsFactors = FALSE)
+}
+
+set.seed(42)
+.ref <- paste(sample(c("A", "C", "G", "T"), 400, TRUE), collapse = "")
+# Sample = reference with a deletion, an insertion and scattered substitutions,
+# flanked by unrelated sequence so there is something to trim.
+.core <- paste0(
+  substr(.ref, 21, 180),
+  substr(.ref, 201, 360)
+)
+.sample <- paste0(
+  paste(sample(c("A", "C", "G", "T"), 30, TRUE), collapse = ""),
+  .core,
+  paste(sample(c("A", "C", "G", "T"), 25, TRUE), collapse = "")
+)
+
+test_that("project_alignment_trim keeps ungapped tracks and the base pairing", {
+  a <- make_aln(.sample, .ref)
+  expect_equal(nrow(a), 1)
+  expect_equal(a$strand[1], "+")
+  n <- nchar(.sample)
+  from <- 31L
+  to <- n - 25L
+
+  res <- project_alignment_trim(a$aligned_sample[1], a$aligned_ref[1],
+                                a$strand[1], a$rotation[1], n, from, to)
+  expect_false(is.null(res))
+  # The sample track is exactly the trimmed assembly ...
+  expect_equal(ungapped(res$aligned_sample), substr(.sample, from, to))
+  # ... and the reference track is still the WHOLE reference, which the plot
+  # relies on to place reference genes by counting non-gap bases.
+  expect_equal(ungapped(res$aligned_ref), .ref)
+  expect_equal(nchar(res$aligned_sample), nchar(res$aligned_ref))
+
+  before <- aln_pairs(a$aligned_sample[1], a$aligned_ref[1])
+  after <- aln_pairs(res$aligned_sample, res$aligned_ref)
+  kept <- before[before$s >= from & before$s <= to, ]
+  kept$s <- kept$s - from + 1L
+  expect_equal(no_rn(after), no_rn(kept))
+})
+
+test_that("project_alignment_trim mirrors the window on a reverse-strand row", {
+  asm <- rc(.sample)
+  a <- make_aln(asm, .ref)
+  expect_equal(a$strand[1], "-")
+  n <- nchar(asm)
+  from <- 26L
+  to <- n - 30L
+
+  res <- project_alignment_trim(a$aligned_sample[1], a$aligned_ref[1],
+                                a$strand[1], a$rotation[1], n, from, to)
+  expect_false(is.null(res))
+  # A "-" row stores the reverse complement of the assembly, so the retained
+  # window must mirror with it.
+  expect_equal(ungapped(res$aligned_sample), rc(substr(asm, from, to)))
+  expect_equal(ungapped(res$aligned_ref), .ref)
+})
+
+test_that("project_alignment_trim refuses a row that is already stale", {
+  a <- make_aln(.sample, .ref)
+  # n disagrees with the stored sample track: repairing it would cement the error.
+  expect_null(project_alignment_trim(a$aligned_sample[1], a$aligned_ref[1],
+                                     a$strand[1], a$rotation[1],
+                                     nchar(.sample) + 10L, 5L, 100L))
+  expect_null(project_alignment_trim(NA_character_, NA_character_, "+", 0L,
+                                     nchar(.sample), 5L, 100L))
+})
+
+test_that("rotate_alignment_columns rotates both tracks and updates rotation", {
+  a <- make_aln(.sample, .ref)
+  n <- nchar(.sample)
+  ref_len <- as.integer(a$ref_length[1])
+  start <- 120L
+
+  res <- rotate_alignment_columns(a$aligned_sample[1], a$aligned_ref[1],
+                                  a$strand[1], a$rotation[1], ref_len, n, start)
+  expect_false(is.null(res))
+  rotated <- paste0(substr(.sample, start, n), substr(.sample, 1, start - 1))
+  expect_equal(ungapped(res$aligned_sample), rotated)
+  # The reference is rotated by the same cut, so it is still whole and still the
+  # same length; only its origin moved, which `rotation` records.
+  expect_equal(nchar(ungapped(res$aligned_ref)), ref_len)
+  r_off <- (res$rotation - a$rotation[1]) %% ref_len
+  expect_equal(
+    ungapped(res$aligned_ref),
+    paste0(substr(.ref, r_off + 1L, ref_len), substr(.ref, 1L, r_off))
+  )
+
+  # Every aligned base pair survives the rotation, just re-indexed.
+  before <- aln_pairs(a$aligned_sample[1], a$aligned_ref[1])
+  after <- aln_pairs(res$aligned_sample, res$aligned_ref)
+  expected <- data.frame(
+    s = ((before$s - start) %% n) + 1L,
+    r = ((before$r - r_off - 1L) %% ref_len) + 1L
+  )
+  expect_equal(no_rn(after[order(after$s), ]), no_rn(expected[order(expected$s), ]))
+})
+
+test_that("rotate_alignment_columns mirrors the cut on a reverse-strand row", {
+  asm <- rc(.sample)
+  a <- make_aln(asm, .ref)
+  expect_equal(a$strand[1], "-")
+  n <- nchar(asm)
+  start <- 90L
+
+  res <- rotate_alignment_columns(a$aligned_sample[1], a$aligned_ref[1],
+                                  a$strand[1], a$rotation[1],
+                                  as.integer(a$ref_length[1]), n, start)
+  expect_false(is.null(res))
+  rotated <- paste0(substr(asm, start, n), substr(asm, 1, start - 1))
+  expect_equal(ungapped(res$aligned_sample), rc(rotated))
+})
+
+test_that("rotate_alignment_columns declines out-of-range cut points", {
+  a <- make_aln(.sample, .ref)
+  n <- nchar(.sample)
+  rl <- as.integer(a$ref_length[1])
+  # start == 1 is not a rotation; start > n is not a position.
+  expect_null(rotate_alignment_columns(a$aligned_sample[1], a$aligned_ref[1],
+                                       a$strand[1], a$rotation[1], rl, n, 1L))
+  expect_null(rotate_alignment_columns(a$aligned_sample[1], a$aligned_ref[1],
+                                       a$strand[1], a$rotation[1], rl, n, n + 1L))
+})
+
+# --- DB wrappers -------------------------------------------------------------
+
+aln_test_db <- function(topology = "circular") {
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  DBI::dbExecute(con, "CREATE TABLE blast_ref_alignment (
+    ID TEXT, path INTEGER, scaffold INTEGER, accession TEXT,
+    aligned_sample TEXT, aligned_ref TEXT, rotation INTEGER, ref_length INTEGER,
+    ref_start INTEGER, strand TEXT, time_stamp INTEGER,
+    PRIMARY KEY (ID, path, scaffold, accession))")
+  DBI::dbExecute(con, "CREATE TABLE blast_ref_sequences (
+    accession TEXT PRIMARY KEY, sequence TEXT, topology TEXT)")
+  DBI::dbExecute(con, "CREATE TABLE assemblies (
+    ID TEXT, path INTEGER, scaffold INTEGER, sequence TEXT)")
+  DBI::dbExecute(con, "CREATE TABLE blast_ref_annotations (
+    accession TEXT, gene TEXT, pos1 INTEGER)")
+  DBI::dbExecute(con, "CREATE TABLE annotate (
+    ID TEXT, path INTEGER, scaffold INTEGER, annotate_opts TEXT)")
+  DBI::dbExecute(con, "CREATE TABLE annotate_opts (
+    annotate_opts TEXT, start_gene TEXT)")
+
+  a <- make_aln(.sample, .ref)
+  DBI::dbExecute(
+    con, "INSERT INTO blast_ref_alignment VALUES ('S1',1,1,'ACC1',?,?,?,?,?,?,0)",
+    params = list(a$aligned_sample[1], a$aligned_ref[1], a$rotation[1],
+                  a$ref_length[1], a$ref_start[1], a$strand[1])
+  )
+  DBI::dbExecute(con, "INSERT INTO blast_ref_sequences VALUES ('ACC1', ?, ?)",
+                 params = list(.ref, topology))
+  DBI::dbExecute(con, "INSERT INTO assemblies VALUES ('S1',1,1,?)",
+                 params = list(.sample))
+  DBI::dbExecute(con, "INSERT INTO blast_ref_annotations VALUES ('ACC1','COX1',41)")
+  DBI::dbExecute(con, "INSERT INTO annotate VALUES ('S1',1,1,'default')")
+  DBI::dbExecute(con, "INSERT INTO annotate_opts VALUES ('default','COX1')")
+  con
+}
+
+test_that("project_ref_alignment_trim rewrites the cached row", {
+  con <- aln_test_db()
+  on.exit(DBI::dbDisconnect(con))
+  n <- nchar(.sample)
+  project_ref_alignment_trim(con, "S1", 1, 1, n, 31L, n - 25L)
+  row <- DBI::dbGetQuery(con, "SELECT * FROM blast_ref_alignment")
+  expect_equal(nrow(row), 1)
+  expect_equal(ungapped(row$aligned_sample[1]), substr(.sample, 31L, n - 25L))
+  expect_equal(ungapped(row$aligned_ref[1]), .ref)
+})
+
+test_that("rotate_ref_alignment rotates against a circular reference", {
+  con <- aln_test_db("circular")
+  on.exit(DBI::dbDisconnect(con))
+  n <- nchar(.sample)
+  rotate_ref_alignment(con, "S1", 1, 1, n, 120L)
+  row <- DBI::dbGetQuery(con, "SELECT * FROM blast_ref_alignment")
+  expect_equal(nrow(row), 1)
+  expect_equal(ungapped(row$aligned_sample[1]),
+               paste0(substr(.sample, 120L, n), substr(.sample, 1L, 119L)))
+})
+
+test_that("rotate_ref_alignment drops the row for a linear reference", {
+  con <- aln_test_db("linear")
+  on.exit(DBI::dbDisconnect(con))
+  # Permuting a linear reference would invent an origin it does not have, so the
+  # row is dropped and recomputed on demand instead.
+  rotate_ref_alignment(con, "S1", 1, 1, nchar(.sample), 120L)
+  expect_equal(nrow(DBI::dbGetQuery(con, "SELECT * FROM blast_ref_alignment")), 0)
+})
+
+test_that("ensure_ref_alignment recomputes a missing row", {
+  con <- aln_test_db()
+  on.exit(DBI::dbDisconnect(con))
+  DBI::dbExecute(con, "DELETE FROM blast_ref_alignment")
+  expect_true(ensure_ref_alignment(con, "S1", 1, 1, "ACC1"))
+  row <- DBI::dbGetQuery(con, "SELECT * FROM blast_ref_alignment")
+  expect_equal(nrow(row), 1)
+  expect_equal(ungapped(row$aligned_sample[1]), .sample)
+  expect_equal(nchar(ungapped(row$aligned_ref[1])), row$ref_length[1])
+  # Circular reference + a start_gene at position 41 -> 40 bp rotation, same as
+  # the pipeline's own SQL.
+  expect_equal(row$rotation[1], 40)
+})
+
+test_that("ensure_ref_alignment refuses a pair too large to align in-app", {
+  con <- aln_test_db()
+  on.exit(DBI::dbDisconnect(con))
+  DBI::dbExecute(con, "DELETE FROM blast_ref_alignment")
+  # The DP matrix is quadratic; an oversized pair would take the app down.
+  expect_message(
+    expect_false(ensure_ref_alignment(con, "S1", 1, 1, "ACC1", max_cells = 1e3)),
+    "too large to align"
+  )
+  expect_equal(nrow(DBI::dbGetQuery(con, "SELECT * FROM blast_ref_alignment")), 0)
+})
+
+test_that("ensure_ref_alignment is a no-op when the reference sequence is absent", {
+  con <- aln_test_db()
+  on.exit(DBI::dbDisconnect(con))
+  DBI::dbExecute(con, "DELETE FROM blast_ref_alignment")
+  DBI::dbExecute(con, "DELETE FROM blast_ref_sequences")
+  expect_false(ensure_ref_alignment(con, "S1", 1, 1, "ACC1"))
+  expect_equal(nrow(DBI::dbGetQuery(con, "SELECT * FROM blast_ref_alignment")), 0)
+})


### PR DESCRIPTION
## Problem

The two assembly edits in the Annotate details modal both broke the synteny view:

- **Linearize** never dropped the cached `blast_ref_alignment` row. The sample track is projected through `s_nongap[pos]`, so after a rotation the plot drew a fake genome rearrangement, internally coherent and plausible-looking. This is in 1.5.1.
- **Trim** deleted the row (correct, but the panel then went blank) and nothing in the app rebuilt it. It only came back on the next pipeline run.

## Fix

Both edits now repair the cached alignment in place instead of invalidating it:

- **Trim** restricts the alignment to the retained range: cut bases become sample gaps, and only columns that are gaps on *both* tracks are dropped. Preserves the two invariants the plot depends on, ungapped `aligned_ref` still equals the whole reference and ungapped `aligned_sample` equals the trimmed assembly.
- **Linearize** cuts the column vector at the new origin and swaps halves, so both tracks rotate together and stay collinear; the reference's new origin goes into the stored `rotation`. Gated on a circular reference, since permuting a linear one would invent an origin it does not have.

Both handle reverse-strand rows by mirroring the cut. Both are O(alignment length), ~2 ms at mitogenome scale vs ~6 s to realign.

A row that fails any guard is dropped per-accession rather than left to mis-register, and `load_blast_ref` recomputes a missing row on demand behind a spinner. That also repairs units whose pipeline align step failed, or projects predating the feature. Only the reference actually being displayed is recomputed, failures are memoized for the session, and a size guard refuses pairs whose DP matrix would exceed ~3 GB.

## Notes

- "Restore assembly" still deletes and lets the recompute rebuild, so undo costs ~5 s on the next open. `assembly_backup` could snapshot the alignment rows and make it instant; left out of this PR.
- The candidate-broadcast issue above roughly doubles align work on multi-scaffold samples. Separate bug, not addressed here.