### PR TITLE
Fix stale MSA in PCG outlier review after a Back to Review edit

### DIFF
--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -413,9 +413,6 @@ annotations_details_server <- function(id, rv) {
           identical(goto$ID, rv$updating$ID)) {
         # Remember the flag so the banner can remind the user what to edit
         outlier_flag(goto)
-        # Snapshot the focal gene's edit-relevant fields so the reopen handler can
-        # tell whether anything changed and skip the recompute if not.
-        session$userData$review_entry_sig <- focal_sig(rv$annotations, goto$gene)
         gidx <- which(rv$annotations$gene == goto$gene)
         if (length(gidx) > 0) {
           gidx <- gidx[[1]]
@@ -432,7 +429,6 @@ annotations_details_server <- function(id, rv) {
         session$userData$goto_annotate_target <- NULL
       } else {
         outlier_flag(NULL)
-        session$userData$review_entry_sig <- NULL
       }
     })
 
@@ -801,20 +797,6 @@ annotations_details_server <- function(id, rv) {
     # poly-A stop trim change partial_start/partial_stop/stop_codon/positions
     # without altering the translation, so a translation-only test would let the
     # user close/lock and silently drop those edits.
-    # Order-independent signature of a gene's annotation rows over the fields that
-    # drive the outlier recompute (translation for single-exon genes; pos/direction
-    # for multi-exon). Lets "Back to Review" skip the recompute when nothing changed.
-    focal_sig <- function(ann, gene) {
-      if (is.null(ann) || is.null(gene)) return(NULL)
-      rows <- ann[!is.na(ann$gene) & ann$gene == gene, , drop = FALSE]
-      if (nrow(rows) == 0) return("")
-      flds <- c("translation", "pos1", "pos2", "direction")
-      cols <- lapply(flds, function(f) {
-        if (f %in% names(rows)) as.character(rows[[f]]) else rep(NA_character_, nrow(rows))
-      })
-      paste(sort(do.call(paste, c(cols, sep = "|"))), collapse = ";")
-    }
-
     editing_unsaved <- function(idx = selected()) {
       if (is.null(rv$editing) || is.null(rv$editing$backup)) return(FALSE)
       bak <- rv$editing$backup
@@ -887,20 +869,12 @@ annotations_details_server <- function(id, rv) {
       }
     })
 
-    # Return to the export outlier review (saves via the standard close path)
+    # Return to the export outlier review (saves via the standard close path).
+    # Which unit/gene was reviewed, and whether it changed, is tracked by the
+    # export module against the db - nothing about that decision is carried back
+    # from here, so a rejected close or a modal reload cannot corrupt it.
     observeEvent(input$back_to_review, {
       session$userData$return_to_review <- TRUE
-      # Record the (sample, gene) just reviewed so the review modal can mark it
-      # resolved and navigate back to that gene. goto_annotate_target is cleared
-      # when this modal opens, so read the persisted flag instead.
-      info <- outlier_flag()
-      if (!is.null(info) && !is.null(info$ID) && !is.null(info$gene)) {
-        session$userData$resolve_on_return <- list(ID = info$ID, gene = info$gene)
-        # If the focal gene's annotation is unchanged vs the entry snapshot, the
-        # reopen handler can skip the alignment recompute entirely.
-        session$userData$review_annotation_changed <-
-          !identical(session$userData$review_entry_sig, focal_sig(rv$annotations, info$gene))
-      }
       shinyjs::click("close")
     })
     ## Lock and Close ----

--- a/R/app_annotate_details.R
+++ b/R/app_annotate_details.R
@@ -161,6 +161,10 @@ annotations_details_server <- function(id, rv) {
           copy = TRUE,
           in_place = TRUE
         )
+      # The trim control measures the unannotated flanks straight from the db, so
+      # any annotation write can change them (deleting, restoring or nudging the
+      # outermost feature). Bump after the write so the re-read sees it.
+      bump_asmb_edit()
     }
 
     # Write the given columns of rv$updating to this unit's annotate row. Keyed on

--- a/R/app_export.R
+++ b/R/app_export.R
@@ -29,6 +29,34 @@ export_help_label <- function(label, tip) {
   htmltools::tagList(label, export_help_icon(tip))
 }
 
+# Per-gene signature of one unit's PCG annotations, read straight from the db.
+# Covers exactly the fields flag_PCG_outliers aligns on (see
+# get_export_PCG_annotations), so two equal signatures mean the alignment for
+# that gene cannot have changed. Returns a named character vector (names =
+# gene); multi-exon genes collapse order-independently.
+unit_pcg_sig <- function(con, ID, path, scaffold) {
+  rows <- DBI::dbGetQuery(
+    con,
+    "SELECT gene, pos1, pos2, direction, translation FROM annotations
+      WHERE ID = ? AND path = ? AND scaffold = ? AND type = 'PCG' AND pos1 > 0",
+    params = list(as.character(ID), as.integer(path), as.integer(scaffold))
+  )
+  if (nrow(rows) == 0) return(stats::setNames(character(0), character(0)))
+  key <- paste(rows$pos1, rows$pos2, rows$direction, rows$translation, sep = "|")
+  vapply(split(key, rows$gene), function(x) paste(sort(x), collapse = ";"), character(1))
+}
+
+# Genes whose signature differs between two unit_pcg_sig snapshots (edited,
+# added or removed). NULL for either snapshot means "unknown", never "unchanged".
+sig_diff <- function(before, now) {
+  if (is.null(before) || is.null(now)) return(NULL)
+  genes <- union(names(before), names(now))
+  if (length(genes) == 0) return(character(0))
+  b <- unname(before[genes])
+  n <- unname(now[genes])
+  genes[!(!is.na(b) & !is.na(n) & b == n)]
+}
+
 #' export UI Function
 #'
 #' @description A shiny Module.
@@ -104,13 +132,18 @@ export_server <- function(id) {
       data = fetch_export_data(),
       updating = NULL,
       outliers = NULL,    # flags tibble from flag_PCG_outliers()
-      alns = NULL,        # named list of aligned AAStringSet (by gene)
       review_samples = NULL, # named list (by gene) of every unit in the alignment,
                              # so any sample can be picked for editing (not just flagged)
       review_genes = NULL, # genes still pending review (drives navigation)
       review_idx = 1L,     # cursor into review_genes
       resolved = character(0), # "ID|gene" keys the user marked resolved;
                               # persists across flag/alignment recomputes
+      # The (unit, gene) the user jumped out to edit, plus that unit's PCG
+      # signature at jump-out. Compared against the db on return to decide what
+      # to re-align. Owned here, not by the annotate module, so the decision
+      # never depends on the details modal's state surviving the round trip.
+      review_focus = NULL,
+      review_focus_sig = NULL,
       # Currently selected header-template name, so the modal reopens with it
       export_template = "default",
       # Last-used review options, so the modal reopens with them (not defaults)
@@ -952,14 +985,38 @@ export_server <- function(id) {
       open_path(rv$export_done_path)
     })
 
+    # Aligned AAStringSets for the review modal, keyed by gene, held in a plain
+    # environment rather than a reactiveValues field. These are large objects that
+    # need no dependency tracking of their own: every write is immediately followed
+    # by trigger("outlier_modal"), and aln_nonce() is what invalidates the panel.
+    # Keeping them out of reactiveValues also removes the copy-on-write hop that
+    # was leaving the panel one edit behind the recompute.
+    aln_store <- new.env(parent = emptyenv())
+    aln_put <- function(gene, aln) {
+      if (is.null(gene)) return(invisible())
+      if (is.null(aln)) {
+        if (exists(gene, aln_store, inherits = FALSE)) rm(list = gene, envir = aln_store)
+      } else {
+        assign(gene, aln, envir = aln_store)
+      }
+    }
+    aln_get <- function(gene) {
+      if (is.null(gene) || !exists(gene, aln_store, inherits = FALSE)) return(NULL)
+      get(gene, envir = aln_store)
+    }
+    aln_reset <- function(alns = list()) {
+      rm(list = ls(aln_store, all.names = TRUE), envir = aln_store)
+      for (g in names(alns)) aln_put(g, alns[[g]])
+    }
+
     # Load a review result into rv and open the modal (or report none found).
     # focus_gene: optional gene name to navigate to (e.g. the gene just reviewed
     # via "Back to Review"); falls back to the first gene when absent or no longer
     # flagged.
     present_review <- function(res, focus_gene = NULL) {
       rv$outliers <- res$flags
-      rv$alns <- res$alignments
       rv$review_samples <- res$samples
+      aln_reset(res$alignments)
       flagged_genes <- unique(res$flags$gene)
       if (length(flagged_genes) > 0) {
         rv$review_genes <- flagged_genes
@@ -976,52 +1033,81 @@ export_server <- function(id) {
       }
     }
 
-    # Merge a single-gene recompute into the cached review state. Editing one gene
-    # only changes that gene's alignment, so replace just its flags/alignment and
-    # keep review_genes (and the user's position) stable, then navigate back to
-    # the focal gene and reopen.
-    merge_review <- function(res, gene) {
+    # Merge a scoped recompute into the cached review state. Only the genes that
+    # actually changed are re-aligned, so replace just their flags/alignments and
+    # keep review_genes (and the user's position) stable, then navigate to
+    # focus_gene and reopen.
+    merge_review <- function(res, genes, focus_gene = NULL) {
       rv$outliers <- dplyr::bind_rows(
-        rv$outliers[rv$outliers$gene != gene, , drop = FALSE],
+        rv$outliers[!rv$outliers$gene %in% genes, , drop = FALSE],
         res$flags
       )
-      # res$alignments/res$samples keep the recomputed gene even when the edit
+      # res$alignments/res$samples keep a recomputed gene even when the edit
       # cleared its last flag (flag_PCG_outliers retains explicitly-requested
       # genes), so the corrected alignment replaces the stale one instead of the
       # panel freezing on the pre-edit view.
-      rv$alns[[gene]] <- res$alignments[[gene]]
-      rv$review_samples[[gene]] <- res$samples[[gene]]
+      samps <- rv$review_samples
+      for (g in genes) {
+        aln_put(g, res$alignments[[g]])
+        samps[[g]] <- res$samples[[g]]
+      }
+      rv$review_samples <- samps
       # review_genes intentionally unchanged: genes stay in the list and are
       # marked resolved rather than removed.
-      if (gene %in% rv$review_genes) {
-        rv$review_idx <- which(rv$review_genes == gene)[1]
+      if (!is.null(focus_gene) && focus_gene %in% rv$review_genes) {
+        rv$review_idx <- which(rv$review_genes == focus_gene)[1]
       }
       removeModal()
       trigger("outlier_modal")
     }
 
-    # Returning from the annotate details modal: recompute against the (now
-    # possibly edited) annotations so resolved flags drop off, then reopen. The
-    # editing lock guarantees only the focal gene changed, so recompute just that
-    # gene and merge it into the cached results instead of re-aligning every PCG.
+    # Remember which unit/gene the user is off to edit and snapshot that unit's
+    # current PCG signature, so the return trip can tell exactly what changed.
+    set_review_focus <- function(ID, path, scaffold, gene) {
+      rv$review_focus <- list(ID = ID, path = path, scaffold = scaffold, gene = gene)
+      rv$review_focus_sig <- tryCatch(
+        unit_pcg_sig(session$userData$con, ID, path, scaffold),
+        error = function(e) NULL
+      )
+    }
+
+    # Returning from the annotate details modal: re-align whatever the user
+    # actually changed so resolved flags drop off, then reopen.
+    #
+    # What changed is decided HERE, by diffing the focal unit's PCG annotations in
+    # the db against the snapshot taken when we jumped out. The db is the same
+    # source flag_PCG_outliers reads, so the verdict cannot disagree with the
+    # alignment. (An earlier version trusted a flag the annotate module set from
+    # its in-memory copy; that flag could survive a rejected close or be wiped by
+    # an unrelated modal reload, and a wrong "unchanged" silently showed the
+    # pre-edit alignment with no recompute.)
     on("reopen_outlier_review", {
       req(rv$review_group)
-      # The (sample, gene) just reviewed in the annotate details modal: mark it
-      # resolved (survives the recompute below) and remember the gene so we can
-      # navigate back to it.
-      rr <- session$userData$resolve_on_return
-      session$userData$resolve_on_return <- NULL
-      focal <- if (!is.null(rr)) rr$gene else NULL
-      # Only skip the recompute when the details modal reported NO change (explicit
-      # FALSE); an unset flag means recompute to be safe.
-      unchanged <- identical(session$userData$review_annotation_changed, FALSE)
-      session$userData$review_annotation_changed <- NULL
-      if (!is.null(rr)) {
-        rv$resolved <- union(rv$resolved, paste(rr$ID, rr$gene, sep = "|"))
+      # The (unit, gene) just reviewed: mark it resolved (survives the recompute
+      # below) and remember the gene so we can navigate back to it.
+      focus <- rv$review_focus
+      sig_before <- rv$review_focus_sig
+      rv$review_focus <- NULL
+      rv$review_focus_sig <- NULL
+      focal <- if (!is.null(focus)) focus$gene else NULL
+      if (!is.null(focus)) {
+        rv$resolved <- union(rv$resolved, paste(focus$ID, focus$gene, sep = "|"))
       }
-      # Nothing was edited: the cached flags/alignments are still valid, so just
+      have_cache <- !is.null(rv$outliers) && length(rv$review_genes) > 0
+      # NULL = we could not read one of the two states, so treat everything as
+      # suspect and reload the whole group.
+      changed <- if (is.null(focus)) {
+        NULL
+      } else {
+        sig_now <- tryCatch(
+          unit_pcg_sig(session$userData$con, focus$ID, focus$path, focus$scaffold),
+          error = function(e) NULL
+        )
+        sig_diff(sig_before, sig_now)
+      }
+      # Nothing in the db moved: the cached flags/alignments are still valid, so
       # reopen at the focal gene and skip the (expensive) alignment recompute.
-      if (unchanged && !is.null(rv$outliers) && length(rv$review_genes) > 0) {
+      if (!is.null(changed) && length(changed) == 0 && have_cache) {
         if (!is.null(focal) && focal %in% rv$review_genes) {
           rv$review_idx <- which(rv$review_genes == focal)[1]
         }
@@ -1029,6 +1115,9 @@ export_server <- function(id) {
         trigger("outlier_modal")
         return()
       }
+      # Scope the recompute to the changed genes only when we know them AND have
+      # cached state to merge into; otherwise re-align the whole group.
+      scope <- if (!is.null(changed) && length(changed) > 0 && have_cache) changed else NULL
       # Show the overlay first, then defer the (blocking) recompute one tick so
       # the "hold tight" message actually paints before alignment starts.
       waiter::waiter_show(
@@ -1046,22 +1135,12 @@ export_server <- function(id) {
             start_aa = rv$review_start %||% 10,
             stop_aa = rv$review_stop %||% 10,
             ident_pct = rv$review_ident %||% 60,
-            genes = focal
+            genes = scope
           ),
           finally = waiter::waiter_hide()
         )
-        # TEMP diagnostic: ungapped AA length per sequence straight from the fresh
-        # recompute (compare against "REVIEW RENDER" to localize any staleness).
-        if (!is.null(focal) && !is.null(res$alignments[[focal]])) {
-          message(
-            "RECOMPUTE gene=", focal,
-            " lens=", paste(nchar(gsub("-", "", as.character(res$alignments[[focal]]))), collapse = ",")
-          )
-        }
-        # Scoped merge when we know the single edited gene and have cached state;
-        # otherwise fall back to a full reload.
-        if (!is.null(focal) && !is.null(rv$outliers)) {
-          merge_review(res, focal)
+        if (!is.null(scope)) {
+          merge_review(res, scope, focus_gene = focal)
         } else {
           present_review(res, focus_gene = focal)
         }
@@ -1260,8 +1339,10 @@ export_server <- function(id) {
     # Size the alignment viewport to the number of sequences so small groups
     # don't leave a large blank gap below the rows.
     review_aln_height <- reactive({
+      # aln_nonce() so the height tracks the store, which is not reactive itself.
+      aln_nonce()
       g <- current_gene()
-      aln <- rv$alns[[g]]
+      aln <- aln_get(g)
       if (is.null(aln)) return(120L)
       min(400L, max(120L, as.integer(length(aln) * 18 + 40)))
     })
@@ -1269,7 +1350,7 @@ export_server <- function(id) {
     # Render the MSA as the uiOutput content itself (not a msaROutput placeholder
     # filled by a separate renderMsaR). Returning the widget from renderUI makes
     # Shiny REPLACE the container's innerHTML on every (re)open, so the old widget
-    # DOM is torn down and a fresh one built from the current rv$alns - the
+    # DOM is torn down and a fresh one built from the current alignment store - the
     # msaROutput+dynamic-renderMsaR pattern instead let htmlwidgets reuse a stale
     # binding (and msaR::renderValue appends rather than clearing), which showed the
     # pre-edit alignment after "Back to Review". aln_nonce() forces a rebuild even
@@ -1277,7 +1358,7 @@ export_server <- function(id) {
     output$review_aln_ui <- renderUI({
       aln_nonce()
       g <- current_gene()
-      aln <- rv$alns[[g]]
+      aln <- aln_get(g)
       if (is.null(aln)) {
         return(div(style = "color:#666; padding:1em;", "No alignment for this gene."))
       }
@@ -1287,11 +1368,6 @@ export_server <- function(id) {
         aln <- aln[c(which(names(aln) == hl), which(names(aln) != hl))]
         names(aln)[1] <- paste0(">> ", names(aln)[1])
       }
-      # TEMP diagnostic: ungapped AA length per sequence in the rendered alignment.
-      message(
-        "REVIEW RENDER gene=", g, " nonce=", isolate(aln_nonce()),
-        " lens=", paste(nchar(gsub("-", "", as.character(aln))), collapse = ",")
-      )
       msaR::msaR(
         aln,
         overviewbox = FALSE,
@@ -1459,6 +1535,7 @@ export_server <- function(id) {
         start_offset = fr$start_offset, stop_offset = fr$stop_offset,
         pct_identity = fr$pct_identity
       )
+      set_review_focus(fr$ID, fr$path, fr$scaffold, fr$gene)
       removeModal()
       trigger("goto_annotate")
     })
@@ -1478,6 +1555,7 @@ export_server <- function(id) {
         start_offset = NA_integer_, stop_offset = NA_integer_,
         pct_identity = NA_real_
       )
+      set_review_focus(row$ID, row$path, row$scaffold, current_gene())
       removeModal()
       trigger("goto_annotate")
     })
@@ -1488,11 +1566,13 @@ export_server <- function(id) {
       removeModal()
       highlight_label(NULL)
       rv$outliers <- NULL
-      rv$alns <- NULL
+      aln_reset()
       rv$review_samples <- NULL
       rv$review_genes <- NULL
       rv$review_idx <- 1L
       rv$resolved <- character(0)
+      rv$review_focus <- NULL
+      rv$review_focus_sig <- NULL
     })
   })
 }

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ of the curation rulesets are contained in the underlying Docker image
 If you have a group of organisms that you would like to try with
 MitoPilot, feel free to post an
 [issue](https://github.com/Smithsonian/MitoPilot/issues) or reach out to
-Dan MacGuigan directly at <daniel.macguigan@noaa.gov>.
+Dan MacGuigan directly at <macguigand@si.edu>.
 
 Curation reference databases can be specified independently of the
 annotation reference databases. We have provided curation databases for

--- a/inst/app/www/custom.js
+++ b/inst/app/www/custom.js
@@ -81,26 +81,10 @@ $( document ).ready(function(){
   });
 });
 
-// Mousewheel -> horizontal scroll for the annotate-details alignment views.
-// The coverage map and synteny PNGs sit in overflow-x:auto containers
-// (coverageDiv / syntenyScrollDiv). Translate vertical wheel delta into
-// horizontal scroll (down = right, up = left) and suppress page scroll over
-// these views. The MSA viewer is intentionally excluded: it needs vertical
-// wheel for scrolling alignment rows up/down.
-$( document ).ready(function(){
-  document.addEventListener('wheel', function(e) {
-    if (!e.target.closest) return;
-    var delta = e.deltaY;
-    if (!delta) return;
-
-    var box = e.target.closest('[id$="coverageDiv"], [id$="syntenyScrollDiv"]');
-    if (box) {
-      box.scrollLeft += delta;
-      e.preventDefault();
-      return;
-    }
-  }, { passive: false });
-});
+// The annotate-details views (coverage map, synteny, synteny zoom, alignment)
+// use native scrolling only: a vertical wheel scrolls the page, and horizontal
+// input scrolls the view. Vertical wheel is deliberately NOT translated into
+// horizontal scroll here.
 
 // Add an "All" choice to the sample-table page-size dropdowns. reactable
 // (0.4.5) has no native "All", so append an option with a very large page size

--- a/tests/testthat/test-annotate-unannotated-ends.R
+++ b/tests/testthat/test-annotate-unannotated-ends.R
@@ -1,0 +1,74 @@
+# `unannotated_ends` measures the flanks the Trim control reports and cuts to.
+# Deleting an annotation in the modal soft-deletes it (gene suffixed "_DELETED_",
+# pos1 = pos2 = 0), so the measurement must ignore those tombstones and move to
+# the next real feature.
+
+make_db <- function(len = 1000L, ann = NULL, topology = "linear") {
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  DBI::dbWriteTable(
+    con, "assemblies",
+    data.frame(ID = "S1", path = 1L, scaffold = 1L, length = len,
+               topology = topology, stringsAsFactors = FALSE)
+  )
+  if (is.null(ann)) {
+    ann <- data.frame(ID = character(), path = integer(), scaffold = integer(),
+                      gene = character(), pos1 = integer(), pos2 = integer(),
+                      stringsAsFactors = FALSE)
+  }
+  DBI::dbWriteTable(con, "annotations", ann)
+  con
+}
+
+anns <- function(...) {
+  rows <- list(...)
+  data.frame(
+    ID = "S1", path = 1L, scaffold = 1L,
+    gene = vapply(rows, function(r) r[[1]], character(1)),
+    pos1 = vapply(rows, function(r) as.integer(r[[2]]), integer(1)),
+    pos2 = vapply(rows, function(r) as.integer(r[[3]]), integer(1)),
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("flanks are measured from the outermost live annotations", {
+  con <- make_db(ann = anns(list("COX1", 101, 200), list("ND1", 301, 400)))
+  on.exit(DBI::dbDisconnect(con))
+  e <- unannotated_ends(con, "S1", 1, 1)
+  expect_equal(e$from, 101L)
+  expect_equal(e$to, 400L)
+  expect_equal(e$lead, 100L)
+  expect_equal(e$trail, 600L)
+})
+
+test_that("a soft-deleted leading annotation moves the trim start inward", {
+  con <- make_db(ann = anns(
+    list("COX1_DELETED_1700000000", 0, 0),
+    list("ND1", 301, 400)
+  ))
+  on.exit(DBI::dbDisconnect(con))
+  e <- unannotated_ends(con, "S1", 1, 1)
+  expect_equal(e$from, 301L)
+  expect_equal(e$lead, 300L)
+  expect_equal(e$trail, 600L)
+})
+
+test_that("a soft-deleted trailing annotation moves the trim end inward", {
+  con <- make_db(ann = anns(
+    list("COX1", 101, 200),
+    list("ND1_DELETED_1700000000", 0, 0)
+  ))
+  on.exit(DBI::dbDisconnect(con))
+  e <- unannotated_ends(con, "S1", 1, 1)
+  expect_equal(e$to, 200L)
+  expect_equal(e$lead, 100L)
+  expect_equal(e$trail, 800L)
+})
+
+test_that("only tombstones means nothing to trim to", {
+  con <- make_db(ann = anns(list("COX1_DELETED_1", 0, 0)))
+  on.exit(DBI::dbDisconnect(con))
+  e <- unannotated_ends(con, "S1", 1, 1)
+  expect_true(is.na(e$from))
+  expect_true(is.na(e$lead))
+  expect_equal(e$topology, "linear")
+})

--- a/tests/testthat/test-export-outlier-review-refresh.R
+++ b/tests/testthat/test-export-outlier-review-refresh.R
@@ -1,0 +1,96 @@
+# The PCG outlier review skips its (expensive) alignment recompute when the user
+# returns from the annotate editor without changing anything. That decision is
+# made by diffing the focal unit's PCG annotations in the db against a snapshot
+# taken on the way out: a wrong "unchanged" verdict silently re-shows the
+# pre-edit alignment. These cover the verdict, including the fail-safe cases,
+# which must never report "unchanged" when the state is unknown.
+
+ann_row <- function(gene, pos1, pos2, direction = "+", translation = "MPQL",
+                    type = "PCG", ID = "S1", path = 1L, scaffold = 1L) {
+  data.frame(
+    ID = ID, path = as.integer(path), scaffold = as.integer(scaffold),
+    type = type, gene = gene, pos1 = as.integer(pos1), pos2 = as.integer(pos2),
+    direction = direction, translation = translation, stringsAsFactors = FALSE
+  )
+}
+
+sig_db <- function(...) {
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con))
+  DBI::dbWriteTable(con, "annotations", do.call(rbind, list(...)))
+  unit_pcg_sig(con, "S1", 1L, 1L)
+}
+
+test_that("a 5' shortening of one gene is reported as that gene changing", {
+  before <- sig_db(
+    ann_row("atp8", 10374, 10541, translation = "MPQLSTNTW"),
+    ann_row("cox1", 7894, 9441, translation = "MAITRW")
+  )
+  after <- sig_db(
+    ann_row("atp8", 10425, 10541, translation = "MAFLFIVPL"),
+    ann_row("cox1", 7894, 9441, translation = "MAITRW")
+  )
+  expect_equal(sig_diff(before, after), "atp8")
+})
+
+test_that("an untouched unit reports nothing changed", {
+  s <- sig_db(ann_row("atp8", 10374, 10541), ann_row("cox1", 7894, 9441))
+  expect_length(sig_diff(s, s), 0L)
+})
+
+test_that("a position-only edit is caught even when the translation is unchanged", {
+  before <- sig_db(ann_row("nad5", 14374, 16212))
+  after <- sig_db(ann_row("nad5", 14374, 16215))
+  expect_equal(sig_diff(before, after), "nad5")
+})
+
+test_that("added and removed genes are both reported", {
+  one <- sig_db(ann_row("atp8", 10374, 10541))
+  two <- sig_db(ann_row("atp8", 10374, 10541), ann_row("atp6", 10532, 11214))
+  expect_equal(sig_diff(one, two), "atp6")
+  expect_equal(sig_diff(two, one), "atp6")
+})
+
+test_that("multi-exon genes collapse order-independently", {
+  a <- sig_db(ann_row("nad5", 100, 200), ann_row("nad5", 400, 500))
+  b <- sig_db(ann_row("nad5", 400, 500), ann_row("nad5", 100, 200))
+  expect_length(sig_diff(a, b), 0L)
+  c3 <- sig_db(ann_row("nad5", 100, 200), ann_row("nad5", 400, 501))
+  expect_equal(sig_diff(a, c3), "nad5")
+})
+
+test_that("non-PCG rows and deleted tombstones are ignored", {
+  before <- sig_db(
+    ann_row("atp8", 10374, 10541),
+    ann_row("trnF", 1, 70, type = "tRNA")
+  )
+  after <- sig_db(
+    ann_row("atp8", 10374, 10541),
+    ann_row("trnF", 5, 74, type = "tRNA"),
+    ann_row("cox1_DELETED_1", 0, 0)
+  )
+  expect_length(sig_diff(before, after), 0L)
+})
+
+test_that("only the requested unit is measured", {
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con))
+  DBI::dbWriteTable(con, "annotations", rbind(
+    ann_row("atp8", 10374, 10541),
+    ann_row("atp8", 999, 1200, scaffold = 2L)
+  ))
+  expect_equal(unname(unit_pcg_sig(con, "S1", 1L, 1L)), "10374|10541|+|MPQL")
+  expect_equal(unname(unit_pcg_sig(con, "S1", 1L, 2L)), "999|1200|+|MPQL")
+})
+
+test_that("an unknown snapshot is never mistaken for unchanged", {
+  s <- sig_db(ann_row("atp8", 10374, 10541))
+  # A failed db read on either side must fall through to a full recompute.
+  expect_null(sig_diff(NULL, s))
+  expect_null(sig_diff(s, NULL))
+  expect_null(sig_diff(NULL, NULL))
+  # A unit that has no PCG rows at all is a real (empty) snapshot, not unknown.
+  empty <- sig_db(ann_row("trnF", 1, 70, type = "tRNA"))
+  expect_length(empty, 0L)
+  expect_equal(sig_diff(empty, s), "atp8")
+})


### PR DESCRIPTION
Editing a sample from the PCG Annotation Outlier Review modal and returning via "Back to Review" left the MSA panel showing the pre-edit alignment. Reproduced on a 14-sample export group by shortening/extending the 5' end of `atp6` for `SRR21844202`.

Two independent faults, both fixed here.

### 1. The recompute was skipped

The skip was gated on `session$userData$review_annotation_changed`, which the annotate module computed from its in-memory `rv$annotations` and handed back across the module boundary. That flag has no owner and no lifecycle:

- it survives a close rejected by `editing_unsaved()` (`req(F)`), and is then consumed by a later close carrying a stale verdict;
- `trigger("annotations_modal")` from the assembly trim/restore paths clears `outlier_flag()` and the entry snapshot while leaving `in_outlier_review` set, so "Back to Review" writes nothing at all;
- `focal_sig()` returns `""` for an unmatched gene and `NULL` for a missing table, so `identical()` reports "unchanged" for both degenerate cases.

A wrong "unchanged" reopened the modal with no recompute and no "Recomputing alignments" overlay.

The export module now decides for itself. `unit_pcg_sig()` reads the focal unit's PCG rows (`pos1`, `pos2`, `direction`, `translation`) straight from the project `.sqlite` — the same source `flag_PCG_outliers()` reads — and `sig_diff()` compares a snapshot taken when jumping out against the db on return. An unreadable snapshot yields `NULL`, which forces a full recompute rather than a skip. The recompute is scoped to the genes that actually moved, so a trim/restore that rewrites every coordinate is caught too, and `merge_review()` now takes a gene vector.

The cross-module plumbing (`review_entry_sig`, `review_annotation_changed`, `resolve_on_return`, `focal_sig`) is removed.

### 2. The alignment write did not stick

With the recompute confirmed correct, the panel was still one edit behind. Instrumenting the handoff showed the write itself failing:

```
RECOMPUTE gene=atp6 scope=atp6 lens=199,227,...
MERGE genes=atp6 in=199,227,... stored=209,227,... keys=atp6/atp8/cox1/nad6
```

`in` is what `flag_PCG_outliers()` returned; `stored` is what `rv$alns` gave back on the next line, after assigning it. The render was faithful — 209 was genuinely what was stored.

I could not reproduce this in isolation (standalone, nested in a function, and with the real `AAStringSet` objects the write lands every time), and shiny's `ReactiveValues$set` dedupe is ruled out since `identical()` on the two alignment lists is `FALSE`. Rather than keep guessing, the hop is removed: alignments now live in a plain environment keyed by gene (`aln_put`/`aln_get`/`aln_reset`). They are large objects that need no dependency tracking of their own — `aln_nonce()` already invalidates the panel on every modal open, and every write is immediately followed by `trigger("outlier_modal")`. So the fix removes the failing mechanism without explaining it.

For the record, the render layer was not at fault, contrary to the two earlier attempts at this bug (5fd44c9, 1b78bd1): shiny's `bindOutput` replays the cached `$values[id]` into any newly bound element, so the DOM always matches whatever R last computed.