### PR TITLE
Annotate: refresh trim preview after annotation edits

### DIFF
--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -161,6 +161,10 @@ annotations_details_server <- function(id, rv) {
           copy = TRUE,
           in_place = TRUE
         )
+      # The trim control measures the unannotated flanks straight from the db, so
+      # any annotation write can change them (deleting, restoring or nudging the
+      # outermost feature). Bump after the write so the re-read sees it.
+      bump_asmb_edit()
     }
 
     # Write the given columns of rv$updating to this unit's annotate row. Keyed on

--- a/inst/app/www/custom.js
+++ b/inst/app/www/custom.js
@@ -81,26 +81,10 @@ $( document ).ready(function(){
   });
 });
 
-// Mousewheel -> horizontal scroll for the annotate-details alignment views.
-// The coverage map and synteny PNGs sit in overflow-x:auto containers
-// (coverageDiv / syntenyScrollDiv). Translate vertical wheel delta into
-// horizontal scroll (down = right, up = left) and suppress page scroll over
-// these views. The MSA viewer is intentionally excluded: it needs vertical
-// wheel for scrolling alignment rows up/down.
-$( document ).ready(function(){
-  document.addEventListener('wheel', function(e) {
-    if (!e.target.closest) return;
-    var delta = e.deltaY;
-    if (!delta) return;
-
-    var box = e.target.closest('[id$="coverageDiv"], [id$="syntenyScrollDiv"]');
-    if (box) {
-      box.scrollLeft += delta;
-      e.preventDefault();
-      return;
-    }
-  }, { passive: false });
-});
+// The annotate-details views (coverage map, synteny, synteny zoom, alignment)
+// use native scrolling only: a vertical wheel scrolls the page, and horizontal
+// input scrolls the view. Vertical wheel is deliberately NOT translated into
+// horizontal scroll here.
 
 // Add an "All" choice to the sample-table page-size dropdowns. reactable
 // (0.4.5) has no native "All", so append an option with a very large page size

--- a/tests/testthat/test-annotate-unannotated-ends.R
+++ b/tests/testthat/test-annotate-unannotated-ends.R
@@ -1,0 +1,74 @@
+# `unannotated_ends` measures the flanks the Trim control reports and cuts to.
+# Deleting an annotation in the modal soft-deletes it (gene suffixed "_DELETED_",
+# pos1 = pos2 = 0), so the measurement must ignore those tombstones and move to
+# the next real feature.
+
+make_db <- function(len = 1000L, ann = NULL, topology = "linear") {
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  DBI::dbWriteTable(
+    con, "assemblies",
+    data.frame(ID = "S1", path = 1L, scaffold = 1L, length = len,
+               topology = topology, stringsAsFactors = FALSE)
+  )
+  if (is.null(ann)) {
+    ann <- data.frame(ID = character(), path = integer(), scaffold = integer(),
+                      gene = character(), pos1 = integer(), pos2 = integer(),
+                      stringsAsFactors = FALSE)
+  }
+  DBI::dbWriteTable(con, "annotations", ann)
+  con
+}
+
+anns <- function(...) {
+  rows <- list(...)
+  data.frame(
+    ID = "S1", path = 1L, scaffold = 1L,
+    gene = vapply(rows, function(r) r[[1]], character(1)),
+    pos1 = vapply(rows, function(r) as.integer(r[[2]]), integer(1)),
+    pos2 = vapply(rows, function(r) as.integer(r[[3]]), integer(1)),
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("flanks are measured from the outermost live annotations", {
+  con <- make_db(ann = anns(list("COX1", 101, 200), list("ND1", 301, 400)))
+  on.exit(DBI::dbDisconnect(con))
+  e <- unannotated_ends(con, "S1", 1, 1)
+  expect_equal(e$from, 101L)
+  expect_equal(e$to, 400L)
+  expect_equal(e$lead, 100L)
+  expect_equal(e$trail, 600L)
+})
+
+test_that("a soft-deleted leading annotation moves the trim start inward", {
+  con <- make_db(ann = anns(
+    list("COX1_DELETED_1700000000", 0, 0),
+    list("ND1", 301, 400)
+  ))
+  on.exit(DBI::dbDisconnect(con))
+  e <- unannotated_ends(con, "S1", 1, 1)
+  expect_equal(e$from, 301L)
+  expect_equal(e$lead, 300L)
+  expect_equal(e$trail, 600L)
+})
+
+test_that("a soft-deleted trailing annotation moves the trim end inward", {
+  con <- make_db(ann = anns(
+    list("COX1", 101, 200),
+    list("ND1_DELETED_1700000000", 0, 0)
+  ))
+  on.exit(DBI::dbDisconnect(con))
+  e <- unannotated_ends(con, "S1", 1, 1)
+  expect_equal(e$to, 200L)
+  expect_equal(e$lead, 100L)
+  expect_equal(e$trail, 800L)
+})
+
+test_that("only tombstones means nothing to trim to", {
+  con <- make_db(ann = anns(list("COX1_DELETED_1", 0, 0)))
+  on.exit(DBI::dbDisconnect(con))
+  e <- unannotated_ends(con, "S1", 1, 1)
+  expect_true(is.na(e$from))
+  expect_true(is.na(e$lead))
+  expect_equal(e$topology, "linear")
+})


### PR DESCRIPTION
## Stale trim preview

`asmb_state()` (`R/app_annotate_details.R`) measures a unit's unannotated flanks from the db, but depended only on `asmb_edit_tick()` and `rv$updating`. Annotation edits write to the db through `persist_annotations()` and bump neither, so the reactive stayed cached: deleting the outermost feature left the "Trim unannotated ends (N bp)" label, and the confirm dialog that reads the same reactive, showing the old bp count.

Fixed by bumping the tick at the end of `persist_annotations()`, which covers every annotation write that can move the outermost feature: delete, restore, merge, and START/STOP boundary edits.

Trimming itself was already correct. Deletes are soft deletes (`pos1 = pos2 = 0`, gene suffixed `_DELETED_`) and `unannotated_ends` filters `pos1 > 0`, so tombstones were never counted; `trim_assembly_ends` re-reads that function at cut time. The cut was right while the dialog was wrong, so the two could disagree. They now agree.

## Wheel scrolling

Removed the handler in `inst/app/www/custom.js` that translated vertical wheel into horizontal scroll over `coverageDiv` / `syntenyScrollDiv`. Vertical wheel over the coverage map and synteny views now scrolls the page; horizontal input scrolls the view natively. The synteny zoom plot and MSA viewer were never in that selector. The `hScroll` auto-scroll-to-selected-gene handler is untouched.